### PR TITLE
fix(validation): narrow COV-001 exported async function detection

### DIFF
--- a/src/validation/tier2/cov001.ts
+++ b/src/validation/tier2/cov001.ts
@@ -34,9 +34,10 @@ const ENTRY_POINT_PARAM_NAMES = new Set([
 
 /**
  * Directory names that indicate a file is a service module (entry point container).
- * Matched as path segments (e.g., /routes/ or /services/).
+ * Matched as path segments — handles POSIX (/routes/), Windows (\routes\),
+ * and repo-relative paths (routes/file.js).
  */
-const SERVICE_MODULE_DIRS = /\/(routes|handlers|controllers|api|services)\//;
+const SERVICE_MODULE_DIRS = /(?:^|[\\/])(routes|handlers|controllers|api|services)(?:[\\/])/;
 
 /**
  * COV-001: Verify that entry points have spans.

--- a/test/validation/tier2/cov001.test.ts
+++ b/test/validation/tier2/cov001.test.ts
@@ -303,6 +303,32 @@ describe('checkEntryPointSpans (COV-001)', () => {
       expect(results[0].passed).toBe(false);
     });
 
+    it('flags ESM export in repo-relative service path', () => {
+      const code = [
+        'export async function processOrder(order) {',
+        '  const result = await db.query("INSERT INTO orders...");',
+        '  return result;',
+        '}',
+      ].join('\n');
+
+      const results = checkEntryPointSpans(code, 'services/orders.js');
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
+    it('flags ESM export in Windows-style service path', () => {
+      const code = [
+        'export async function processOrder(order) {',
+        '  const result = await db.query("INSERT INTO orders...");',
+        '  return result;',
+        '}',
+      ].join('\n');
+
+      const results = checkEntryPointSpans(code, 'C:\\app\\services\\orders.js');
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
     it('passes when ESM service function has span', () => {
       const code = [
         'import { trace } from "@opentelemetry/api";',


### PR DESCRIPTION
## Summary

- COV-001's ESM and CJS export paths were flagging **every** exported async function missing a span, but the spec scopes COV-001 to "exported async functions from **service modules**"
- Utility functions exported for reuse (`formatDate`, `loadConfig`, etc.) are not entry points and should not require spans
- Added two heuristics to distinguish service entry points from utility exports:
  1. **Parameter names** signaling request handling (`req`, `res`, `ctx`, `event`, etc.)
  2. **File path** in a service-module directory (`routes/`, `handlers/`, `controllers/`, `api/`, `services/`)

## Test plan

- [x] New tests: ESM exports in service module paths are flagged
- [x] New tests: ESM exports with request-like params are flagged regardless of path
- [x] New tests: ESM/CJS utility exports in non-service paths are NOT flagged
- [x] New tests: service directory variants (routes/, handlers/, controllers/, api/)
- [x] Existing tests updated: CJS export tests use service paths where appropriate
- [x] Full suite passes (1054 tests, 0 regressions)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of service entry-point functions by combining parameter-name heuristics and file-path patterns, reducing false positives when flagging uninstrumented utilities.

* **Tests**
  * Expanded test coverage across module types and path patterns (CJS/ESM, service directories, edge cases) to validate the refined detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->