### PR TITLE
fix: surface failure reason in instrument progress output

### DIFF
--- a/src/interfaces/instrument-handler.ts
+++ b/src/interfaces/instrument-handler.ts
@@ -131,9 +131,15 @@ export async function handleInstrument(
       deps.stderr(`Processing file ${index + 1} of ${total}: ${path}`);
     },
     onFileComplete: (result, _index, _total) => {
-      const statusLabel = result.status === 'success'
-        ? `success (${result.spansAdded} spans)`
-        : result.status;
+      let statusLabel: string;
+      if (result.status === 'success') {
+        statusLabel = `success (${result.spansAdded} spans)`;
+      } else if (result.status === 'failed') {
+        const detail = result.reason || result.lastError || '';
+        statusLabel = detail ? `failed (${detail})` : 'failed';
+      } else {
+        statusLabel = result.status;
+      }
       deps.stderr(`  ${result.path}: ${statusLabel}`);
     },
     onRunComplete: (results) => {


### PR DESCRIPTION
## Summary
- The `onFileComplete` callback previously showed only the bare status string for failed files (just "failed"), giving no indication of why instrumentation failed
- Now includes `reason` or `lastError` detail so operators can diagnose issues directly from stderr output

## Test plan
- [ ] Run `instrument` against a file that triggers a failure and verify stderr shows the reason
- [ ] Run against a successful file and verify output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when file processing fails to include specific failure reasons, enabling better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->