### PR TITLE
fix: validationStrategyUsed misreports multi-turn-fix for retried initial generations

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -266,23 +266,29 @@ async function executeRetryLoop(
   let lastStrategy: ValidationStrategy = 'initial-generation';
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const strategy = strategyForAttempt(attempt, maxAttempts);
-    lastStrategy = strategy;
+    const plannedStrategy = strategyForAttempt(attempt, maxAttempts);
 
     // Build call options for retry attempts based on strategy
     let callOptions: InstrumentFileCallOptions | undefined;
-    if (strategy === 'multi-turn-fix' && lastConversationContext && lastValidation) {
+    let actualStrategy: ValidationStrategy = plannedStrategy;
+    if (plannedStrategy === 'multi-turn-fix' && lastConversationContext && lastValidation) {
       // Multi-turn fix: grow the conversation with validation feedback
       callOptions = {
         conversationContext: lastConversationContext,
         feedbackMessage: buildFixPrompt(formatFeedbackFn(lastValidation)),
       };
-    } else if (strategy === 'fresh-regeneration' && lastValidation) {
+    } else if (plannedStrategy === 'fresh-regeneration' && lastValidation) {
       // Fresh regeneration: new conversation with failure category hint
       callOptions = {
         failureHint: buildFailureHint(lastValidation),
       };
+    } else if (plannedStrategy !== 'initial-generation') {
+      // No conversation context or validation available — this is a retry
+      // of initial generation triggered by a retryable failure, not a real
+      // multi-turn fix or fresh regeneration.
+      actualStrategy = 'retry-initial';
     }
+    lastStrategy = actualStrategy;
 
     // Call instrumentFile
     const instrumentResult = await instrumentFileFn(
@@ -302,7 +308,7 @@ async function executeRetryLoop(
       // Terminal failure or last attempt — stop immediately
       return buildFailedResult(
         filePath, instrumentResult.error, instrumentResult.error,
-        cumulativeTokens, attempt, strategy, errorProgression, lastOutput,
+        cumulativeTokens, attempt, actualStrategy, errorProgression, lastOutput,
       );
     }
 
@@ -319,7 +325,7 @@ async function executeRetryLoop(
     if (totalTokens(cumulativeTokens) > config.maxTokensPerFile) {
       const reason = `Token budget exceeded: ${totalTokens(cumulativeTokens)} tokens used, budget is ${config.maxTokensPerFile}`;
       return buildFailedResult(
-        filePath, reason, reason, cumulativeTokens, attempt, strategy, errorProgression, output,
+        filePath, reason, reason, cumulativeTokens, attempt, actualStrategy, errorProgression, output,
       );
     }
 
@@ -346,7 +352,7 @@ async function executeRetryLoop(
         schemaExtensions: output.schemaExtensions,
         attributesCreated: output.attributesCreated,
         validationAttempts: attempt,
-        validationStrategyUsed: strategy,
+        validationStrategyUsed: actualStrategy,
         errorProgression,
         spanCategories: output.spanCategories,
         notes: output.notes,
@@ -365,7 +371,7 @@ async function executeRetryLoop(
     if (attempt > 1 && previousValidation) {
       const oscillation = detectOscillation(validation, previousValidation);
       if (oscillation.shouldSkip) {
-        const isFreshRegen = strategy === 'fresh-regeneration';
+        const isFreshRegen = actualStrategy === 'fresh-regeneration';
         if (isFreshRegen) {
           // Already on fresh regeneration — bail immediately
           const reason = `Oscillation detected during fresh regeneration: ${oscillation.reason}`;
@@ -374,7 +380,7 @@ async function executeRetryLoop(
             .join('\n');
           return buildFailedResult(
             filePath, reason, lastError, cumulativeTokens,
-            attempt, strategy, errorProgression, lastOutput,
+            attempt, actualStrategy, errorProgression, lastOutput,
             validation.blockingFailures[0]?.ruleId,
           );
         }

--- a/src/fix-loop/types.ts
+++ b/src/fix-loop/types.ts
@@ -11,7 +11,8 @@ import type { LibraryRequirement, SpanCategories, TokenUsage } from '../agent/sc
 export type ValidationStrategy =
   | 'initial-generation'
   | 'multi-turn-fix'
-  | 'fresh-regeneration';
+  | 'fresh-regeneration'
+  | 'retry-initial';
 
 /**
  * Complete outcome of instrumenting a single file, including all retry metadata.

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -1935,6 +1935,34 @@ describe('instrumentWithRetry — retryable instrumentFile failures', () => {
     expect(callCount).toBe(2);
   });
 
+  it('reports retry-initial strategy when retryable failure triggers re-run', async () => {
+    let callCount = 0;
+    const goodOutput = makeInstrumentationOutput({ tokenUsage: attempt2Tokens });
+
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            success: false,
+            error: 'Output rejected: elision detected. File is 200 lines shorter than original.',
+            tokenUsage: attempt1Tokens,
+          } as InstrumentFileResult;
+        }
+        return { success: true, output: goodOutput } as InstrumentFileResult;
+      },
+      validateFile: async () => makePassingValidation(testFilePath),
+    };
+
+    const result = await instrumentWithRetry(
+      testFilePath, originalContent, {}, makeConfig({ maxFixAttempts: 1 }), { deps },
+    );
+
+    expect(result.status).toBe('success');
+    // Attempt 2 ran without conversation context — it was a retry of initial generation
+    expect(result.validationStrategyUsed).toBe('retry-initial');
+  });
+
   it('tracks retryable failures in errorProgression', async () => {
     let callCount = 0;
     const goodOutput = makeInstrumentationOutput({ tokenUsage: attempt2Tokens });


### PR DESCRIPTION
## Summary
- Added `retry-initial` to the `ValidationStrategy` type
- When a retryable failure (elision/null output) triggers a re-run at attempt 2+, the strategy is now correctly reported as `retry-initial` instead of `multi-turn-fix`
- Detects the mismatch by checking whether conversation context/validation actually exist for the planned strategy slot

## Test plan
- [x] New test: retryable failure on attempt 1 → success on attempt 2 reports `retry-initial`
- [x] All 55 instrument-with-retry tests pass
- [x] Full suite: 1224 passed, 19 skipped, 0 failed

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of retry strategy reporting to reflect the actual strategy applied during automatic retries, ensuring consistency between observed behavior and reported results.

* **Tests**
  * Added test coverage for retry behavior to verify correct strategy tracking when automatic retries are triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->