### PR TITLE
docs: define token budget strategy for over-budget files

### DIFF
--- a/docs/specs/telemetry-agent-spec-v3.9.md
+++ b/docs/specs/telemetry-agent-spec-v3.9.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft v3.9
 **Created:** 2026-02-05
-**Updated:** 2026-03-12
+**Updated:** 2026-03-13
 **Purpose:** AI agent that auto-instruments JavaScript code with OpenTelemetry based on a Weaver schema (agent written in TypeScript)
 
 ## Revision History


### PR DESCRIPTION
## Summary
- Defines "accept and skip" strategy for files exceeding `maxTokensPerFile` budget
- Coordinator uses `countTokens()` pre-flight check to skip over-budget files without making API calls
- Documents why chunking and automatic budget increases are deferred to post-PoC
- `maxTokensPerFile` config is the user-facing escape hatch; post-PoC path is function-level extraction

Closes #69

## Test plan
- [ ] Verify new section renders correctly in GitHub markdown
- [ ] Verify version history entry is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Released telemetry agent spec v3.9.4 introducing a token-budget strategy: files over per-file token limits are skipped during pre-flight cost checks with no API calls; maxTokensPerFile remains user-configurable and chunking/budget increase deferral rationale documented.
  * Expanded public per-file result contract: added validation metadata, token-usage reporting, span categorization, notes, and error progression for richer diagnostics.
  * Clarified "skipped" semantics and enumerated skip reasons (already-instrumented, budget-exceeded, excluded).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->