### PR TITLE
fix: exclude acceptance gate tests from default vitest run

### DIFF
--- a/.claude/verify.json
+++ b/.claude/verify.json
@@ -1,6 +1,6 @@
 {
   "commands": {
-    "acceptance_test": "vals exec -f .vals.yaml -- bash -c 'shopt -s globstar && for p in /opt/homebrew/bin /usr/local/bin; do [ -x \"$p/node\" ] && export PATH=\"$p:$PATH\" && break; done && npx vitest run test/**/acceptance-gate.test.ts'",
+    "acceptance_test": "vals exec -f .vals.yaml -- bash -c 'for p in /opt/homebrew/bin /usr/local/bin; do [ -x \"$p/node\" ] && export PATH=\"$p:$PATH\" && break; done && npx vitest run --config vitest.acceptance.config.ts'",
     "acceptance_test_ci": "acceptance-gate.yml"
   }
 }

--- a/vitest.acceptance.config.ts
+++ b/vitest.acceptance.config.ts
@@ -1,0 +1,10 @@
+// ABOUTME: Vitest configuration for acceptance gate tests only.
+// ABOUTME: Used by verify.json acceptance_test command — runs only acceptance-gate.test.ts files.
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/acceptance-gate.test.ts'],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Vitest configuration — excludes acceptance gate tests from default runs.
+// ABOUTME: Acceptance gates run explicitly via verify.json commands, not via `npm test`.
+
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [
+      ...configDefaults.exclude,
+      '**/acceptance-gate.test.ts',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `vitest.config.ts` that excludes `**/acceptance-gate.test.ts` from default test runs, preventing accidental execution when `ANTHROPIC_API_KEY` is set via `vals exec`
- Adds `vitest.acceptance.config.ts` for dedicated acceptance gate runs
- Updates `verify.json` to use the acceptance config instead of glob file paths

The CLI `--exclude` flag does not reliably suppress acceptance gate tests when the API key is present — the `describe.skipIf` guard evaluates at import time, so if vitest collects the file, the test runs.

Closes #206

## Test plan
- [x] Default `vitest run` excludes acceptance gate files (101 files, 1726 tests)
- [x] `vitest run --config vitest.acceptance.config.ts` finds all 4 acceptance gate files (skipped without API key)
- [ ] `vals exec` wrapped run no longer triggers acceptance gate tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)