### PR TITLE
feat: add human-readable rule names to error summaries

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -12,6 +12,7 @@ import type { InstrumentationOutput, TokenUsage } from '../agent/schema.ts';
 import type { InstrumentFileResult, ConversationContext } from '../agent/instrument-file.ts';
 import type { ValidateFileInput, ValidationResult } from '../validation/types.ts';
 import { addTokenUsage, totalTokens, estimateMinTokens, estimateOutputBudget, MAX_OUTPUT_BUDGET } from './token-budget.ts';
+import { formatRuleId } from '../validation/rule-names.ts';
 import { detectOscillation } from './oscillation.ts';
 import { extractExportedFunctions } from './function-extraction.ts';
 import { reassembleFunctions, ensureTracerAfterImports } from './function-reassembly.ts';
@@ -115,7 +116,7 @@ function summarizeErrors(validation: ValidationResult): string {
   }
   const breakdown = [...ruleCounts.entries()]
     .sort((a, b) => b[1] - a[1])
-    .map(([rule, count]) => `${rule}:${count}`)
+    .map(([rule, count]) => `${formatRuleId(rule)}:${count}`)
     .join(', ');
   return `${blockingCount} blocking error${blockingCount === 1 ? '' : 's'} (${breakdown})`;
 }

--- a/src/validation/rule-names.ts
+++ b/src/validation/rule-names.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Human-readable display names for validation rule IDs.
+// ABOUTME: Used in error summaries, CLI output, PR summaries, and diagnostics.
+
+/**
+ * Map validation rule IDs to human-readable display names.
+ * Used wherever rule IDs appear in user-facing output.
+ */
+const RULE_NAMES: Record<string, string> = {
+  // Tier 1 — Structural
+  'ELISION': 'Elision Detected',
+  'NDS-001': 'Syntax Valid',
+  'LINT': 'Lint Clean',
+  'WEAVER': 'Schema Valid',
+
+  // Tier 2 — Coverage
+  'COV-001': 'Entry Point Spans',
+  'COV-002': 'Outbound Call Spans',
+  'COV-003': 'Error Recording',
+  'COV-004': 'Async Operation Spans',
+  'COV-005': 'Domain Attributes',
+  'COV-006': 'Auto-Instrumentation Preference',
+
+  // Tier 2 — Quality
+  'CDQ-001': 'Spans Closed',
+  'CDQ-006': 'isRecording Guard',
+  'CDQ-008': 'Tracer Naming',
+
+  // Tier 2 — Restraint
+  'RST-001': 'No Utility Spans',
+  'RST-002': 'No Trivial Accessor Spans',
+  'RST-003': 'No Thin Wrapper Spans',
+  'RST-004': 'No Internal Detail Spans',
+  'RST-005': 'No Double Instrumentation',
+
+  // Tier 2 — Non-destructive
+  'NDS-003': 'Code Preserved',
+  'NDS-004': 'Signatures Preserved',
+  'NDS-005': 'Control Flow Preserved',
+  'NDS-005b': 'Control Flow Preserved',
+  'NDS-006': 'Module System Match',
+
+  // Tier 2 — API
+  'API-001': 'OTel API Only',
+  'API-002': 'Dependency Placement',
+
+  // Tier 2 — Schema
+  'SCH-001': 'Span Names Match Registry',
+  'SCH-002': 'Attribute Keys Match Registry',
+  'SCH-003': 'Attribute Values Conform',
+  'SCH-004': 'No Redundant Schema Entries',
+};
+
+/**
+ * Get the human-readable name for a rule ID.
+ * Returns the rule ID unchanged if no name is registered.
+ *
+ * @param ruleId - Validation rule identifier (e.g. "SCH-002")
+ * @returns Human-readable name (e.g. "Attribute Keys Match Registry") or the original ruleId
+ */
+export function getRuleName(ruleId: string): string {
+  return RULE_NAMES[ruleId] ?? ruleId;
+}
+
+/**
+ * Format a rule ID with its human-readable name for display.
+ * Produces "SCH-002 (Attribute Keys Match Registry)" format.
+ *
+ * @param ruleId - Validation rule identifier
+ * @returns Formatted string with both code and name
+ */
+export function formatRuleId(ruleId: string): string {
+  const name = RULE_NAMES[ruleId];
+  return name ? `${ruleId} (${name})` : ruleId;
+}

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -293,7 +293,7 @@ describe('instrumentWithRetry — single-attempt pass-through', () => {
     expect(result.reason).toContain('NDS-001');
     expect(result.lastError).toBeDefined();
     expect(result.lastError!.length).toBeGreaterThan(0);
-    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001:1)']);
+    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001 (Syntax Valid):1)']);
     expect(result.tokenUsage).toEqual(sampleTokens);
 
     // File should be reverted to original content
@@ -698,7 +698,7 @@ describe('instrumentWithRetry — multi-turn fix (Milestone 4)', () => {
       testFilePath, originalContent, {}, makeConfig({ maxFixAttempts: 1 }), { deps },
     );
 
-    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001:1)', '0 errors']);
+    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001 (Syntax Valid):1)', '0 errors']);
   });
 
   it('tracks cumulative token usage across attempts', async () => {
@@ -877,7 +877,7 @@ describe('instrumentWithRetry — multi-turn fix (Milestone 4)', () => {
     expect(result.status).toBe('failed');
     expect(result.validationAttempts).toBe(2);
     expect(result.validationStrategyUsed).toBe('multi-turn-fix');
-    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001:1)', '1 blocking error (NDS-001:1)']);
+    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001 (Syntax Valid):1)', '1 blocking error (NDS-001 (Syntax Valid):1)']);
     expect(result.reason).toBeDefined();
     expect(result.lastError).toBeDefined();
     // File reverted to original
@@ -1220,7 +1220,7 @@ describe('instrumentWithRetry — fresh regeneration (Milestone 5)', () => {
     expect(result.reason).toBeDefined();
     expect(result.reason!.length).toBeGreaterThan(0);
     expect(result.lastError).toBeDefined();
-    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001:1)', '1 blocking error (NDS-001:1)', '1 blocking error (NDS-001:1)']);
+    expect(result.errorProgression).toEqual(['1 blocking error (NDS-001 (Syntax Valid):1)', '1 blocking error (NDS-001 (Syntax Valid):1)', '1 blocking error (NDS-001 (Syntax Valid):1)']);
     // File reverted to original
     expect(readFileSync(testFilePath, 'utf-8')).toBe(originalContent);
   });
@@ -1420,7 +1420,7 @@ describe('instrumentWithRetry — fresh regeneration (Milestone 5)', () => {
     );
 
     expect(result.status).toBe('success');
-    expect(result.errorProgression).toEqual(['2 blocking errors (NDS-001:1, LINT:1)', '1 blocking error (NDS-001:1)', '0 errors']);
+    expect(result.errorProgression).toEqual(['2 blocking errors (NDS-001 (Syntax Valid):1, LINT (Lint Clean):1)', '1 blocking error (NDS-001 (Syntax Valid):1)', '0 errors']);
   });
 });
 
@@ -1665,7 +1665,7 @@ describe('instrumentWithRetry — oscillation detection (Milestone 6)', () => {
     // Normal flow — attempt 2 had fewer errors, so no oscillation. Attempt 3 succeeds.
     expect(result.status).toBe('success');
     expect(result.validationAttempts).toBe(3);
-    expect(result.errorProgression).toEqual(['2 blocking errors (NDS-001:1, LINT:1)', '1 blocking error (NDS-001:1)', '0 errors']);
+    expect(result.errorProgression).toEqual(['2 blocking errors (NDS-001 (Syntax Valid):1, LINT (Lint Clean):1)', '1 blocking error (NDS-001 (Syntax Valid):1)', '0 errors']);
   });
 
   it('budget exceeded stops further retries but current attempt still validates', async () => {

--- a/test/validation/rule-names.test.ts
+++ b/test/validation/rule-names.test.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Tests for human-readable rule name lookup.
+// ABOUTME: Verifies getRuleName and formatRuleId for known and unknown rule IDs.
+
+import { describe, it, expect } from 'vitest';
+import { getRuleName, formatRuleId } from '../../src/validation/rule-names.ts';
+
+describe('getRuleName', () => {
+  it('returns human-readable name for known rule IDs', () => {
+    expect(getRuleName('SCH-002')).toBe('Attribute Keys Match Registry');
+    expect(getRuleName('NDS-003')).toBe('Code Preserved');
+    expect(getRuleName('COV-003')).toBe('Error Recording');
+    expect(getRuleName('NDS-001')).toBe('Syntax Valid');
+  });
+
+  it('returns the rule ID unchanged for unknown rules', () => {
+    expect(getRuleName('UNKNOWN-999')).toBe('UNKNOWN-999');
+    expect(getRuleName('NDS-005b')).toBe('Control Flow Preserved');
+  });
+});
+
+describe('formatRuleId', () => {
+  it('formats known rules as "CODE (Name)"', () => {
+    expect(formatRuleId('SCH-002')).toBe('SCH-002 (Attribute Keys Match Registry)');
+    expect(formatRuleId('NDS-003')).toBe('NDS-003 (Code Preserved)');
+  });
+
+  it('returns unknown rules unchanged', () => {
+    expect(formatRuleId('UNKNOWN-999')).toBe('UNKNOWN-999');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/validation/rule-names.ts` — lookup table mapping all validation rule IDs to display names
- Wires `formatRuleId()` into `summarizeErrors()` so error progressions show both code and meaning
- Before: `6 blocking errors (SCH-002:4, NDS-003:2)`
- After: `6 blocking errors (SCH-002 (Attribute Keys Match Registry):4, NDS-003 (Code Preserved):2)`

Closes #216

## Test plan
- [x] 4 new tests for `getRuleName` and `formatRuleId` (known rules, unknown rules)
- [x] Updated 6 existing tests for new error format
- [x] All 1736 tests pass
- [x] Unknown rule IDs pass through unchanged (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation error summaries now display human-readable rule names alongside identifiers (e.g., "NDS-001 (Syntax Valid)") when reporting validation failures, providing clearer and more informative feedback.

* **Tests**
  * Added comprehensive test coverage for rule name mapping and formatting to ensure accurate rule identification and display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->