### PR TITLE
fix(validation): enable all 17 Tier 2 checks in buildValidationConfig

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -86,17 +86,33 @@ function summarizeErrors(validation: ValidationResult): string {
 
 /**
  * Build a default ValidationConfig from AgentConfig.
- * Enables all Tier 2 checks with their default blocking/advisory settings.
+ * Enables all 17 Tier 2 checks with their blocking/advisory settings
+ * per the PRD Dimension Rules tables (Phases 2, 4, 5).
  */
 function buildValidationConfig(config: AgentConfig) {
   return {
     enableWeaver: false,
     tier2Checks: {
+      // Phase 2 checks
       'CDQ-001': { enabled: true, blocking: true },
       'NDS-003': { enabled: true, blocking: true },
       'COV-002': { enabled: true, blocking: true },
       'RST-001': { enabled: true, blocking: false },
       'COV-005': { enabled: true, blocking: false },
+      // Phase 4 checks
+      'COV-001': { enabled: true, blocking: true },
+      'COV-003': { enabled: true, blocking: true },
+      'COV-006': { enabled: true, blocking: true },
+      'COV-004': { enabled: true, blocking: false },
+      'RST-002': { enabled: true, blocking: false },
+      'RST-003': { enabled: true, blocking: false },
+      'RST-004': { enabled: true, blocking: false },
+      'CDQ-006': { enabled: true, blocking: false },
+      // Phase 5 checks
+      'SCH-001': { enabled: true, blocking: true },
+      'SCH-002': { enabled: true, blocking: true },
+      'SCH-003': { enabled: true, blocking: true },
+      'SCH-004': { enabled: true, blocking: false },
     },
   };
 }

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'node:os';
 import { instrumentWithRetry } from '../../src/fix-loop/instrument-with-retry.ts';
 import type { FileResult } from '../../src/fix-loop/types.ts';
 import type { InstrumentationOutput, TokenUsage } from '../../src/agent/schema.ts';
-import type { ValidationResult, CheckResult } from '../../src/validation/types.ts';
+import type { ValidationResult, CheckResult, ValidateFileInput } from '../../src/validation/types.ts';
 import type { InstrumentFileResult, ConversationContext } from '../../src/agent/instrument-file.ts';
 import type { AgentConfig } from '../../src/config/schema.ts';
 import type { InstrumentWithRetryDeps, InstrumentFileCallOptions } from '../../src/fix-loop/instrument-with-retry.ts';
@@ -149,6 +149,51 @@ describe('instrumentWithRetry — single-attempt pass-through', () => {
     expect(result.notes).toEqual(output.notes);
     expect(result.tokenUsage).toEqual(sampleTokens);
     expect(result.errorProgression).toEqual(['0 errors']);
+  });
+
+  it('passes all 17 Tier 2 checks to validateFile with correct blocking flags', async () => {
+    const output = makeInstrumentationOutput();
+    let capturedConfig: ValidateFileInput['config'] | undefined;
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async () => ({ success: true, output }) as InstrumentFileResult,
+      validateFile: async (input: ValidateFileInput) => {
+        capturedConfig = input.config;
+        return makePassingValidation(testFilePath);
+      },
+    };
+
+    await instrumentWithRetry(
+      testFilePath, originalContent, {}, makeConfig(), { deps },
+    );
+
+    expect(capturedConfig).toBeDefined();
+    const checks = capturedConfig!.tier2Checks;
+
+    // Phase 2 checks (5)
+    expect(checks['CDQ-001']).toEqual({ enabled: true, blocking: true });
+    expect(checks['NDS-003']).toEqual({ enabled: true, blocking: true });
+    expect(checks['COV-002']).toEqual({ enabled: true, blocking: true });
+    expect(checks['RST-001']).toEqual({ enabled: true, blocking: false });
+    expect(checks['COV-005']).toEqual({ enabled: true, blocking: false });
+
+    // Phase 4 checks (8)
+    expect(checks['COV-001']).toEqual({ enabled: true, blocking: true });
+    expect(checks['COV-003']).toEqual({ enabled: true, blocking: true });
+    expect(checks['COV-006']).toEqual({ enabled: true, blocking: true });
+    expect(checks['COV-004']).toEqual({ enabled: true, blocking: false });
+    expect(checks['RST-002']).toEqual({ enabled: true, blocking: false });
+    expect(checks['RST-003']).toEqual({ enabled: true, blocking: false });
+    expect(checks['RST-004']).toEqual({ enabled: true, blocking: false });
+    expect(checks['CDQ-006']).toEqual({ enabled: true, blocking: false });
+
+    // Phase 5 checks (4)
+    expect(checks['SCH-001']).toEqual({ enabled: true, blocking: true });
+    expect(checks['SCH-002']).toEqual({ enabled: true, blocking: true });
+    expect(checks['SCH-003']).toEqual({ enabled: true, blocking: true });
+    expect(checks['SCH-004']).toEqual({ enabled: true, blocking: false });
+
+    // Total: 17 checks
+    expect(Object.keys(checks)).toHaveLength(17);
   });
 
   it('returns failed FileResult and reverts file when validation fails', async () => {


### PR DESCRIPTION
## Summary

- Adds 12 missing Tier 2 check entries to `buildValidationConfig` — all were fully implemented and tested but never executed because their config entries were absent
- Phase 4 additions (8): COV-001, COV-003, COV-006 (blocking); COV-004, RST-002, RST-003, RST-004, CDQ-006 (advisory)
- Phase 5 additions (4): SCH-001, SCH-002, SCH-003 (blocking); SCH-004 (advisory)

Closes #23

## Test plan

- [x] New test: captures the config passed to `validateFile` and asserts all 17 checks are present with correct blocking/advisory flags
- [x] All 46 instrument-with-retry tests pass
- [x] Full suite: 1018 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled 17 additional Tier 2 validation checks with configurable blocking and advisory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->