### PR TITLE
fix: prompt guidance for schema-uncovered attributes and Date objects

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -126,6 +126,21 @@ When adding span attributes, you MUST exhaust registered keys before inventing n
 
 Report ALL new schema entries in \`schemaExtensions\`. For each extension, explain in \`notes\` why no existing key was a semantic match.
 
+### Schema-Uncovered Files
+
+When a file has NO registry-defined attributes for its spans, you MUST still add contextual attributes. Derive 1-2 domain-relevant attributes per span from:
+- **Function parameters**: Input values that identify the operation (IDs, paths, names, counts)
+- **Return values**: Output characteristics that aid debugging (result counts, status indicators, sizes)
+
+A span with zero attributes provides minimal diagnostic value. Even without registry guidance, function signatures reveal what data matters.
+
+### Attribute Type Safety
+
+OpenTelemetry attributes must be primitive types: string, number, boolean, or arrays of these. Do NOT pass objects directly to \`span.setAttribute()\`. Common violations:
+- **Date objects**: Convert to ISO strings with \`.toISOString()\` before setting (e.g., \`span.setAttribute('task.created_at', date.toISOString())\`)
+- **Objects/Maps**: Extract specific primitive fields instead of passing the whole object
+- **Arrays of objects**: Map to arrays of primitive values first
+
 ## Scoring Checklist
 
 Your output is scored against these rules. Violating gate rules causes immediate rejection and retry. Quality rules affect the instrumentation score.

--- a/test/agent/prompt.test.ts
+++ b/test/agent/prompt.test.ts
@@ -204,6 +204,21 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('why no existing key');
   });
 
+  it('guides adding contextual attributes for schema-uncovered files (#184)', () => {
+    const prompt = buildSystemPrompt(schema);
+
+    // Must instruct agent to derive attributes from function parameters and return values
+    expect(prompt).toContain('Function parameters');
+    expect(prompt).toContain('Return values');
+  });
+
+  it('instructs converting Date objects to ISO strings before setAttribute (#184)', () => {
+    const prompt = buildSystemPrompt(schema);
+
+    expect(prompt).toContain('Date');
+    expect(prompt).toContain('toISOString');
+  });
+
   describe('scoring checklist', () => {
     it('includes all 6 evaluation dimensions', () => {
       const prompt = buildSystemPrompt(schema);


### PR DESCRIPTION
## Summary

- Schema-uncovered files had spans with zero attributes because the agent only added attributes when registry definitions existed. New prompt section instructs deriving 1-2 contextual attributes from function parameters and return values.
- Date objects passed to `setAttribute()` silently coerce or drop. New prompt section on attribute type safety instructs converting Date objects to ISO strings and extracting primitive fields from objects.

Closes #184

## Test plan

- [x] 2 new tests: schema-uncovered attribute guidance, Date/toISOString guidance
- [x] All 58 prompt tests pass
- [x] Full suite: 1703 passed, 22 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced guidance for deriving domain-relevant attributes for spans when schema definitions are unavailable
  * Added type safety rules for OpenTelemetry attributes, including proper handling of Date objects and complex types

* **Tests**
  * Added test coverage for schema-uncovered file attribute derivation behavior
  * Added verification for proper Date object conversion to ISO string format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->