### PR TITLE
fix(dx): close env var documentation and prerequisite check gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Required — Anthropic API key for LLM-powered instrumentation
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Optional — GitHub token for PR creation (if gh CLI keyring auth isn't available)
+GITHUB_TOKEN=your-github-token

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 AI-powered OpenTelemetry instrumentation for JavaScript applications. Analyzes your source code, adds spans, attributes, and context propagation using LLM-guided code generation — validated against your [Weaver](https://github.com/open-telemetry/weaver) schema and the [Instrumentation Score](https://github.com/instrumentation-score/spec) quality standard. When your schema [declares OTel semantic conventions as a dependency](https://github.com/open-telemetry/weaver/blob/main/crates/weaver_forge/README.md#registry-manifest), the agent uses them for attribute naming and validates against them.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Node.js >= 24](https://img.shields.io/badge/Node.js-%3E%3D24-green.svg)](https://nodejs.org/)
 
 ## What is this?
 
@@ -125,20 +124,22 @@ All three interfaces share the same `orbweaver.yaml` configuration and produce t
 
 ### Required
 
-- **Node.js >= 24.0.0** — uses native type stripping and `fs.glob`
 - **[Weaver CLI](https://github.com/open-telemetry/weaver) >= 0.21.2** — schema validation and semantic convention resolution ([installation guide](https://github.com/open-telemetry/weaver/blob/main/docs/installation.md))
-- **Anthropic API key** — set once in your environment:
+- **Anthropic API key** — add to a `.env` file in the directory where you run orbweaver:
   ```bash
-  export ANTHROPIC_API_KEY=your-key
+  ANTHROPIC_API_KEY=your-key
   ```
+  Or set in your shell environment: `export ANTHROPIC_API_KEY=your-key`. See [`.env.example`](.env.example) for a template.
 - **A [Weaver registry](https://github.com/open-telemetry/weaver/blob/main/docs/define-your-own-telemetry-schema.md)** — your project needs a telemetry schema directory that defines your spans and attributes ([setup guide](https://github.com/open-telemetry/weaver/blob/main/docs/define-your-own-telemetry-schema.md), [examples](https://github.com/open-telemetry/opentelemetry-weaver-examples))
 - **An [OTel SDK init file](https://opentelemetry.io/docs/languages/js/getting-started/nodejs/)** — a file that initializes the OpenTelemetry SDK and registers instrumentations (e.g., `src/instrumentation.js`). `orbweaver init` auto-detects common file names like `src/instrumentation.js`, `src/telemetry.js`, or `src/tracing.js`.
 - **`@opentelemetry/api` as a peerDependency** — must be in your `package.json` peerDependencies (not dependencies) to avoid silent trace loss from duplicate instances
 
 ### Optional
 
-- **`gh` CLI** — for automatic PR creation. Without it, the agent still creates the feature branch and commits; it just prints a warning and skips the PR. Use `--no-pr` to suppress the warning.
+- **`gh` CLI** — for automatic PR creation. If `gh auth login` credentials aren't available to subprocesses, set `GITHUB_TOKEN` in your `.env` file. Without gh auth, the agent still creates the feature branch and commits. Use `--no-pr` to suppress the warning.
 - **An existing test suite** — if `testCommand` is configured in `orbweaver.yaml`, the agent runs it as an end-of-run validation gate. If not configured, it skips the check with a note in the results.
+
+> **Note:** The orbweaver CLI itself requires Node.js >= 24 (native type stripping, `fs.glob`). Your target project can use any Node.js version.
 
 ## Project Setup
 

--- a/src/config/prerequisites.ts
+++ b/src/config/prerequisites.ts
@@ -18,6 +18,7 @@ const PREREQUISITE_IDS = {
   OTEL_API_DEPENDENCY: 'OTEL_API_DEPENDENCY',
   SDK_INIT_FILE: 'SDK_INIT_FILE',
   WEAVER_SCHEMA: 'WEAVER_SCHEMA',
+  ANTHROPIC_API_KEY: 'ANTHROPIC_API_KEY',
 } as const;
 
 type PrerequisiteId = typeof PREREQUISITE_IDS[keyof typeof PREREQUISITE_IDS];
@@ -233,6 +234,32 @@ async function checkWeaverSchema(projectRoot: string, schemaPath: string): Promi
 }
 
 /**
+ * Check that the ANTHROPIC_API_KEY environment variable is set and non-empty.
+ * This is the most common failure mode for new users — the API key is required
+ * for all LLM calls but wasn't previously validated during prerequisites.
+ *
+ * @returns Structured result indicating whether the API key is available
+ */
+function checkAnthropicApiKey(): PrerequisiteCheckResult {
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (key && key.length > 0) {
+    return {
+      id: PREREQUISITE_IDS.ANTHROPIC_API_KEY,
+      passed: true,
+      message: 'ANTHROPIC_API_KEY found in environment.',
+    };
+  }
+
+  return {
+    id: PREREQUISITE_IDS.ANTHROPIC_API_KEY,
+    passed: false,
+    message:
+      'ANTHROPIC_API_KEY not found in environment. ' +
+      'Add it to a .env file in your project root or set it in your shell: export ANTHROPIC_API_KEY=your-key',
+  };
+}
+
+/**
  * Run all prerequisite checks for the project.
  * Each check produces a structured result; the aggregate reports whether all passed.
  *
@@ -246,6 +273,7 @@ async function checkPrerequisites(projectRoot: string, config: AgentConfig): Pro
     checkOtelApiDependency(projectRoot),
     checkSdkInitFile(projectRoot, config.sdkInitFile),
     checkWeaverSchema(projectRoot, config.schemaPath),
+    Promise.resolve(checkAnthropicApiKey()),
   ]);
 
   return {
@@ -259,6 +287,7 @@ export {
   checkOtelApiDependency,
   checkSdkInitFile,
   checkWeaverSchema,
+  checkAnthropicApiKey,
   checkPrerequisites,
   PREREQUISITE_IDS,
 };

--- a/src/coordinator/coordinate.ts
+++ b/src/coordinator/coordinate.ts
@@ -77,7 +77,7 @@ export interface CoordinateDeps {
     callbacks?: Pick<CoordinatorCallbacks, 'onValidationStart' | 'onValidationComplete'>,
   ) => Promise<LiveCheckResult>;
   readFileForAdvisory: (filePath: string) => Promise<string>;
-  checkGhAvailable?: () => Promise<boolean>;
+  checkGhAvailable?: () => Promise<boolean | { available: boolean; warning?: string }>;
   liveCheckOptions?: LiveCheckOptions;
 }
 
@@ -169,9 +169,13 @@ export async function coordinate(
   // Advisory: Check gh CLI authentication early so users know before tokens are spent
   const ghWarnings: string[] = [];
   try {
-    const ghAuthenticated = await checkGh();
-    if (!ghAuthenticated) {
+    const ghResult = await checkGh();
+    // Support both old boolean return and new object return
+    const ghAvailable = typeof ghResult === 'object' ? ghResult.available : ghResult;
+    const ghWarning = typeof ghResult === 'object' ? ghResult.warning : undefined;
+    if (!ghAvailable) {
       ghWarnings.push(
+        ghWarning ??
         'gh CLI is not installed or not authenticated — PR creation will be skipped. ' +
         'Run \'gh auth login\' to enable PR creation, or use --no-pr to suppress this warning.',
       );

--- a/src/deliverables/git-workflow.ts
+++ b/src/deliverables/git-workflow.ts
@@ -52,7 +52,7 @@ export interface GitWorkflowDeps {
   renderPrSummary: (runResult: RunResult, config: AgentConfig, projectDir?: string) => string;
   writePrSummary: (projectDir: string, content: string) => Promise<string>;
   createPr: (projectDir: string, title: string, body: string) => Promise<string>;
-  checkGhAvailable: () => Promise<boolean>;
+  checkGhAvailable: () => Promise<boolean | { available: boolean; warning?: string }>;
   stderr: (msg: string) => void;
 }
 
@@ -155,9 +155,14 @@ export async function runGitWorkflow(
     prSummaryPath = await deps.writePrSummary(projectDir, prBody);
     deps.stderr(`PR summary saved to ${prSummaryPath}`);
 
-    const ghAvailable = await deps.checkGhAvailable();
+    const ghResult = await deps.checkGhAvailable();
+    // Support both old boolean return and new object return
+    const ghAvailable = typeof ghResult === 'object' ? ghResult.available : ghResult;
+    const ghWarning = typeof ghResult === 'object' ? ghResult.warning : undefined;
     if (!ghAvailable) {
-      deps.stderr('gh CLI is not installed or not authenticated — skipping PR creation. Install gh (https://cli.github.com) and run \'gh auth login\' to enable PR creation, or use --no-pr to skip.');
+      const msg = ghWarning ??
+        'gh CLI is not installed or not authenticated — skipping PR creation. Install gh (https://cli.github.com) and run \'gh auth login\' to enable PR creation, or use --no-pr to skip.';
+      deps.stderr(msg);
     } else {
       let pushSucceeded = false;
       try {
@@ -190,17 +195,44 @@ export async function runGitWorkflow(
 }
 
 /**
- * Check whether the gh CLI is installed and authenticated.
- * Runs `gh auth status` which validates both installation and active credentials.
+ * Check whether the gh CLI is installed and has credentials available to subprocesses.
  *
- * @returns True if gh is installed and authenticated
+ * Uses `gh auth token` instead of `gh auth status` because `gh auth status` can
+ * pass when credentials are in the system keyring but unavailable to subprocesses
+ * (e.g., `gh pr create` run by the agent). `gh auth token` outputs the actual token,
+ * confirming credentials are accessible programmatically.
+ *
+ * @returns Object with `available` (gh is installed and has a token) and optional `warning`
  */
-export async function checkGhAvailable(): Promise<boolean> {
-  return new Promise((res) => {
+export async function checkGhAvailable(): Promise<{ available: boolean; warning?: string }> {
+  // First check if gh auth token works — this confirms credentials are accessible to subprocesses
+  const tokenAvailable = await new Promise<boolean>((res) => {
+    execFile('gh', ['auth', 'token'], { timeout: 5000 }, (error, stdout) => {
+      res(!error && stdout.trim().length > 0);
+    });
+  });
+
+  if (tokenAvailable) {
+    return { available: true };
+  }
+
+  // Token not available — check if gh auth status passes (keyring-only auth)
+  const statusPasses = await new Promise<boolean>((res) => {
     execFile('gh', ['auth', 'status'], { timeout: 5000 }, (error) => {
       res(!error);
     });
   });
+
+  if (statusPasses) {
+    return {
+      available: false,
+      warning:
+        'gh CLI is authenticated via keyring but credentials may not be available to subprocesses. ' +
+        'Set GITHUB_TOKEN in your .env file for reliable PR creation, or use --no-pr to skip.',
+    };
+  }
+
+  return { available: false };
 }
 
 /**

--- a/test/config/prerequisites.test.ts
+++ b/test/config/prerequisites.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for prerequisite checks before instrumentation.
-// ABOUTME: Covers package.json, OTel API dependency, SDK init file, and Weaver schema checks.
+// ABOUTME: Covers package.json, OTel API dependency, SDK init file, Weaver schema, and API key checks.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
@@ -10,6 +10,7 @@ import {
   checkOtelApiDependency,
   checkSdkInitFile,
   checkWeaverSchema,
+  checkAnthropicApiKey,
   checkPrerequisites,
 } from '../../src/config/prerequisites.ts';
 import type { AgentConfig } from '../../src/config/schema.ts';
@@ -218,6 +219,43 @@ describe('checkWeaverSchema', () => {
   });
 });
 
+describe('checkAnthropicApiKey', () => {
+  const originalEnv = process.env.ANTHROPIC_API_KEY;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.ANTHROPIC_API_KEY = originalEnv;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it('passes when ANTHROPIC_API_KEY is set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+    const result = checkAnthropicApiKey();
+    expect(result.passed).toBe(true);
+    expect(result.id).toBe('ANTHROPIC_API_KEY');
+    expect(result.message).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('fails when ANTHROPIC_API_KEY is not set', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const result = checkAnthropicApiKey();
+    expect(result.passed).toBe(false);
+    expect(result.id).toBe('ANTHROPIC_API_KEY');
+    expect(result.message).toContain('not found');
+    expect(result.message).toContain('.env');
+  });
+
+  it('fails when ANTHROPIC_API_KEY is empty string', () => {
+    process.env.ANTHROPIC_API_KEY = '';
+    const result = checkAnthropicApiKey();
+    expect(result.passed).toBe(false);
+    expect(result.id).toBe('ANTHROPIC_API_KEY');
+    expect(result.message).toContain('not found');
+  });
+});
+
 describe('checkPrerequisites', () => {
   it('returns allPassed true when all checks pass', async () => {
     writeFile('package.json', JSON.stringify(makePackageJson({
@@ -228,8 +266,8 @@ describe('checkPrerequisites', () => {
 
     const config = makeMinimalConfig();
     const result = await checkPrerequisites(testDir, config);
-    // allPassed depends on weaver CLI availability — check structure
-    expect(result.checks).toHaveLength(4);
+    // allPassed depends on weaver CLI and env availability — check structure
+    expect(result.checks).toHaveLength(5);
     expect(result.checks[0].id).toBe('PACKAGE_JSON');
     expect(result.checks[0].passed).toBe(true);
     expect(result.checks[1].id).toBe('OTEL_API_DEPENDENCY');

--- a/test/deliverables/git-workflow.test.ts
+++ b/test/deliverables/git-workflow.test.ts
@@ -615,8 +615,12 @@ describe('checkGhAvailable', () => {
     expect(typeof checkGhAvailable).toBe('function');
   });
 
-  it('resolves to a boolean when invoked against real gh CLI', async () => {
+  it('resolves to an object with available and optional warning when invoked against real gh CLI', async () => {
     const result = await checkGhAvailable();
-    expect(typeof result).toBe('boolean');
+    expect(typeof result).toBe('object');
+    expect(typeof result.available).toBe('boolean');
+    if (result.warning !== undefined) {
+      expect(typeof result.warning).toBe('string');
+    }
   });
 });


### PR DESCRIPTION
## Description

**What does this PR do?**

Closes documentation and prerequisite check gaps that cause friction for new users setting up orbweaver.

**Why is this change needed?**

Users discovered during eval repo setup that env var requirements weren't clearly documented and prerequisite checks didn't catch the most common failure mode (missing API key). Six specific issues identified in #140.

## Related Issues

- Closes #140

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📚 Documentation update

## Testing Checklist

- [x] Tests added or updated
- [x] All existing tests pass locally
- [x] Test coverage maintained or improved

**Test commands run:**
```bash
npx vitest run test/config/prerequisites.test.ts
npx vitest run test/deliverables/git-workflow.test.ts
```

**Test results:**
- 24 prerequisite tests pass (3 new for ANTHROPIC_API_KEY check)
- 65 git-workflow tests pass (1 updated for new checkGhAvailable return type)

## Documentation Checklist

- [x] README.md updated (if user-facing changes)
- [x] Code comments added for complex logic

## Security Checklist

- [x] No secrets or credentials committed
- [x] `.env.example` contains only placeholder values

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

`checkGhAvailable()` return type changed from `boolean` to `{ available: boolean; warning?: string }` but callers handle both shapes via runtime type check.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally with my changes
- [x] PR title follows Conventional Commits format

## Additional Context

**Reviewer Notes:**
- `.env.example` is the main user-facing addition — verify placeholder values are sensible
- `checkGhAvailable()` now uses `gh auth token` instead of `gh auth status` to detect when keyring-only auth won't work for subprocesses
- Node.js badge removed from README — the >= 24 requirement is scoped as an orbweaver-internal detail, not a target project requirement

**Follow-up Work:**
- None identified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration template file (.env.example) for streamlined setup of API credentials
  * Enhanced GitHub integration with improved credential handling and informative warnings

* **Documentation**
  * Updated setup instructions with clearer guidance on environment variable configuration
  * Clarified Node.js version requirements and credential setup options
  * Improved documentation for optional GitHub token integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->