### PR TITLE
fix: use acceptance vitest config in CI workflow

### DIFF
--- a/.github/workflows/acceptance-gate.yml
+++ b/.github/workflows/acceptance-gate.yml
@@ -61,7 +61,7 @@ jobs:
       - run: npm ci
 
       - name: Run ${{ matrix.test-group.name }} acceptance tests
-        run: npx vitest run --reporter=verbose ${{ matrix.test-group.pattern }}
+        run: npx vitest run --config vitest.acceptance.config.ts --reporter=verbose ${{ matrix.test-group.pattern }}
         timeout-minutes: 75
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds `--config vitest.acceptance.config.ts` to the vitest invocation in `.github/workflows/acceptance-gate.yml`
- The default `vitest.config.ts` (from PR #220) excludes `**/acceptance-gate.test.ts`, so every CI acceptance gate run was finding zero test files and failing

Closes #225

## Test plan
- [x] CI workflow YAML is valid
- [ ] Next acceptance gate CI run finds and executes test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated acceptance gate CI configuration to explicitly specify test configuration during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->