### PR TITLE
docs: document totalTokens spec deviation

### DIFF
--- a/src/fix-loop/token-budget.ts
+++ b/src/fix-loop/token-budget.ts
@@ -23,6 +23,12 @@ export function addTokenUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
  * Calculate the total token count from a TokenUsage object.
  * Sums all four fields: input, output, cache creation, and cache read.
  *
+ * Note: The spec says to sum input_tokens + output_tokens, but we include
+ * cache_creation_input_tokens and cache_read_input_tokens too. This is more
+ * conservative (hits budget sooner) and treats the OTel gen_ai.usage.input_tokens
+ * as total input tokens inclusive of cache, rather than the Anthropic API's
+ * narrower input_tokens field.
+ *
  * @param usage - Token usage to total
  * @returns Total number of tokens across all categories
  */


### PR DESCRIPTION
## Summary

- Adds a JSDoc comment to `totalTokens()` in `src/fix-loop/token-budget.ts` explaining why it sums all four token fields instead of just `input_tokens + output_tokens` as the spec suggests
- No code change — the implementation is correct (more conservative budget tracking)

Closes #18

## Test plan

- [x] Docs-only change, no behavior modified
- [x] Build and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified token budget documentation to better explain how cache-related tokens are calculated in totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->