### PR TITLE
feat: add per-file attempt count and token usage to CLI output

### DIFF
--- a/src/interfaces/instrument-handler.ts
+++ b/src/interfaces/instrument-handler.ts
@@ -135,11 +135,16 @@ export async function handleInstrument(
     },
     onFileComplete: (result, _index, _total) => {
       let statusLabel: string;
+      const outputKTokens = (result.tokenUsage.outputTokens / 1000).toFixed(1);
+      const attempts = result.validationAttempts;
+      const attemptSuffix = attempts > 1 ? `, ${attempts} attempts` : '';
       if (result.status === 'success') {
-        statusLabel = `success (${result.spansAdded} spans)`;
+        statusLabel = `success (${result.spansAdded} spans${attemptSuffix}, ${outputKTokens}K output tokens)`;
       } else if (result.status === 'failed') {
         const detail = result.reason || result.lastError || '';
-        statusLabel = detail ? `failed (${detail})` : 'failed';
+        statusLabel = detail ? `failed (${detail}${attemptSuffix})` : `failed${attemptSuffix ? ` (${attemptSuffix.slice(2)})` : ''}`;
+      } else if (result.status === 'partial') {
+        statusLabel = `partial (${result.spansAdded} spans${attemptSuffix}, ${outputKTokens}K output tokens)`;
       } else {
         statusLabel = result.status;
       }
@@ -155,9 +160,19 @@ export async function handleInstrument(
       const failed = results.filter(r => r.status === 'failed').length;
       const partial = results.filter(r => r.status === 'partial').length;
       const skipped = results.filter(r => r.status === 'skipped').length;
+      const totalInput = results.reduce((sum, r) => sum + r.tokenUsage.inputTokens, 0);
+      const totalOutput = results.reduce((sum, r) => sum + r.tokenUsage.outputTokens, 0);
+      const totalCached = results.reduce((sum, r) => sum + r.tokenUsage.cacheReadInputTokens, 0);
       deps.stderr(
         `\nRun complete: ${succeeded} succeeded, ${failed} failed, ${partial} partial, ${skipped} skipped`,
       );
+      if (totalInput > 0 || totalOutput > 0) {
+        let tokenLine = `  Total tokens: ${(totalInput / 1000).toFixed(1)}K input, ${(totalOutput / 1000).toFixed(1)}K output`;
+        if (totalCached > 0) {
+          tokenLine += ` (${(totalCached / 1000).toFixed(1)}K cached)`;
+        }
+        deps.stderr(tokenLine);
+      }
     },
   };
 


### PR DESCRIPTION
## Summary
- `onFileComplete` now shows attempt count and output tokens: `success (2 spans, 3 attempts, 23.7K output tokens)`
- `onRunComplete` now shows aggregate token usage: `Total tokens: 31.2K input, 23.7K output (29.4K cached)`
- Single-attempt successes omit the attempt count for clean output
- Partial and failed statuses also show attempts

Users paying per-token deserve visibility into what they spent. The contrast between a 1-attempt/7K-token file and a 4-attempt/76K-token file is invisible without this.

Closes #213

## Test plan
- [x] All 1734 existing tests pass (existing assertions use `toContain('success')` which still matches)
- [x] Token formatting uses K suffix with 1 decimal place
- [ ] Manual verification of CLI output formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced reporting with token usage metrics, now displaying output tokens in thousands and validation attempt counts in status messages for improved visibility into processing details
  * Added comprehensive run-completion statistics aggregating total input tokens, output tokens, and cached tokens across all results with a summary line for aggregated token metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->