### PR TITLE
Fix hono transitive vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "orb": "bin/orb.js"
+        "orbweaver": "bin/orbweaver.js"
       },
       "devDependencies": {
         "@types/node": "^24.11.0",
@@ -1996,9 +1996,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- Bumps hono to >=4.12.7 in package-lock.json via `npm audit fix`
- Resolves prototype pollution CVE (GHSA-v8w9-8mx6-g223) inherited transitively through `@modelcontextprotocol/sdk`
- None of the vulnerable APIs are called directly by orbweaver

## Test plan

- [x] `npm audit` returns 0 vulnerabilities
- [x] Full test suite passes (1309 passed, 19 skipped, 0 failed)
- [x] Typecheck clean

Closes #129