### PR TITLE
docs: PRD #99 - configurable auto-instrumentation allowlist

### DIFF
--- a/prds/99-configurable-auto-instrumentation.md
+++ b/prds/99-configurable-auto-instrumentation.md
@@ -80,6 +80,7 @@ autoInstrumentation:
 - If an import appears in both `additionalMappings` and `disabledImports`, `disabledImports` takes precedence — the import is excluded from the merged allowlist. A warning is emitted.
 - If `additionalMappings` contains an import that matches a built-in mapping, the custom mapping overrides the built-in. A warning is emitted so users are aware of the customization.
 - Package names in `additionalMappings` must be valid npm package names (non-empty strings).
+- If `disabledImports` contains an import that doesn't exist in the built-in or `additionalMappings` lists, a warning is emitted (typo protection) but config validation still passes (forward-compatible if built-ins expand later).
 
 ### Allowlist Data Module
 


### PR DESCRIPTION
## Summary
- PRD for making the auto-instrumentation allowlist configurable via `orb.yaml`
- Three controls: `additionalMappings`, `disabledImports`, `strictPackages`
- Addresses security/compliance concerns for regulated orgs (arbitrary package installation)
- Uses OTel-aligned terminology (enabled/disabled, not allowlist/denylist)
- 7 milestones defined

**This PR is for CodeRabbit review of the PRD only.** The PRD is already committed to main. This branch will be deleted after review.

Links to #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design specs for a configurable auto-instrumentation allowlist: custom mappings, disabled imports, and strict package enforcement; merged allowlist behavior and precedence rules; updated prompt construction and dynamic prompt generation; logging of blocked packages with source info when strict mode is enabled; renamed settings to align with OpenTelemetry terminology; milestones and success criteria included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->