### PR TITLE
fix: inject concrete tracer name from schema namespace

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -14,7 +14,12 @@ import type { OTelImportDetectionResult } from '../ast/import-detection.ts';
  */
 export function buildSystemPrompt(resolvedSchema: object): string {
   const schemaJson = JSON.stringify(resolvedSchema, null, 2);
-  const tracerName = (resolvedSchema as Record<string, unknown>).namespace as string | undefined ?? 'unknown_service';
+  const rawNamespace = (resolvedSchema as Record<string, unknown>).namespace;
+  const tracerName =
+    typeof rawNamespace === 'string' && rawNamespace.trim().length > 0
+      ? rawNamespace
+      : 'unknown_service';
+  const tracerNameLiteral = JSON.stringify(tracerName);
 
   return `You are an instrumentation engineer. Your job is to add OpenTelemetry instrumentation to a JavaScript source file according to a Weaver schema contract.
 
@@ -43,7 +48,7 @@ Add \`import { trace, SpanStatusCode } from '@opentelemetry/api';\` at the top o
 
 ### Tracer Acquisition
 
-Add \`const tracer = trace.getTracer('${tracerName}');\` at module scope if not already present. Use exactly this tracer name in every file — do not vary it. If a tracer variable is already declared, reuse it.
+Add \`const tracer = trace.getTracer(${tracerNameLiteral});\` at module scope if not already present. Use exactly this tracer name in every file — do not vary it. If a tracer variable is already declared, reuse it.
 
 ### Manual Span Instrumentation (Path 2)
 

--- a/test/agent/prompt.test.ts
+++ b/test/agent/prompt.test.ts
@@ -79,7 +79,7 @@ describe('buildSystemPrompt', () => {
     const prompt = buildSystemPrompt(schema);
 
     // Should contain the exact tracer name, not a placeholder or derivation instruction
-    expect(prompt).toContain("trace.getTracer('test_service')");
+    expect(prompt).toContain('trace.getTracer("test_service")');
     // Should NOT tell the LLM to "derive" the name — it should be given directly
     expect(prompt).not.toContain('Derive the service name');
   });
@@ -88,7 +88,36 @@ describe('buildSystemPrompt', () => {
     const customSchema = makeSchema({ namespace: 'my_app' });
     const prompt = buildSystemPrompt(customSchema);
 
-    expect(prompt).toContain("trace.getTracer('my_app')");
+    expect(prompt).toContain('trace.getTracer("my_app")');
+  });
+
+  it('falls back to unknown_service when namespace is missing', () => {
+    const noNamespace = makeSchema({ namespace: undefined });
+    const prompt = buildSystemPrompt(noNamespace);
+
+    expect(prompt).toContain('trace.getTracer("unknown_service")');
+  });
+
+  it('falls back to unknown_service when namespace is empty string', () => {
+    const emptyNamespace = makeSchema({ namespace: '' });
+    const prompt = buildSystemPrompt(emptyNamespace);
+
+    expect(prompt).toContain('trace.getTracer("unknown_service")');
+  });
+
+  it('falls back to unknown_service when namespace is non-string', () => {
+    const numericNamespace = makeSchema({ namespace: 42 });
+    const prompt = buildSystemPrompt(numericNamespace);
+
+    expect(prompt).toContain('trace.getTracer("unknown_service")');
+  });
+
+  it('safely escapes namespace with special characters', () => {
+    const specialNamespace = makeSchema({ namespace: 'my"service' });
+    const prompt = buildSystemPrompt(specialNamespace);
+
+    // JSON.stringify escapes the double quote
+    expect(prompt).toContain('trace.getTracer("my\\"service")');
   });
 
   it('includes instrumentation priority hierarchy', () => {


### PR DESCRIPTION
## Summary
- Extract `namespace` from the resolved Weaver schema and inject it as a concrete tracer name in the system prompt
- Replace vague "derive the service name" instruction with exact `trace.getTracer('<namespace>')` so every file uses the same name
- Eliminates inconsistent tracer naming (e.g., `commit-story` vs `commit_story`) across instrumented files

## Test plan
- [x] New test: prompt contains concrete tracer name from schema namespace
- [x] New test: tracer name changes when schema namespace changes
- [x] Full test suite passes (1204 tests, 0 failures)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tracer names now reflect service namespaces, default to "unknown_service" when absent, and safely handle special characters for clearer observability.
  * Instrumentation prompt now prioritizes the concrete tracer name.

* **Tests**
  * Added tests validating tracer name derivation, namespace customization, fallbacks, escaping of special characters, and prompt prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->