### PR TITLE
fix(ci): increase acceptance gate timeout to 75 minutes

### DIFF
--- a/.github/workflows/acceptance-gate.yml
+++ b/.github/workflows/acceptance-gate.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   acceptance-gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +60,6 @@ jobs:
 
       - name: Run ${{ matrix.test-group.name }} acceptance tests
         run: npx vitest run --reporter=verbose ${{ matrix.test-group.pattern }}
-        timeout-minutes: 40
+        timeout-minutes: 75
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Description

**What does this PR do?**

Increases the acceptance gate CI step timeout from 40 to 75 minutes (job timeout from 45 to 80 minutes).

**Why is this change needed?**

The coordinator acceptance tests take ~34 minutes of test execution plus 3-5 minutes of setup overhead. The 40-minute step timeout was too tight — PR #144's acceptance gate passed all 8 tests but timed out before completion. These tests are advisory-only, so generous timeouts are appropriate.

## Related Issues

- Related to: #144 (acceptance gate timed out on this PR)

## Type of Change

- [x] 🔨 CI/CD changes

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] PR title follows Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended timeout limits for acceptance test execution to prevent test failures due to timeout constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->