### PR TITLE
fix: add @opentelemetry/api to coordinator test fixture dependencies

### DIFF
--- a/test/coordinator/acceptance-gate.test.ts
+++ b/test/coordinator/acceptance-gate.test.ts
@@ -118,6 +118,7 @@ function setupTempProject(): string {
     dependencies: {
       express: '^4.18.0',
       pg: '^8.11.0',
+      '@opentelemetry/api': '^1.9.0',
     },
   }, null, 2), 'utf-8');
 


### PR DESCRIPTION
## Summary
- Adds `@opentelemetry/api` to the coordinator acceptance gate fixture's `dependencies` to make the test project realistic — an application project being instrumented would have OTel API as a regular dependency
- Completes the fix started in f82cf8f (which removed `peerDependencies` but didn't add to `dependencies`)

Closes #205

## Test plan
- [x] All 1726 unit/integration tests pass
- [ ] Coordinator acceptance gate test passes with realistic fixture package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing dependencies to ensure code quality and reliability standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->