### PR TITLE
fix: PR summary failure reason renders as broken markdown

### DIFF
--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -100,17 +100,16 @@ function renderPerFileStatus(runResult: RunResult, display: DisplayFn): string {
 
   for (const file of runResult.fileResults) {
     const name = display(file.path);
-    const statusIcon = file.status === 'success' ? 'success' : file.status === 'failed' ? 'failed' : 'skipped';
+    let statusText = file.status === 'success' ? 'success' : file.status === 'failed' ? 'failed' : 'skipped';
+    if (file.status === 'failed' && file.reason) {
+      statusText = `failed: ${sanitizeCell(file.reason)}`;
+    }
     const libs = file.librariesNeeded.map(l => `\`${l.package}\``).join(', ') || '—';
     const exts = file.schemaExtensions.length > 0
       ? file.schemaExtensions.map(e => `\`${sanitizeCell(e)}\``).join(', ')
       : '—';
 
-    lines.push(`| ${name} | ${statusIcon} | ${file.spansAdded} | ${libs} | ${exts} |`);
-
-    if (file.status === 'failed' && file.reason) {
-      lines.push(`| | | | \\> ${sanitizeCell(file.reason)} | |`);
-    }
+    lines.push(`| ${name} | ${statusText} | ${file.spansAdded} | ${libs} | ${exts} |`);
   }
 
   return lines.join('\n');

--- a/test/deliverables/pr-summary.test.ts
+++ b/test/deliverables/pr-summary.test.ts
@@ -114,6 +114,30 @@ describe('renderPrSummary', () => {
       expect(md).toContain('broken.js');
       expect(md).toMatch(/failed/i);
       expect(md).toContain('Syntax errors persisted after 3 attempts');
+      // Reason must not use broken \> markdown syntax in table cells
+      expect(md).not.toContain('\\>');
+    });
+
+    it('renders failure reason inline in the status cell', () => {
+      const result = _makeRunResult({
+        fileResults: [
+          _makeFileResult({
+            path: '/project/src/broken.js',
+            status: 'failed',
+            spansAdded: 0,
+            reason: 'Lint errors after retries',
+          }),
+        ],
+        filesSucceeded: 0,
+        filesFailed: 1,
+      });
+      const md = renderPrSummary(result, _makeConfig());
+
+      // The reason should appear in the same row as the file, in the status cell
+      const tableLines = md.split('\n').filter(l => l.includes('broken.js'));
+      expect(tableLines).toHaveLength(1);
+      expect(tableLines[0]).toContain('failed');
+      expect(tableLines[0]).toContain('Lint errors after retries');
     });
 
     it('includes skipped files', () => {


### PR DESCRIPTION
## Summary
- Replaced broken `\>` blockquote-in-table-cell syntax with inline `failed: <reason>` in the status column
- The `\>` rendered literally in all markdown renderers, hiding failure reasons on every PR with failed files
- Failure reason now appears in the same table row as the file, in the Status cell

## Test plan
- [x] New assertion: output does not contain `\>` syntax
- [x] New test: failure reason renders inline in the status cell on the same row
- [x] All 26 PR summary tests pass
- [x] Full suite: 1224 passed, 19 skipped, 0 failed

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced PR summary status display by consolidating failure information into the status column. When a file fails, the reason now appears inline within the same row instead of displaying as a separate entry, reducing visual clutter and improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->