### PR TITLE
fix: commit N passing functions from partial fallback even when assembly validation fails

### DIFF
--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -299,8 +299,8 @@ export async function dispatchFiles(
       // Track whether the extension block already handled rollback
       let extensionRollbackDone = false;
 
-      // Write schema extensions per-file for successful files
-      if (registryDir && result.status === 'success' && result.schemaExtensions.length > 0) {
+      // Write schema extensions per-file for successful and partial files
+      if (registryDir && (result.status === 'success' || result.status === 'partial') && result.schemaExtensions.length > 0) {
         for (const ext of result.schemaExtensions) {
           if (!seenExtensions.has(ext)) {
             seenExtensions.add(ext);

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -759,13 +759,10 @@ async function functionLevelFallback(
     config: validationConfig,
   });
 
-  if (!partialValidation.passed) {
-    // Even partial reassembly fails — restore original and return null
-    await writeFile(filePath, originalCode, 'utf-8');
-    return null;
-  }
-
-  // Restore original file when 0 spans added (same as executeRetryLoop)
+  // Commit the partial code regardless of whether blocking rules fire on the assembly.
+  // Coverage rules (COV-001 etc.) will flag the intentionally-uninstrumented functions,
+  // but those failures are expected for partial files and should not discard the N
+  // successfully-instrumented functions.
   if (totalSpans === 0) {
     await writeFile(filePath, originalCode, 'utf-8');
   }

--- a/test/coordinator/dispatch-per-file-extensions.test.ts
+++ b/test/coordinator/dispatch-per-file-extensions.test.ts
@@ -60,6 +60,23 @@ function makeSuccessResult(filePath: string, overrides: Partial<FileResult> = {}
   };
 }
 
+function makePartialResult(filePath: string, overrides: Partial<FileResult> = {}): FileResult {
+  return {
+    path: filePath,
+    status: 'partial',
+    spansAdded: 2,
+    librariesNeeded: [],
+    schemaExtensions: [],
+    attributesCreated: 1,
+    validationAttempts: 1,
+    validationStrategyUsed: 'initial-generation',
+    tokenUsage: { inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+    functionsInstrumented: 1,
+    functionsSkipped: 1,
+    ...overrides,
+  };
+}
+
 function makeFailedResult(filePath: string, overrides: Partial<FileResult> = {}): FileResult {
   return {
     path: filePath,
@@ -181,6 +198,30 @@ describe('dispatchFiles — per-file schema extension writing', () => {
     });
 
     expect(writeSchemaExtensions).not.toHaveBeenCalled();
+  });
+
+  it('calls writeSchemaExtensions after a partial file with extensions', async () => {
+    const file1 = await createFile('a.js', 'function a() {}');
+
+    const extensionYaml = '- id: myapp.payment.amount\n  type: double';
+    const writeSchemaExtensions = vi.fn().mockResolvedValue(makeWriteResult());
+    const deps = makeDeps({
+      instrumentWithRetry: vi.fn().mockResolvedValue(
+        makePartialResult(file1, { schemaExtensions: [extensionYaml] }),
+      ),
+      writeSchemaExtensions,
+    });
+
+    const config = makeConfig();
+    const registryDir = join(tmpDir, 'registry');
+
+    await dispatchFiles([file1], tmpDir, config, undefined, {
+      deps,
+      registryDir,
+    });
+
+    expect(writeSchemaExtensions).toHaveBeenCalledTimes(1);
+    expect(writeSchemaExtensions).toHaveBeenCalledWith(registryDir, [extensionYaml]);
   });
 
   it('does not call writeSchemaExtensions for skipped files', async () => {

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -2485,16 +2485,12 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
 
     const result = await instrumentWithRetry(filePath, FALLBACK_FIXTURE, {}, makeConfig(), { deps });
 
-    // Should still produce a partial result via the fallback-to-partial path
-    if (result.status === 'partial') {
-      expect(result.notes?.some(n => n.includes('Reassembly validation failed'))).toBe(true);
-    }
-    // If the fallback path didn't activate (e.g., all validations failed),
-    // at minimum the result should have a defined status
-    expect(['partial', 'failed']).toContain(result.status);
+    // Should produce a partial result via the fallback-to-partial path
+    expect(result.status).toBe('partial');
+    expect(result.notes?.some(n => n.includes('Reassembly validation failed'))).toBe(true);
   });
 
-  it('restores original file when even partial reassembly fails', async () => {
+  it('commits N passing functions even when partial reassembly validation fails blocking rules', async () => {
     const deps: InstrumentWithRetryDeps = {
       instrumentFile: async (path) => {
         if (isPerFunctionCall(path)) {
@@ -2502,6 +2498,7 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
             success: true,
             output: makeInstrumentationOutput({
               instrumentedCode: 'const x = 1;\n',
+              spanCategories: { externalCalls: 1, schemaDefined: 0, serviceEntryPoints: 0, totalFunctionsInFile: 1 },
             }),
           };
         }
@@ -2513,17 +2510,17 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
           return makePassingValidation(input.filePath);
         }
         // All non-per-function validations fail (whole-file, full reassembly, partial reassembly)
+        // This simulates coverage rules (COV-001 etc.) firing on uninstrumented functions
         return makeFailingValidation(input.filePath);
       },
     };
 
     const result = await instrumentWithRetry(filePath, FALLBACK_FIXTURE, {}, makeConfig(), { deps });
 
-    // When both full and partial reassembly fail, fallback returns null → whole-file failure
-    expect(result.status).toBe('failed');
-    // File should be restored to original content
-    const fileContent = readFileSync(filePath, 'utf-8');
-    expect(fileContent).toBe(FALLBACK_FIXTURE);
+    // N passing functions are committed even when partial assembly validation fails
+    expect(result.status).toBe('partial');
+    expect(result.functionsInstrumented).toBeGreaterThan(0);
+    expect(result.notes?.some(n => n.includes('Reassembly validation failed'))).toBe(true);
   });
 
   it('sets functionsInstrumented and functionsSkipped counts correctly', async () => {


### PR DESCRIPTION
## Summary

- Removes the `null` return path in `functionLevelFallback` when partial assembly validation fails — blocking rules (e.g. `COV-001`) fire on intentionally-uninstrumented functions in a partial assembly and should not discard the N successfully-validated functions
- Writes schema extensions for `partial` files in `dispatchFiles`, since instrumented functions reference span names that must exist in the registry
- Updates test expectations to reflect the new "always commit N passing functions" contract

## Test plan

- [x] New test: `commits N passing functions even when partial reassembly validation fails blocking rules` — confirms `partial` status instead of `failed` when all whole-file validations fail
- [x] Existing test updated: `falls back to partial results when reassembly validation fails` — strengthened from `['partial', 'failed']` to always `'partial'`
- [x] New test: `calls writeSchemaExtensions after a partial file with extensions` in dispatch-per-file-extensions
- [x] Full suite: 1705 passed, 22 skipped, 0 failed

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced partial file handling to preserve partially instrumented code instead of discarding it when validation encounters issues.
  
* **Bug Fixes**
  * Schema extensions now correctly persist for all file processing outcomes, ensuring consistent behavior across different instrumentation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->