### PR TITLE
fix(dispatch): rejected extension removal compares IDs against parsed YAML

### DIFF
--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -14,6 +14,7 @@ import {
   writeSchemaExtensions as defaultWriteSchemaExtensions,
   snapshotExtensionsFile as defaultSnapshotExtensionsFile,
   restoreExtensionsFile as defaultRestoreExtensionsFile,
+  parseExtension,
 } from './schema-extensions.ts';
 
 /**
@@ -259,15 +260,17 @@ export async function dispatchFiles(
         try {
           const writeResult = await writeExtFn(registryDir, [...accumulatedExtensions]);
           if (writeResult.rejected.length > 0) {
-            // Remove rejected extensions from accumulator so they aren't resubmitted
+            // Remove rejected extensions from accumulator so they aren't resubmitted.
+            // rejected IDs are plain strings (e.g. "bad.namespace.attr") while
+            // accumulatedExtensions are full YAML strings — extract the ID to compare.
             const rejectedSet = new Set(writeResult.rejected);
             for (let j = accumulatedExtensions.length - 1; j >= 0; j--) {
-              if (rejectedSet.has(accumulatedExtensions[j])) {
+              const parsed = parseExtension(accumulatedExtensions[j]);
+              const extId = parsed?.id as string | undefined;
+              if (extId && rejectedSet.has(extId)) {
+                seenExtensions.delete(accumulatedExtensions[j]);
                 accumulatedExtensions.splice(j, 1);
               }
-            }
-            for (const rejected of writeResult.rejected) {
-              seenExtensions.delete(rejected);
             }
             if (extWarnings) {
               extWarnings.push(

--- a/src/coordinator/index.ts
+++ b/src/coordinator/index.ts
@@ -12,7 +12,7 @@ export { updateSdkInitFile } from './sdk-init.ts';
 export type { SdkInitResult } from './sdk-init.ts';
 export { installDependencies } from './dependencies.ts';
 export type { DependencyInstallResult, InstallDeps } from './dependencies.ts';
-export { writeSchemaExtensions, collectSchemaExtensions, extractNamespacePrefix } from './schema-extensions.ts';
+export { writeSchemaExtensions, collectSchemaExtensions, extractNamespacePrefix, parseExtension } from './schema-extensions.ts';
 export type { WriteSchemaExtensionsResult } from './schema-extensions.ts';
 export { computeSchemaHash } from './schema-hash.ts';
 export { runSchemaCheckpoint } from './schema-checkpoint.ts';

--- a/src/coordinator/schema-extensions.ts
+++ b/src/coordinator/schema-extensions.ts
@@ -83,7 +83,7 @@ export async function extractNamespacePrefix(registryDir: string): Promise<strin
  * @param extensionYaml - YAML string for a single attribute definition
  * @returns Parsed attribute object, or null if parsing fails
  */
-function parseExtension(extensionYaml: string): Record<string, unknown> | null {
+export function parseExtension(extensionYaml: string): Record<string, unknown> | null {
   try {
     // The extension is a YAML list item — parse it as a list
     const parsed = parse(extensionYaml) as unknown;

--- a/test/coordinator/dispatch-per-file-extensions.test.ts
+++ b/test/coordinator/dispatch-per-file-extensions.test.ts
@@ -457,6 +457,39 @@ describe('dispatchFiles — per-file schema extension writing', () => {
     });
   });
 
+  it('removes rejected extensions from accumulator so they are not resubmitted on subsequent files', async () => {
+    const file1 = await createFile('a.js', 'function a() {}');
+    const file2 = await createFile('b.js', 'function b() {}');
+
+    const goodExt = '- id: myapp.payment.amount\n  type: double';
+    const badExt = '- id: bad.namespace.attr\n  type: string';
+    const newExt = '- id: myapp.order.total\n  type: int';
+
+    // File 1 produces both a good and bad extension; bad one gets rejected
+    // File 2 produces a new extension
+    const writeSchemaExtensions = vi.fn()
+      .mockResolvedValueOnce(makeWriteResult({ rejected: ['bad.namespace.attr'] }))
+      .mockResolvedValueOnce(makeWriteResult());
+
+    const instrumentWithRetry = vi.fn()
+      .mockResolvedValueOnce(makeSuccessResult(file1, { schemaExtensions: [goodExt, badExt] }))
+      .mockResolvedValueOnce(makeSuccessResult(file2, { schemaExtensions: [newExt] }));
+
+    const deps = makeDeps({ instrumentWithRetry, writeSchemaExtensions });
+    const config = makeConfig();
+    const registryDir = join(tmpDir, 'registry');
+
+    await dispatchFiles([file1, file2], tmpDir, config, undefined, {
+      deps,
+      registryDir,
+    });
+
+    // First call includes both extensions
+    expect(writeSchemaExtensions).toHaveBeenNthCalledWith(1, registryDir, [goodExt, badExt]);
+    // Second call should NOT include the rejected badExt — only goodExt + newExt
+    expect(writeSchemaExtensions).toHaveBeenNthCalledWith(2, registryDir, [goodExt, newExt]);
+  });
+
   it('pushes rejection warnings into schemaExtensionWarnings when extensions are rejected', async () => {
     const file1 = await createFile('a.js', 'function a() {}');
 


### PR DESCRIPTION
## Summary

- Fixes rejected extension removal in dispatch loop — was comparing extension IDs against full YAML strings, so rejected extensions were never removed from the accumulator
- Exports `parseExtension` from `schema-extensions.ts` to extract IDs from YAML strings before comparison
- Deletes from `seenExtensions` by full YAML string (during the same loop) instead of by bare ID

Closes #38

## Test plan

- [x] New test: verifies rejected extensions are removed from accumulator and not resubmitted on subsequent files
- [x] All 24 dispatch-per-file-extensions tests pass
- [x] Full suite: 1018 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rejected schema extensions to ensure they are properly removed from memory and not resubmitted in subsequent operations.

* **Tests**
  * Added test coverage to verify rejected extensions are correctly excluded from future writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->