### PR TITLE
fix: distinguish MODULE_NOT_FOUND from runtime errors (#89)

### DIFF
--- a/src/interfaces/instrument-handler.ts
+++ b/src/interfaces/instrument-handler.ts
@@ -35,6 +35,8 @@ export interface InstrumentDeps {
     targetPath?: string,
   ) => Promise<RunResult>;
   gitWorkflow?: Partial<Omit<GitWorkflowDeps, 'coordinate'>>;
+  /** Override dynamic module resolution for git workflow deps (testing). */
+  resolveGitModule?: (modulePath: string) => Promise<Record<string, unknown>>;
   stderr: (msg: string) => void;
   stdout: (msg: string) => void;
   promptConfirm: (message: string) => Promise<boolean>;
@@ -152,32 +154,46 @@ export async function handleInstrument(
     },
   };
 
-  // Run git workflow (wraps coordinate with branch/commit/PR operations)
+  // Resolve dynamic imports for git workflow dependencies.
+  // Separated from execution so MODULE_NOT_FOUND errors (missing dependencies)
+  // are distinguishable from runtime failures in the workflow itself.
+  const loadModule = deps.resolveGitModule ?? ((p: string) => import(p));
+  let runGitWorkflow: typeof import('../deliverables/git-workflow.ts')['runGitWorkflow'];
+  let gitDeps: GitWorkflowDeps;
+  try {
+    const gitWorkflowMod = await loadModule('../deliverables/git-workflow.ts') as typeof import('../deliverables/git-workflow.ts');
+    runGitWorkflow = gitWorkflowMod.runGitWorkflow;
+    const gitWrapperMod = await loadModule('../git/git-wrapper.ts') as typeof import('../git/git-wrapper.ts');
+    const perFileCommitMod = await loadModule('../git/per-file-commit.ts') as typeof import('../git/per-file-commit.ts');
+    const aggregateCommitMod = await loadModule('../git/aggregate-commit.ts') as typeof import('../git/aggregate-commit.ts');
+    const prSummaryMod = await loadModule('../deliverables/pr-summary.ts') as typeof import('../deliverables/pr-summary.ts');
+    gitDeps = {
+      coordinate: deps.coordinate,
+      createBranch: deps.gitWorkflow?.createBranch ?? gitWrapperMod.createBranch,
+      commitFileResult: deps.gitWorkflow?.commitFileResult ?? perFileCommitMod.commitFileResult,
+      commitAggregateChanges: deps.gitWorkflow?.commitAggregateChanges ?? aggregateCommitMod.commitAggregateChanges,
+      pushBranch: deps.gitWorkflow?.pushBranch ?? gitWrapperMod.pushBranch,
+      renderPrSummary: deps.gitWorkflow?.renderPrSummary ?? prSummaryMod.renderPrSummary,
+      createPr: deps.gitWorkflow?.createPr ?? gitWorkflowMod.createPr,
+      checkGhAvailable: deps.gitWorkflow?.checkGhAvailable ?? gitWorkflowMod.checkGhAvailable,
+      stderr: deps.stderr,
+    };
+  } catch (err) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND') {
+      deps.stderr(`Module not found: ${err.message}. Check that all dependencies are installed.`);
+      return { exitCode: 2 };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    deps.stderr(`Unexpected error during module loading: ${message}`);
+    return { exitCode: 2 };
+  }
+
+  // Execute git workflow
   let runResult: RunResult;
   let prUrl: string | undefined;
   let branchName: string | undefined;
   try {
-    const { runGitWorkflow } = await import('../deliverables/git-workflow.ts');
     const registryDir = resolve(options.projectDir, config.schemaPath);
-    const gitDeps: GitWorkflowDeps = {
-      coordinate: deps.coordinate,
-      createBranch: deps.gitWorkflow?.createBranch
-        ?? (await import('../git/git-wrapper.ts')).createBranch,
-      commitFileResult: deps.gitWorkflow?.commitFileResult
-        ?? (await import('../git/per-file-commit.ts')).commitFileResult,
-      commitAggregateChanges: deps.gitWorkflow?.commitAggregateChanges
-        ?? (await import('../git/aggregate-commit.ts')).commitAggregateChanges,
-      pushBranch: deps.gitWorkflow?.pushBranch
-        ?? (await import('../git/git-wrapper.ts')).pushBranch,
-      renderPrSummary: deps.gitWorkflow?.renderPrSummary
-        ?? (await import('../deliverables/pr-summary.ts')).renderPrSummary,
-      createPr: deps.gitWorkflow?.createPr
-        ?? (await import('../deliverables/git-workflow.ts')).createPr,
-      checkGhAvailable: deps.gitWorkflow?.checkGhAvailable
-        ?? (await import('../deliverables/git-workflow.ts')).checkGhAvailable,
-      stderr: deps.stderr,
-    };
-
     const workflowResult = await runGitWorkflow(
       {
         projectDir: options.projectDir,
@@ -198,11 +214,6 @@ export async function handleInstrument(
       deps.stderr(err.message);
       const exitCode = isCostCeilingRejection(err) ? 3 : 2;
       return { exitCode };
-    }
-    // Distinguish missing modules (dependency not installed) from runtime failures
-    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND') {
-      deps.stderr(`Module not found: ${err.message}. Check that all dependencies are installed.`);
-      return { exitCode: 2 };
     }
     const message = err instanceof Error ? err.message : String(err);
     deps.stderr(`Unexpected error: ${message}`);

--- a/test/interfaces/instrument-handler.test.ts
+++ b/test/interfaces/instrument-handler.test.ts
@@ -297,29 +297,27 @@ describe('handleInstrument', () => {
     it('reports a specific message when dynamic import fails with ERR_MODULE_NOT_FOUND', async () => {
       const moduleError = new Error("Cannot find module '../git/git-wrapper.ts'");
       (moduleError as NodeJS.ErrnoException).code = 'ERR_MODULE_NOT_FOUND';
+
       const deps = makeDeps({
-        coordinate: vi.fn().mockRejectedValue(moduleError),
-        gitWorkflow: undefined, // Force it to hit real dynamic imports
+        resolveGitModule: vi.fn().mockRejectedValue(moduleError),
       });
-      // The error comes from the try-catch around the git workflow block
       const result = await handleInstrument(makeOptions(), deps);
       expect(result.exitCode).toBe(2);
       const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0]);
-      const moduleMsg = stderrCalls.find((s: string) => s.includes('not installed') || s.includes('not found'));
+      const moduleMsg = stderrCalls.find((s: string) => s.includes('Module not found'));
       expect(moduleMsg).toBeDefined();
-      expect(moduleMsg).toContain('Module not found');
     });
 
     it('reports generic message for non-MODULE_NOT_FOUND import errors', async () => {
       const runtimeError = new Error('Cannot read properties of undefined');
+
       const deps = makeDeps({
-        coordinate: vi.fn().mockRejectedValue(runtimeError),
-        gitWorkflow: undefined,
+        resolveGitModule: vi.fn().mockRejectedValue(runtimeError),
       });
       const result = await handleInstrument(makeOptions(), deps);
       expect(result.exitCode).toBe(2);
       const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0]);
-      const unexpectedMsg = stderrCalls.find((s: string) => s.includes('Unexpected error'));
+      const unexpectedMsg = stderrCalls.find((s: string) => s.includes('Unexpected error during module loading'));
       expect(unexpectedMsg).toBeDefined();
     });
   });


### PR DESCRIPTION
## Summary
- Dynamic imports in `instrument-handler.ts` now check `error.code` for `ERR_MODULE_NOT_FOUND` before falling through to the generic "Unexpected error" message
- Distinguishes "module not installed" (dependency missing) from "module failed to load" (runtime error in imported module)
- Improves debugging ergonomics when dependencies are missing

## Test plan
- [x] New test: ERR_MODULE_NOT_FOUND produces specific "Module not found" message
- [x] New test: non-MODULE_NOT_FOUND errors still produce generic "Unexpected error" message
- [x] Full suite: 1231 passed, 19 skipped, 0 failed
- [ ] Acceptance gate CI

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic resolution of workflow dependencies to allow configurable module loading.

* **Bug Fixes**
  * Improved error reporting and exit behavior when required workflow modules fail to load, distinguishing missing-module cases from other load errors.

* **Tests**
  * Added tests covering missing-module vs generic import failures to ensure clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->