### PR TITLE
fix(coordinator): restore file content when schema extension validation fails

### DIFF
--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -357,6 +357,10 @@ export async function dispatchFiles(
               extWarnings?.push(`Schema extension restore failed for ${filePath}: ${restoreMsg}`);
             }
           }
+          // Restore original file content (same as validation failure path)
+          try {
+            await writeFile(filePath, fileContent, 'utf-8');
+          } catch { /* best-effort restore — failure already recorded above */ }
         }
       }
 

--- a/test/coordinator/dispatch-per-file-extensions.test.ts
+++ b/test/coordinator/dispatch-per-file-extensions.test.ts
@@ -866,4 +866,39 @@ describe('dispatchFiles — per-file schema extension writing', () => {
     const fileOnDisk = await readFile(file1, 'utf-8');
     expect(fileOnDisk).toBe(originalContent);
   });
+
+  it('restores original file content when writeSchemaExtensions throws', async () => {
+    const originalContent = 'function a() { return 1; }';
+    const file1 = await createFile('a.js', originalContent);
+
+    const extensionYaml = '- id: myapp.payment.amount\n  type: double';
+    const instrumentedContent = 'import { trace } from "@opentelemetry/api";\nfunction a() { return 1; }';
+
+    const instrumentWithRetry = vi.fn().mockImplementation(async (filePath: string) => {
+      await writeFile(filePath, instrumentedContent, 'utf-8');
+      return makeSuccessResult(filePath, { schemaExtensions: [extensionYaml] });
+    });
+
+    const writeSchemaExtensions = vi.fn().mockRejectedValue(new Error('Weaver write crashed'));
+    const snapshotExtensionsFile = vi.fn().mockResolvedValue('previous-content');
+    const restoreExtensionsFile = vi.fn().mockResolvedValue(undefined);
+
+    const deps = makeDeps({
+      instrumentWithRetry,
+      writeSchemaExtensions,
+      snapshotExtensionsFile,
+      restoreExtensionsFile,
+    });
+    const config = makeConfig();
+    const registryDir = join(tmpDir, 'registry');
+
+    await dispatchFiles([file1], tmpDir, config, undefined, {
+      deps,
+      registryDir,
+    });
+
+    // The file on disk should be restored to original content
+    const fileOnDisk = await readFile(file1, 'utf-8');
+    expect(fileOnDisk).toBe(originalContent);
+  });
 });


### PR DESCRIPTION
## Description

**What does this PR do?**

Restores original file content when `validateRegistry()` fails after writing schema extensions. Previously, the schema rollback correctly restored `agent-extensions.yaml` but left the instrumented `.js` file on disk with code referencing now-unregistered attributes.

**Why is this change needed?**

Run-3 evaluation found SCH-002 violations — `commit_story.git.subcommand` and `commit_story.commit.parent_count` appeared in instrumented code but not in the Weaver registry. The schema extension system wrote these to the registry, but when validation failed, extensions were rolled back while the instrumented code was left on disk. This created an inconsistent state where the code references attributes the registry doesn't define.

## Related Issues

- Closes #147

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Test updates (adding or updating tests)

## Testing Checklist

- [x] Tests added or updated
- [x] All existing tests pass locally
- [x] Test coverage maintained or improved

**Test commands run:**
```bash
npx vitest run test/coordinator/dispatch-per-file-extensions.test.ts test/coordinator/dispatch-schema-revert.test.ts --reporter=verbose
npx tsc --noEmit
```

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally with my changes
- [x] PR title follows Conventional Commits format

**Reviewer Notes:**
- The fix is a single `writeFile` call in `src/coordinator/dispatch.ts` (line ~329) that restores original file content on the validation failure path
- The `fileContent` variable was already in scope (read at line 226)
- Matches the pattern used by the dry-run path and the fix loop's internal validation failure handling
- New test in `dispatch-per-file-extensions.test.ts` simulates the full scenario: instrumentWithRetry writes to disk, validation fails, original content verified restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file recovery when validation fails after writing schema extensions. The system now properly restores original file content during error recovery, ensuring files revert to their previous state instead of remaining in an inconsistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->