### PR TITLE
fix: namespace enforcement accepts span-type schema extensions

### DIFF
--- a/src/coordinator/schema-extensions.ts
+++ b/src/coordinator/schema-extensions.ts
@@ -152,11 +152,11 @@ export async function writeSchemaExtensions(
       continue;
     }
 
-    const id = attr.id as string | undefined;
-    if (!id) {
-      rejected.push('(no id)');
+    if (typeof attr.id !== 'string' || attr.id.length === 0) {
+      rejected.push(String(attr.id ?? '(no id)'));
       continue;
     }
+    const id = attr.id;
 
     // Span-type extensions have IDs like "span.myapp.process_order" —
     // strip the "span." prefix before checking the namespace.
@@ -194,12 +194,11 @@ export async function writeSchemaExtensions(
   if (validSpans.length > 0) {
     for (const span of validSpans) {
       groups.push({
-        id: span.id,
+        ...span,
         type: 'span',
         stability: span.stability ?? 'development',
-        brief: span.brief ?? `Agent-discovered span`,
+        brief: span.brief ?? 'Agent-discovered span',
         span_kind: span.span_kind ?? 'internal',
-        ...(span.attributes ? { attributes: span.attributes } : {}),
       });
     }
   }

--- a/test/coordinator/schema-extensions.test.ts
+++ b/test/coordinator/schema-extensions.test.ts
@@ -213,6 +213,19 @@ describe('writeSchemaExtensions', () => {
     expect(result.rejected[0]).toContain('wrong_namespace.order.total');
   });
 
+  it('rejects extensions with non-string id (e.g., numeric) (#176)', async () => {
+    const extensions = [
+      '- id: 123\n  type: int\n  stability: development\n  brief: Numeric ID',
+    ];
+
+    const result = await writeSchemaExtensions(registryDir, extensions);
+
+    expect(result.written).toBe(false);
+    expect(result.extensionCount).toBe(0);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]).toContain('123');
+  });
+
   it('accepts bare string IDs as extensions (LLM output format) (#155)', async () => {
     // The LLM outputs plain string IDs like "myapp.context.collect"
     // rather than YAML objects. The parser must handle both formats.


### PR DESCRIPTION
## Summary

- Span-type extension IDs (e.g., `span.myapp.process_order`) were rejected by namespace enforcement because the check didn't strip the `span.` prefix before validating
- All extensions were hardcoded as `attribute_group` in output YAML — span extensions now output with `type: span`
- `extensionCount` now includes both span and attribute extensions

Closes #176

## Test plan

- [x] 4 new tests covering span-type extensions (bare string, YAML object, wrong namespace rejection, mixed span+attribute output)
- [x] All 30 schema-extensions tests pass
- [x] Full suite: 1693 passed, 22 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema extension handling now supports span-type extensions alongside attribute extensions, including detection of bare "span." IDs, separate span groups in output, improved ID validation, namespace checking, and accurate extension counts.

* **Tests**
  * Expanded tests covering span and attribute acceptance/rejection, namespace validation, bare-string parsing, YAML output grouping, overwrite behavior, and integration with existing attribute groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->