### PR TITLE
fix: NDS-003 cascading false positives from forward pointer walk

### DIFF
--- a/src/validation/tier2/nds003.ts
+++ b/src/validation/tier2/nds003.ts
@@ -49,8 +49,8 @@ function isInstrumentationLine(line: string): boolean {
  * NDS-003: Verify that non-instrumentation lines are unchanged.
  *
  * Two-directional check:
- * 1. Forward: all original lines appear in the instrumented output as a subsequence
- *    (preserving relative order, allowing indentation changes via trim)
+ * 1. Forward: all original lines appear in the instrumented output
+ *    (frequency-counted presence check, allowing indentation changes via trim)
  * 2. Reverse: after filtering instrumentation patterns from the instrumented output,
  *    no non-instrumentation lines were added
  *

--- a/test/validation/tier2/nds003.test.ts
+++ b/test/validation/tier2/nds003.test.ts
@@ -273,9 +273,9 @@ describe('checkNonInstrumentationDiff (NDS-003)', () => {
       const results = checkNonInstrumentationDiff(original, instrumented, filePath);
       const missing = results.filter((r) => !r.passed && r.message.includes('missing'));
 
-      // At most 1 line should be reported as missing (b, which moved after c)
-      // The old pointer walk would report b, d, e as all missing
-      expect(missing.length).toBeLessThanOrEqual(1);
+      // With frequency map, all lines are present → no missing lines.
+      // The old pointer walk would report b, d, e as all missing.
+      expect(missing).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaced the forward subsequence pointer walk in NDS-003 with a frequency map lookup
- The old pointer never reset on miss, so one genuinely absent line cascaded into 30-50 false positives, exhausting the fix loop with noise
- Added tests for cascading behavior with missing lines and reordered lines

## Test plan
- [x] New test: single missing line produces exactly 1 violation (not 8)
- [x] New test: reordered lines produce at most 1 missing-line violation (not 3)
- [x] All 14 NDS-003 tests pass
- [x] Full suite: 1225 passed, 19 skipped, 0 failed

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation improved to use frequency-based matching so missing lines are reported accurately and do not trigger cascading false positives when lines are missing or reordered.

* **Tests**
  * Added tests covering cascading false-positive scenarios to ensure only genuinely missing lines are flagged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->