### PR TITLE
docs: update rubric naming and add COV-006 OpenLLMetry research

### DIFF
--- a/research/evaluation-rubric.md
+++ b/research/evaluation-rubric.md
@@ -184,7 +184,7 @@ The following rules are binary preconditions. If any gate fails, quality scoring
 | **Classification** | Automatable |
 | **Mechanism** | AST/grep: all `@opentelemetry/*` imports resolve to `@opentelemetry/api` only. |
 
-**SDK setup file exemption**: API-001 and API-004 evaluate application source files only. The SDK setup file (configured as `sdkInitFile` in orb.yaml, typically `src/instrumentation.js` or `src/instrumentation.ts`) is expected to import SDK packages and is exempt from these rules.
+**SDK setup file exemption**: API-001 and API-004 evaluate application source files only. The SDK setup file (configured as `sdkInitFile` in orbweaver.yaml, typically `src/instrumentation.js` or `src/instrumentation.ts`) is expected to import SDK packages and is exempt from these rules.
 
 #### NDS-006: Module System Consistency
 

--- a/research/rubric-codebase-mapping.md
+++ b/research/rubric-codebase-mapping.md
@@ -436,13 +436,23 @@ All 15 error handling sites listed under NDS-005. Key ones:
 | `child_process` | `@opentelemetry/instrumentation-child_process` | git-collector.js, commit-analyzer.js, index.js |
 | `fs` | `@opentelemetry/instrumentation-fs` | claude-collector.js, journal-manager.js, MCP tools, journal-paths.js |
 
+**Auto-instrumentation partially available (OpenLLMetry)**:
+
+| Module | Package | JS Coverage | Notes |
+|---|---|---|---|
+| `@langchain/anthropic` (ChatAnthropic) | `@traceloop/instrumentation-langchain` | Chat model calls (`handleChatModelStart`/`End`) | Captures model name, token counts, prompt/completion content via LangChain callback injection. Span names follow `{ComponentName}.{type}` pattern (e.g., `ChatAnthropic.chat`). Uses Traceloop custom attributes (`traceloop.span.kind`, `traceloop.entity.*`), not OTel GenAI semconvs. |
+| `@langchain/langgraph` | `@traceloop/instrumentation-langchain` | LLM calls within nodes only (indirect) | **Significant gap in JS**: LangGraph node execution, state transitions, conditional routing, and graph compilation are NOT instrumented. Only LLM calls made via LangChain wrappers inside nodes are captured. The Python package has LangGraph-specific patches (`Pregel.stream`, `Command.__init__`); the JS package does not. Manual spans are required for graph-level orchestration visibility. |
+
 **Auto-instrumentation NOT available**:
 
 | Module | Notes |
 |---|---|
-| `@langchain/anthropic` (ChatAnthropic) | No OTel auto-instrumentation package — manual spans required |
-| `@langchain/langgraph` | No OTel auto-instrumentation package — manual spans required |
 | `@modelcontextprotocol/sdk` | No OTel auto-instrumentation package — manual spans required |
+
+**OpenLLMetry evaluation guidance for commit-story-v2**: The `@traceloop/instrumentation-langchain` JS package provides partial auto-instrumentation for LangChain operations but has significant LangGraph gaps. For this codebase:
+- `journal-graph.js` (LangGraph graph with `summaryNode`, `technicalNode`, `dialogueNode`): Auto-instrumentation would capture the `ChatAnthropic.invoke()` calls within each node, but NOT the graph orchestration, node dispatch, or state transitions. Manual spans on graph nodes and the `generateJournalSections` entry point are justified — they provide orchestration visibility that auto-instrumentation cannot.
+- If the agent uses `@traceloop/instrumentation-langchain` AND adds manual spans on the same `ChatAnthropic.invoke()` calls, that IS redundant (COV-006 fail). But manual spans on graph nodes alongside auto-instrumented LLM calls is the correct pattern.
+- Known JS reliability issues: [openllmetry-js#471](https://github.com/traceloop/openllmetry-js/issues/471) documents auto-instrumentation not fully supported in some JS environments. The force-instrumentation workaround covers `langchain/chains`, `langchain/agents`, `langchain/tools` but NOT `@langchain/langgraph`.
 
 **Evaluator decision tree**:
 


### PR DESCRIPTION
## Summary
- Fix `orb.yaml` → `orbweaver.yaml` naming in evaluation rubric SDK setup file exemption
- Add COV-006 OpenLLMetry research to rubric codebase mapping: documents `@traceloop/instrumentation-langchain` JS coverage gaps for LangChain/LangGraph, evaluation guidance for commit-story-v2, and known JS reliability issues (openllmetry-js#471)

## Test plan
- [ ] Documentation review — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SDK setup configuration documentation references
  * Added comprehensive guidance on auto-instrumentation coverage, including coverage maps, identified gaps, and instrumentation strategy recommendations for JavaScript components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->