### PR TITLE
fix: SCH-002 feedback includes valid attributes, live-check detects degraded status

### DIFF
--- a/src/coordinator/coordinate.ts
+++ b/src/coordinator/coordinate.ts
@@ -447,6 +447,28 @@ export async function coordinate(
       if (liveCheckResult.warnings.length > 0) {
         runResult.warnings.push(...liveCheckResult.warnings);
       }
+
+      // Detect degraded live-check: if no files succeeded, the live-check
+      // ran against uninstrumented code and its "OK" status is misleading.
+      if (!liveCheckResult.skipped && runResult.filesSucceeded === 0) {
+        runResult.warnings.push(
+          'Live-check degraded: no files were successfully instrumented. ' +
+          'Compliance report reflects uninstrumented code (no spans emitted).',
+        );
+        runResult.endOfRunValidation =
+          `DEGRADED — ${runResult.endOfRunValidation ?? 'no compliance report'}`;
+      } else if (!liveCheckResult.skipped && runResult.filesFailed > 0) {
+        // Partial degradation: some files failed, live-check may be incomplete
+        const failedPaths = fileResults
+          .filter(r => r.status === 'failed')
+          .map(r => r.path)
+          .slice(0, 5);
+        runResult.warnings.push(
+          `Live-check partial: ${runResult.filesFailed} file(s) failed instrumentation ` +
+          `(${failedPaths.join(', ')}${runResult.filesFailed > 5 ? '...' : ''}). ` +
+          `Compliance report may be incomplete — spans from failed files are missing.`,
+        );
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       runResult.warnings.push(`End-of-run live-check failed (degraded): ${message}`);

--- a/src/validation/tier2/sch002.ts
+++ b/src/validation/tier2/sch002.ts
@@ -51,15 +51,21 @@ export function checkAttributeKeysMatchRegistry(
     return [pass(filePath, 'All attribute keys match registry names.')];
   }
 
+  // Build a suggestion of valid registry attribute names for the feedback
+  const registryNamesList = [...registryNames].sort();
+  const suggestionsText = registryNamesList.length <= 30
+    ? `Valid registry attributes: ${registryNamesList.join(', ')}`
+    : `Valid registry attributes (${registryNamesList.length} total, showing first 30): ${registryNamesList.slice(0, 30).join(', ')}`;
+
   return issues.map((i) => ({
     ruleId: 'SCH-002',
     passed: false,
     filePath,
     lineNumber: i.line,
     message:
-      `SCH-002 check failed: "${i.key}" at line ${i.line} not found in the registry.\n` +
-      `Attribute keys must match names defined in the Weaver telemetry registry. ` +
-      `Either use a registered attribute name or add a new attribute definition to the registry.`,
+      `SCH-002 check failed: "${i.key}" at line ${i.line} not found in the registry. ` +
+      `Use a registered attribute name from the schema, or report it as a schemaExtension. ` +
+      `${suggestionsText}`,
     tier: 2,
     blocking: true,
   }));

--- a/test/coordinator/coordinate.test.ts
+++ b/test/coordinator/coordinate.test.ts
@@ -1198,6 +1198,51 @@ describe('coordinate', () => {
       expect(deps.writeFileForRollback).not.toHaveBeenCalled();
     });
 
+    it('warns when live-check runs against all-failed files (degraded)', async () => {
+      const deps = makeDeps({
+        hasTestSuite: vi.fn().mockResolvedValue(true),
+        dispatchFiles: vi.fn().mockImplementation(async (filePaths: string[]) => {
+          return filePaths.map(fp => makeFailedResult(fp));
+        }),
+        runLiveCheck: vi.fn().mockResolvedValue({
+          skipped: false,
+          testsPassed: true,
+          complianceReport: 'All checks passed',
+          warnings: [],
+        }),
+      });
+      const config = makeConfig({ testCommand: 'npm test' });
+
+      const result = await coordinate('/project', config, undefined, deps);
+
+      expect(result.warnings.some((w: string) => w.includes('Live-check degraded'))).toBe(true);
+      expect(result.endOfRunValidation).toContain('DEGRADED');
+    });
+
+    it('warns when live-check has partial file failures', async () => {
+      const deps = makeDeps({
+        hasTestSuite: vi.fn().mockResolvedValue(true),
+        dispatchFiles: vi.fn().mockImplementation(async (filePaths: string[]) => {
+          return [
+            makeSuccessResult(filePaths[0]),
+            makeFailedResult(filePaths[1]),
+          ];
+        }),
+        runLiveCheck: vi.fn().mockResolvedValue({
+          skipped: false,
+          testsPassed: true,
+          complianceReport: 'Some checks passed',
+          warnings: [],
+        }),
+      });
+      const config = makeConfig({ testCommand: 'npm test' });
+
+      const result = await coordinate('/project', config, undefined, deps);
+
+      expect(result.warnings.some((w: string) => w.includes('Live-check partial'))).toBe(true);
+      expect(result.warnings.some((w: string) => w.includes('b.js'))).toBe(true);
+    });
+
     it('degrades gracefully when file restore fails during rollback', async () => {
       const deps = makeRollbackDeps({
         writeFileForRollback: vi.fn().mockRejectedValue(new Error('EACCES')),

--- a/test/validation/tier2/sch002.test.ts
+++ b/test/validation/tier2/sch002.test.ts
@@ -97,6 +97,9 @@ describe('checkAttributeKeysMatchRegistry (SCH-002)', () => {
       expect(results[0].message).toContain('user.custom.field');
       expect(results[0].message).toContain('SCH-002');
       expect(results[0].lineNumber).toBeTypeOf('number');
+      // Feedback should include valid registry attribute names
+      expect(results[0].message).toContain('Valid registry attributes');
+      expect(results[0].message).toContain('http.request.method');
     });
 
     it('reports each non-matching attribute key as a separate CheckResult', () => {


### PR DESCRIPTION
## Summary

- **SCH-002 oscillation fix**: Error messages now list valid registry attribute names so the LLM can pick from real alternatives instead of guessing — which previously caused error count oscillation (9→12 violations on entry point in run-5)
- **Live-check degradation detection**: When no files succeeded, the compliance report is prefixed with `DEGRADED` and a warning explains spans are missing. When some files failed, a warning lists the failed paths so the report's incompleteness is visible

## Test plan

- [x] SCH-002 test verifies feedback includes valid attribute names (`http.request.method` etc.)
- [x] Coordinator test: live-check with all-failed files produces DEGRADED status
- [x] Coordinator test: live-check with partial failures produces partial warning with paths
- [x] Full test suite passes (1664 tests, 0 failures)

Closes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced warning messages for degraded live-checks, including notifications for uninstrumented code and partial file failures.
  * Improved error feedback with curated suggestions for valid registry attribute names.

* **Tests**
  * Added test coverage for degraded and partial live-check scenarios.
  * Updated tests for enhanced error feedback validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->