### PR TITLE
fix: detect library projects, skip SDK init and auto-instrumentation deps (#190)

### DIFF
--- a/src/coordinator/aggregate.ts
+++ b/src/coordinator/aggregate.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Result aggregation for the coordinator module.
 // ABOUTME: Collects FileResult objects into a RunResult with aggregate counts, token usage, warnings, SDK init writing, and dependency installation.
 
+import { readFile as fsReadFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { FileResult } from '../fix-loop/types.ts';
 import type { LibraryRequirement } from '../agent/schema.ts';
 import type { TokenUsage } from '../agent/schema.ts';
@@ -95,6 +97,26 @@ export function collectLibraries(results: FileResult[]): LibraryRequirement[] {
  */
 export interface FinalizeDeps {
   installDeps?: InstallDeps;
+  /** Injectable package.json reader for library project detection. */
+  readPackageJson?: (path: string) => Promise<string>;
+}
+
+/**
+ * Detect whether a project is a library by checking if @opentelemetry/api
+ * is listed in peerDependencies in package.json.
+ * Returns false if package.json is missing or unreadable.
+ */
+async function isLibraryProject(
+  projectDir: string,
+  readFileFn: (path: string) => Promise<string>,
+): Promise<boolean> {
+  try {
+    const content = await readFileFn(join(projectDir, 'package.json'));
+    const pkg = JSON.parse(content);
+    return typeof pkg.peerDependencies?.['@opentelemetry/api'] === 'string';
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -120,6 +142,17 @@ export async function finalizeResults(
   const libraries = collectLibraries(runResult.fileResults);
 
   if (libraries.length === 0) {
+    return;
+  }
+
+  const readPkg = deps?.readPackageJson ?? ((p: string) => fsReadFile(p, 'utf-8'));
+  const isLibrary = await isLibraryProject(projectDir, readPkg);
+
+  if (isLibrary) {
+    // Library projects: skip SDK init and dependency install.
+    // Auto-instrumentation packages are SDK-level concerns — deployers add them
+    // to their application telemetry setup, not the library's dependency tree.
+    runResult.companionPackages = libraries.map(l => l.package);
     return;
   }
 

--- a/src/coordinator/types.ts
+++ b/src/coordinator/types.ts
@@ -56,6 +56,13 @@ export interface RunResult {
   /** Run-level advisory findings from cross-file checks (e.g., CDQ-008 tracer naming). */
   runLevelAdvisory: import('../validation/types.ts').CheckResult[];
   warnings: string[];
+  /**
+   * Auto-instrumentation packages identified for a library project.
+   * These are not installed as dependencies — deployers should add them to
+   * their application's telemetry setup instead.
+   * Only populated when the project is detected as a library (peerDependencies heuristic).
+   */
+  companionPackages?: string[];
 }
 
 /**

--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -34,6 +34,7 @@ export function renderPrSummary(runResult: RunResult, config: AgentConfig, proje
   sections.push(renderAgentNotes(runResult, display));
   sections.push(renderRecommendedRefactors(runResult, display));
   sections.push(renderRolledBackFiles(runResult, display));
+  sections.push(renderCompanionPackages(runResult));
   sections.push(renderTokenUsage(runResult, config));
   sections.push(renderLiveCheckCompliance(runResult));
   sections.push(renderAgentVersion(runResult));
@@ -383,6 +384,24 @@ function renderRolledBackFiles(runResult: RunResult, display: DisplayFn): string
 
   for (const file of rolledBack) {
     lines.push(`| ${display(file.path)} | ${sanitizeCell(file.reason ?? '')} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function renderCompanionPackages(runResult: RunResult): string {
+  if (!runResult.companionPackages || runResult.companionPackages.length === 0) return '';
+
+  const lines: string[] = ['## Recommended Companion Packages'];
+  lines.push('');
+  lines.push(
+    'This project was detected as a library. The following auto-instrumentation packages ' +
+    'were identified but not added as dependencies — they are SDK-level concerns that ' +
+    'deployers should add to their application\'s telemetry setup.',
+  );
+  lines.push('');
+  for (const pkg of runResult.companionPackages) {
+    lines.push(`- \`${pkg}\``);
   }
 
   return lines.join('\n');

--- a/test/coordinator/aggregate.test.ts
+++ b/test/coordinator/aggregate.test.ts
@@ -463,4 +463,139 @@ startTelemetry();
     expect(runResult.sdkInitUpdated).toBe(false);
     expect(runResult.warnings.some(w => w.includes('spiny-orb-instrumentations.js'))).toBe(true);
   });
+
+  describe('library project detection', () => {
+    it('skips SDK init for library projects (peerDependencies heuristic)', async () => {
+      const sdkFile = join(testDir, 'setup.js');
+      await writeFile(sdkFile, `
+import { NodeSDK } from '@opentelemetry/sdk-node';
+const sdk = new NodeSDK({ instrumentations: [] });
+sdk.start();
+`, 'utf-8');
+
+      const results: FileResult[] = [
+        makeSuccessResult('/a.js', {
+          librariesNeeded: [
+            { package: '@traceloop/instrumentation-langchain', importName: 'LangchainInstrumentation' },
+          ],
+        }),
+      ];
+      const runResult = aggregateResults(results, makeCostCeiling({ fileCount: 1 }));
+      const execCalls: string[] = [];
+
+      await finalizeResults(runResult, testDir, sdkFile, 'peerDependencies', {
+        readPackageJson: async () => JSON.stringify({
+          peerDependencies: { '@opentelemetry/api': '^1.0.0' },
+        }),
+        installDeps: {
+          exec: async (cmd: string) => { execCalls.push(cmd); },
+          readFile: async () => '{}',
+          writeFile: async () => {},
+        },
+      });
+
+      // SDK init should be skipped for library projects
+      expect(runResult.sdkInitUpdated).toBe(false);
+      // Dep install should be skipped
+      expect(execCalls).toHaveLength(0);
+      expect(runResult.librariesInstalled).toEqual([]);
+    });
+
+    it('populates companionPackages for library projects', async () => {
+      const sdkFile = join(testDir, 'setup.js');
+      await writeFile(sdkFile, 'sdk.start();', 'utf-8');
+
+      const results: FileResult[] = [
+        makeSuccessResult('/a.js', {
+          librariesNeeded: [
+            { package: '@traceloop/instrumentation-langchain', importName: 'LangchainInstrumentation' },
+            { package: '@traceloop/instrumentation-mcp', importName: 'McpInstrumentation' },
+          ],
+        }),
+      ];
+      const runResult = aggregateResults(results, makeCostCeiling({ fileCount: 1 }));
+
+      await finalizeResults(runResult, testDir, sdkFile, 'peerDependencies', {
+        readPackageJson: async () => JSON.stringify({
+          peerDependencies: { '@opentelemetry/api': '^1.9.0' },
+        }),
+        installDeps: {
+          exec: async () => {},
+          readFile: async () => '{}',
+          writeFile: async () => {},
+        },
+      });
+
+      expect(runResult.companionPackages).toEqual([
+        '@traceloop/instrumentation-langchain',
+        '@traceloop/instrumentation-mcp',
+      ]);
+    });
+
+    it('proceeds normally when @opentelemetry/api is not in peerDependencies', async () => {
+      const sdkFile = join(testDir, 'setup.js');
+      await writeFile(sdkFile, `
+import { NodeSDK } from '@opentelemetry/sdk-node';
+const sdk = new NodeSDK({ instrumentations: [] });
+sdk.start();
+`, 'utf-8');
+
+      const results: FileResult[] = [
+        makeSuccessResult('/a.js', {
+          librariesNeeded: [
+            { package: '@opentelemetry/instrumentation-http', importName: 'HttpInstrumentation' },
+          ],
+        }),
+      ];
+      const runResult = aggregateResults(results, makeCostCeiling({ fileCount: 1 }));
+      const execCalls: string[] = [];
+
+      await finalizeResults(runResult, testDir, sdkFile, 'dependencies', {
+        readPackageJson: async () => JSON.stringify({
+          dependencies: { express: '^4.0.0' },
+        }),
+        installDeps: {
+          exec: async (cmd: string) => { execCalls.push(cmd); },
+          readFile: async () => '{}',
+          writeFile: async () => {},
+        },
+      });
+
+      // Application project: SDK init should be attempted, deps should install
+      expect(execCalls.length).toBeGreaterThan(0);
+      expect(runResult.companionPackages).toBeUndefined();
+    });
+
+    it('proceeds normally when package.json is missing (non-library assumption)', async () => {
+      const sdkFile = join(testDir, 'setup.js');
+      await writeFile(sdkFile, `
+import { NodeSDK } from '@opentelemetry/sdk-node';
+const sdk = new NodeSDK({ instrumentations: [] });
+sdk.start();
+`, 'utf-8');
+
+      const results: FileResult[] = [
+        makeSuccessResult('/a.js', {
+          librariesNeeded: [
+            { package: '@opentelemetry/instrumentation-http', importName: 'HttpInstrumentation' },
+          ],
+        }),
+      ];
+      const runResult = aggregateResults(results, makeCostCeiling({ fileCount: 1 }));
+      const execCalls: string[] = [];
+
+      await finalizeResults(runResult, testDir, sdkFile, 'dependencies', {
+        readPackageJson: async () => { throw new Error('ENOENT'); },
+        installDeps: {
+          exec: async (cmd: string) => { execCalls.push(cmd); },
+          readFile: async () => '{}',
+          writeFile: async () => {},
+        },
+      });
+
+      // Missing package.json → assume application project
+      expect(execCalls.length).toBeGreaterThan(0);
+      expect(runResult.companionPackages).toBeUndefined();
+    });
+  });
 });

--- a/test/deliverables/pr-summary.test.ts
+++ b/test/deliverables/pr-summary.test.ts
@@ -1024,4 +1024,34 @@ describe('renderPrSummary', () => {
       expect(md).not.toContain('Live-Check');
     });
   });
+
+  describe('companion packages section', () => {
+    it('renders companion packages section when companionPackages is populated', () => {
+      const result = _makeRunResult({
+        companionPackages: [
+          '@traceloop/instrumentation-langchain',
+          '@traceloop/instrumentation-mcp',
+        ],
+      });
+      const md = renderPrSummary(result, _makeConfig());
+
+      expect(md).toContain('## Recommended Companion Packages');
+      expect(md).toContain('@traceloop/instrumentation-langchain');
+      expect(md).toContain('@traceloop/instrumentation-mcp');
+    });
+
+    it('omits companion packages section when companionPackages is absent', () => {
+      const result = _makeRunResult();
+      const md = renderPrSummary(result, _makeConfig());
+
+      expect(md).not.toContain('Recommended Companion Packages');
+    });
+
+    it('omits companion packages section when companionPackages is empty', () => {
+      const result = _makeRunResult({ companionPackages: [] });
+      const md = renderPrSummary(result, _makeConfig());
+
+      expect(md).not.toContain('Recommended Companion Packages');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Detects library projects using a peerDependencies heuristic: if `@opentelemetry/api` is in `peerDependencies`, the project is a library
- Skips SDK init file detection and generation for library projects (addresses DEEP-5)
- Skips auto-instrumentation dependency installation for library projects (addresses EVAL-2)
- Populates `RunResult.companionPackages` with the skipped packages
- Renders a "Recommended Companion Packages" section in the PR summary so deployers know which packages to add to their application telemetry setup

## Test plan

- [ ] `finalizeResults` skips SDK init for library projects
- [ ] `finalizeResults` skips dependency install for library projects
- [ ] `finalizeResults` populates `companionPackages` with instrumentation package names
- [ ] `finalizeResults` proceeds normally when `@opentelemetry/api` is not in `peerDependencies`
- [ ] `finalizeResults` proceeds normally when `package.json` is missing
- [ ] PR summary renders "Recommended Companion Packages" section when `companionPackages` is populated
- [ ] PR summary omits section when `companionPackages` is absent or empty
- [ ] Full unit test suite passes (1665 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic library project detection with intelligent handling to skip SDK initialization for library projects and recommend compatible companion packages instead
  * PR summaries now include a "Recommended Companion Packages" section for library projects to guide users on complementary instrumentation options

* **Tests**
  * Added comprehensive test coverage for library detection logic and companion packages functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->