### PR TITLE
fix: whole-file syntax check after function-level assembly

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -618,7 +618,7 @@ async function functionLevelFallback(
     }
   }
 
-  const successful = fnResults.filter(r => r.success);
+  let successful = fnResults.filter(r => r.success);
   if (successful.length === 0) {
     return null; // All functions failed — fall through to whole-file failure
   }
@@ -630,18 +630,30 @@ async function functionLevelFallback(
   await writeFile(filePath, reassembledCode, 'utf-8');
 
   // Whole-file syntax check catches assembly errors (corrupted imports, bad splicing)
-  const syntaxResult = checkSyntax(filePath);
-  if (!syntaxResult.passed) {
+  let syntaxPassed: boolean;
+  try {
+    syntaxPassed = checkSyntax(filePath).passed;
+  } catch {
+    await writeFile(filePath, originalCode, 'utf-8');
+    return null;
+  }
+
+  if (!syntaxPassed) {
     // Identify which function's instrumentation broke syntax by testing each one individually
     for (const fn of extractedFunctions) {
       const result = fnResults.find(r => r.name === fn.name);
       if (!result?.success) continue;
       const singleReassembled = reassembleFunctions(originalCode, extractedFunctions, [result]);
       await writeFile(filePath, singleReassembled, 'utf-8');
-      const singleCheck = checkSyntax(filePath);
-      if (!singleCheck.passed) {
+      try {
+        const singleCheck = checkSyntax(filePath);
+        if (!singleCheck.passed) {
+          result.success = false;
+          result.error = `Whole-file syntax error after assembly: ${singleCheck.message}`;
+        }
+      } catch {
         result.success = false;
-        result.error = `Whole-file syntax error after assembly: ${singleCheck.message}`;
+        result.error = 'Whole-file syntax check threw an unexpected error';
       }
     }
 
@@ -654,12 +666,20 @@ async function functionLevelFallback(
 
     reassembledCode = reassembleFunctions(originalCode, extractedFunctions, fnResults);
     await writeFile(filePath, reassembledCode, 'utf-8');
-    const retryCheck = checkSyntax(filePath);
-    if (!retryCheck.passed) {
+    try {
+      const retryCheck = checkSyntax(filePath);
+      if (!retryCheck.passed) {
+        await writeFile(filePath, originalCode, 'utf-8');
+        return null;
+      }
+    } catch {
       await writeFile(filePath, originalCode, 'utf-8');
       return null;
     }
   }
+
+  // Recompute successful after syntax check may have marked additional functions as failed
+  successful = fnResults.filter(r => r.success);
 
   const validationConfig = buildValidationConfig(config, retryOptions?.projectRoot, resolvedSchema, retryOptions?.anthropicClient);
   const validation = await validateFileFn({

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -2306,11 +2306,11 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
         if (isPerFunctionCall(callPath)) {
           fnCallCount++;
           if (fnCallCount === 1) {
-            // First function: return code with a syntax error (missing closing brace)
+            // First function: return code with a corrupted module-level import (imimport)
             return {
               success: true,
               output: makeInstrumentationOutput({
-                instrumentedCode: `import { trace } from '@opentelemetry/api';\nexport async function fetchWithRetry(url) {\n  return trace.getTracer('svc').startActiveSpan('fn', async (span) => {\n    span.end();\n  );\n}`,
+                instrumentedCode: `imimport { trace } from '@opentelemetry/api';\nexport async function fetchWithRetry(url) {\n  return trace.getTracer('svc').startActiveSpan('fn', async (span) => {\n    span.end();\n  });\n}`,
                 spanCategories: { externalCalls: 1, schemaDefined: 0, serviceEntryPoints: 0, totalFunctionsInFile: 1 },
               }),
             };
@@ -2332,18 +2332,10 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
 
     const result = await instrumentWithRetry(filePath, FALLBACK_FIXTURE, {}, makeConfig(), { deps });
 
-    // The syntax-breaking function should be excluded, but the valid one kept
-    // Result should be partial (some functions succeeded)
-    expect(result.status === 'partial' || result.status === 'failed').toBe(true);
-    if (result.functionResults) {
-      const failed = result.functionResults.filter(r => !r.success);
-      // At least one function should be marked as failed due to syntax error
-      const syntaxFailed = failed.find(r => r.error?.includes('syntax error'));
-      if (syntaxFailed) {
-        expect(syntaxFailed.error).toContain('syntax error');
-      }
-    }
-    // Original file should not be corrupted — either restored or validly instrumented
+    // The whole-file syntax check should catch the module-level imimport corruption
+    // The result should still be partial — the valid function (saveData) is kept
+    expect(result.status).toBe('partial');
+    // The file on disk should NOT contain the corrupted import
     const finalContent = readFileSync(filePath, 'utf-8');
     expect(finalContent).not.toContain('imimport');
   });


### PR DESCRIPTION
## Summary

- After function-level fallback reassembles individually instrumented functions, run `node --check` on the whole file to catch synthesis errors (corrupted imports, bad splicing)
- When syntax fails, identifies the culprit function(s) by testing each individually
- Marks culprit functions as failed and retries reassembly without them
- If even partial reassembly fails syntax, restores original and bails

Closes #187

## Test plan

- [x] New test: syntax-breaking function is excluded, valid functions preserved
- [x] All 82 instrument-with-retry tests pass
- [x] Full suite: 1695 passed, 22 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added whole-file and targeted syntax validation to the instrumentation pipeline, isolating and excluding problematic pieces to avoid corrupt outputs.
  * Improved fallback logic to retry and preserve valid partial results while preventing invalid artifacts from being written.

* **Tests**
  * Added tests that simulate post-assembly syntax failures, verifying culprit isolation, exclusion, and safe partial outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->