### PR TITLE
fix: collectCheckResults mutates CheckResult objects in-place

### DIFF
--- a/src/validation/chain.ts
+++ b/src/validation/chain.ts
@@ -205,15 +205,12 @@ export async function validateFile(input: ValidateFileInput): Promise<Validation
  * from the validation config. Supports the migration from single-result
  * checks to per-finding array results (issue #43).
  */
-function collectCheckResults(
+export function collectCheckResults(
   result: CheckResult | CheckResult[],
   blocking: boolean,
 ): CheckResult[] {
   const results = Array.isArray(result) ? result : [result];
-  for (const r of results) {
-    r.blocking = blocking;
-  }
-  return results;
+  return results.map((r) => ({ ...r, blocking }));
 }
 
 /**

--- a/test/validation/chain.test.ts
+++ b/test/validation/chain.test.ts
@@ -6,8 +6,8 @@ import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { validateFile } from '../../src/validation/chain.ts';
-import type { ValidateFileInput, ValidationConfig } from '../../src/validation/types.ts';
+import { validateFile, collectCheckResults } from '../../src/validation/chain.ts';
+import type { ValidateFileInput, ValidationConfig, CheckResult } from '../../src/validation/types.ts';
 
 const validRegistry = join(import.meta.dirname, '../fixtures/weaver-registry/valid');
 
@@ -257,6 +257,46 @@ describe('validateFile', () => {
       const cdq001Failure = result.blockingFailures.find((r) => r.ruleId === 'CDQ-001');
       expect(cdq001Failure).toBeDefined();
       expect(cdq001Failure?.passed).toBe(false);
+    });
+  });
+
+  describe('collectCheckResults', () => {
+    it('does not mutate the original CheckResult objects', () => {
+      const original: CheckResult = {
+        ruleId: 'CDQ-001',
+        passed: false,
+        filePath: '/tmp/test.js',
+        lineNumber: 5,
+        message: 'test',
+        tier: 2,
+        blocking: true,
+      };
+
+      const collected = collectCheckResults([original], false);
+
+      // The returned result should have blocking=false
+      expect(collected[0].blocking).toBe(false);
+      // The original object should be unchanged
+      expect(original.blocking).toBe(true);
+    });
+
+    it('normalizes a single result to an array', () => {
+      const single: CheckResult = {
+        ruleId: 'CDQ-001',
+        passed: true,
+        filePath: '/tmp/test.js',
+        lineNumber: null,
+        message: 'ok',
+        tier: 2,
+        blocking: false,
+      };
+
+      const collected = collectCheckResults(single, true);
+
+      expect(collected).toHaveLength(1);
+      expect(collected[0].blocking).toBe(true);
+      // Original not mutated
+      expect(single.blocking).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaced in-place mutation (`r.blocking = blocking`) with spread copies (`{ ...r, blocking }`) in `collectCheckResults`
- Exported `collectCheckResults` for direct unit testing
- Prevents potential corruption if any checker caches or shares result objects

## Test plan
- [x] New test: original CheckResult objects are not mutated after collectCheckResults
- [x] New test: single result normalized to array with correct blocking override
- [x] All 12 chain tests pass
- [x] Full suite: 1225 passed, 19 skipped, 0 failed

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)