### PR TITLE
fix: schema-sparse registries — SCH-002 declared extensions + advisory downgrade

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -20,6 +20,7 @@ import type { FileResult, FunctionResult, SuggestedRefactor, ValidationStrategy 
 import { detectPersistentViolations, collectSuggestedRefactors } from './refactor-detection.ts';
 import { extractSpanNamesFromCode } from '../coordinator/schema-extensions.ts';
 import { checkSyntax } from '../validation/tier1/syntax.ts';
+import { parseResolvedRegistry, getSpanDefinitions } from '../validation/tier2/registry-types.ts';
 
 const require = createRequire(import.meta.url);
 const { version: AGENT_VERSION } = require('../../package.json') as { version: string };
@@ -137,6 +138,17 @@ function buildValidationConfig(
   resolvedSchema?: object,
   anthropicClient?: Anthropic,
 ) {
+  // Detect schema-sparse registries: when the registry has very few span
+  // definitions, SCH-001/SCH-002 should be advisory rather than blocking.
+  // The agent invents correct names/attributes, but the registry doesn't
+  // have them — rejecting causes oscillation and wasted retries.
+  const SPARSE_THRESHOLD = 3;
+  let schemaSparse = false;
+  if (resolvedSchema) {
+    const registry = parseResolvedRegistry(resolvedSchema);
+    schemaSparse = getSpanDefinitions(registry).length < SPARSE_THRESHOLD;
+  }
+
   return {
     enableWeaver: false,
     projectRoot,
@@ -158,9 +170,9 @@ function buildValidationConfig(
       'RST-003': { enabled: true, blocking: false },
       'RST-004': { enabled: true, blocking: false },
       'CDQ-006': { enabled: true, blocking: false },
-      // Phase 5 checks
-      'SCH-001': { enabled: true, blocking: true },
-      'SCH-002': { enabled: true, blocking: true },
+      // Phase 5 checks — SCH-001/SCH-002 downgrade to advisory for sparse registries
+      'SCH-001': { enabled: true, blocking: !schemaSparse },
+      'SCH-002': { enabled: true, blocking: !schemaSparse },
       'SCH-003': { enabled: true, blocking: true },
       'SCH-004': { enabled: true, blocking: false },
       // PRD #135 checks (advisory for initial rollout)

--- a/src/validation/chain.ts
+++ b/src/validation/chain.ts
@@ -279,7 +279,7 @@ export async function validateFile(input: ValidateFileInput): Promise<Validation
 
   if (config.tier2Checks['SCH-002']?.enabled && config.resolvedSchema) {
     tier2Results.push(...collectCheckResults(
-      checkAttributeKeysMatchRegistry(instrumentedCode, filePath, config.resolvedSchema),
+      checkAttributeKeysMatchRegistry(instrumentedCode, filePath, config.resolvedSchema, config.declaredSpanExtensions),
       config.tier2Checks['SCH-002'].blocking,
     ));
   }

--- a/src/validation/tier2/sch002.ts
+++ b/src/validation/tier2/sch002.ts
@@ -26,9 +26,20 @@ export function checkAttributeKeysMatchRegistry(
   code: string,
   filePath: string,
   resolvedSchema: object,
+  declaredExtensions?: string[],
 ): CheckResult[] {
   const registry = parseResolvedRegistry(resolvedSchema);
   const registryNames = getAllAttributeNames(registry);
+
+  // Accept agent-declared attribute extensions (non-span extensions).
+  // Span extensions start with "span." or "span:" — everything else is an attribute key.
+  if (declaredExtensions) {
+    for (const ext of declaredExtensions) {
+      if (!ext.startsWith('span.') && !ext.startsWith('span:')) {
+        registryNames.add(ext);
+      }
+    }
+  }
 
   if (registryNames.size === 0) {
     return [pass(filePath, 'No registry attributes to check against.')];

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -193,9 +193,10 @@ describe('instrumentWithRetry — single-attempt pass-through', () => {
     expect(checks['RST-004']).toEqual({ enabled: true, blocking: false });
     expect(checks['CDQ-006']).toEqual({ enabled: true, blocking: false });
 
-    // Phase 5 checks (4)
-    expect(checks['SCH-001']).toEqual({ enabled: true, blocking: true });
-    expect(checks['SCH-002']).toEqual({ enabled: true, blocking: true });
+    // Phase 5 checks (4) — SCH-001/SCH-002 downgrade to advisory for sparse registries
+    // (empty schema has 0 span definitions, below the sparse threshold of 3)
+    expect(checks['SCH-001']).toEqual({ enabled: true, blocking: false });
+    expect(checks['SCH-002']).toEqual({ enabled: true, blocking: false });
     expect(checks['SCH-003']).toEqual({ enabled: true, blocking: true });
     expect(checks['SCH-004']).toEqual({ enabled: true, blocking: false });
 

--- a/test/validation/tier2/sch002.test.ts
+++ b/test/validation/tier2/sch002.test.ts
@@ -178,6 +178,82 @@ describe('checkAttributeKeysMatchRegistry (SCH-002)', () => {
     });
   });
 
+  describe('declared attribute extensions', () => {
+    it('accepts attribute keys declared as schema extensions', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function doWork() {',
+        '  return tracer.startActiveSpan("doWork", (span) => {',
+        '    try {',
+        '      span.setAttribute("myapp.custom.metric", 42);',
+        '      return 1;',
+        '    } finally { span.end(); }',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const declaredExtensions = ['myapp.custom.metric'];
+
+      const results = checkAttributeKeysMatchRegistry(
+        code, filePath, resolvedSchema, declaredExtensions,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('still rejects attribute keys not in registry or declared extensions', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function doWork() {',
+        '  return tracer.startActiveSpan("doWork", (span) => {',
+        '    try {',
+        '      span.setAttribute("totally.unknown.attr", "val");',
+        '      return 1;',
+        '    } finally { span.end(); }',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const declaredExtensions = ['myapp.custom.metric'];
+
+      const results = checkAttributeKeysMatchRegistry(
+        code, filePath, resolvedSchema, declaredExtensions,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('totally.unknown.attr');
+    });
+
+    it('filters span. extensions from attribute matching (only attributes)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function doWork() {',
+        '  return tracer.startActiveSpan("doWork", (span) => {',
+        '    try {',
+        '      span.setAttribute("myapp.custom.metric", 42);',
+        '      return 1;',
+        '    } finally { span.end(); }',
+        '  });',
+        '}',
+      ].join('\n');
+
+      // Only span extensions — no attribute extensions
+      const declaredExtensions = ['span.myapp.custom.operation'];
+
+      const results = checkAttributeKeysMatchRegistry(
+        code, filePath, resolvedSchema, declaredExtensions,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+  });
+
   describe('CheckResult structure', () => {
     it('returns correct structure for passing check', () => {
       const code = [


### PR DESCRIPTION
## Summary

Two fixes for schema-sparse registries (eval run-7's #2 blocker, 12 SCH-001 + 10+ SCH-002 occurrences):

1. **SCH-002 declared extensions**: Same chicken-and-egg fix as PR #234 did for SCH-001. Pass agent-declared attribute extensions through the validation chain so SCH-002 accepts attributes the agent declared as new. Filters out `span.*` extensions (those are for SCH-001).

2. **Sparse-registry advisory downgrade**: When the resolved schema has fewer than 3 span definitions, SCH-001 and SCH-002 become advisory (warn, don't block). The agent invents correct names but the registry doesn't have them — blocking causes oscillation and wasted retries.

## Test plan

- [x] SCH-002 accepts declared attribute extensions
- [x] SCH-002 still rejects undeclared attributes
- [x] SCH-002 ignores span.* extensions (only accepts attribute extensions)
- [x] Sparse-registry detection: empty schema → SCH-001/SCH-002 advisory
- [x] Full suite: 1759 tests pass, 0 failures

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom attribute extensions can now be declared during configuration and will be recognized in validation without triggering errors
  * Validation checks automatically adapt to sparse schemas, downgrading from blocking to advisory mode when schemas contain minimal span definitions
  * Enhanced configuration support for flexible custom attribute extension declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->