### PR TITLE
fix: exempt expected-condition catches from COV-003 error recording

### DIFF
--- a/src/validation/tier2/cov003.ts
+++ b/src/validation/tier2/cov003.ts
@@ -203,14 +203,19 @@ function isExpectedConditionCatch(catchClause: import('ts-morph').CatchClause): 
   // Single return statement with a default/fallback value
   if (statements.length === 1) {
     const stmtText = statements[0].getText().trim();
-    if (/^return\s+(null|undefined|false|true|\{\}|\[\]|''|""|0|-1);?$/.test(stmtText)) {
+    if (/^return\s+(null|undefined|false|\{\}|\[\]|''|"");?$/.test(stmtText)) {
       return true;
     }
   }
 
-  // Error-code checks (e.g., `if (err.code === 'ENOENT')`)
+  // Error-code checks (e.g., `if (err.code === 'ENOENT')`) — but only when the
+  // catch doesn't rethrow on non-expected paths. A catch that checks ENOENT and
+  // rethrows other errors has a genuine error path that needs recording.
   if (EXPECTED_CONDITION_PATTERNS.some((pattern) => bodyText.includes(pattern))) {
-    return true;
+    const hasThrow = bodyText.includes('throw ') || bodyText.includes('throw;');
+    if (!hasThrow) {
+      return true;
+    }
   }
 
   return false;

--- a/test/validation/tier2/cov003.test.ts
+++ b/test/validation/tier2/cov003.test.ts
@@ -231,7 +231,7 @@ describe('checkErrorVisibility (COV-003)', () => {
       expect(results[0].passed).toBe(true);
     });
 
-    it('passes when catch checks for ENOENT (expected condition)', () => {
+    it('flags ENOENT catch that rethrows non-expected errors (mixed path)', () => {
       const code = [
         'const { trace } = require("@opentelemetry/api");',
         'const tracer = trace.getTracer("svc");',
@@ -242,6 +242,29 @@ describe('checkErrorVisibility (COV-003)', () => {
         '    } catch (err) {',
         '      if (err.code === "ENOENT") return null;',
         '      throw err;',
+        '    } finally {',
+        '      span.end();',
+        '    }',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkErrorVisibility(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
+    it('passes when ENOENT catch does not rethrow (pure fallback)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function loadIfExists(path) {',
+        '  return tracer.startActiveSpan("loadIfExists", (span) => {',
+        '    try {',
+        '      return readFileSync(path);',
+        '    } catch (err) {',
+        '      if (err.code === "ENOENT") return null;',
+        '      return null;',
         '    } finally {',
         '      span.end();',
         '    }',


### PR DESCRIPTION
## Summary

- Add `isExpectedConditionCatch()` to detect catch blocks that handle normal control flow (not genuine errors): empty catches, default-value returns, error-code checks (ENOENT etc.), loop `continue`
- These catches are exempt from COV-003 error recording requirements — recording them as errors pollutes metrics and triggers false alerts (NDS-005b violations)
- The agent prompt already documented this exception but the validator was not enforcing it

## Test plan

- [x] 7 new tests covering all expected-condition patterns (empty, unused param, default return, null return, ENOENT check, continue, rethrow-with-log still flagged)
- [x] All existing COV-003 tests still pass (no regressions)
- [x] Full test suite passes (1669 tests, 0 failures)

Closes #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-handling validation to better recognize and exempt expected-condition catch blocks from unnecessary error-recording checks.

* **Tests**
  * Added comprehensive test suite covering expected-condition catch block exemption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->