### PR TITLE
fix: scrub rejected metadata from failed files in PR summary

### DIFF
--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -118,8 +118,13 @@ function renderPerFileStatus(runResult: RunResult, config: AgentConfig, display:
     } else {
       statusText = 'skipped';
     }
-    const libs = file.librariesNeeded.map(l => `\`${l.package}\``).join(', ') || '—';
-    const exts = file.schemaExtensions.length > 0
+    // For failed files, libraries and extensions are from rejected agent output —
+    // showing them misleads reviewers into thinking they're in the committed code.
+    const isCommitted = file.status === 'success' || file.status === 'partial';
+    const libs = isCommitted
+      ? (file.librariesNeeded.map(l => `\`${l.package}\``).join(', ') || '—')
+      : '—';
+    const exts = isCommitted && file.schemaExtensions.length > 0
       ? file.schemaExtensions.map(e => `\`${sanitizeCell(e)}\``).join(', ')
       : '—';
     let costStr = '—';
@@ -144,9 +149,11 @@ function sanitizeCell(value: string): string {
 }
 
 function renderSpanCategoryBreakdown(runResult: RunResult, display: DisplayFn): string {
+  // Only show span categories for committed files — failed files carry
+  // spanCategories from rejected agent output which doesn't reflect the branch.
   const filesWithCategories = runResult.fileResults.filter(
     (f): f is FileResult & { spanCategories: NonNullable<FileResult['spanCategories']> } =>
-      f.spanCategories != null,
+      f.spanCategories != null && (f.status === 'success' || f.status === 'partial'),
   );
 
   if (filesWithCategories.length === 0) return '';
@@ -282,7 +289,7 @@ function computeSensitivityWarnings(runResult: RunResult, config: AgentConfig, d
   const warnings: string[] = [];
   const filesWithCategories = runResult.fileResults.filter(
     (f): f is FileResult & { spanCategories: NonNullable<FileResult['spanCategories']> } =>
-      f.spanCategories != null,
+      f.spanCategories != null && (f.status === 'success' || f.status === 'partial'),
   );
 
   if (filesWithCategories.length === 0) return warnings;

--- a/test/deliverables/pr-summary.test.ts
+++ b/test/deliverables/pr-summary.test.ts
@@ -1054,4 +1054,47 @@ describe('renderPrSummary', () => {
       expect(md).not.toContain('Recommended Companion Packages');
     });
   });
+
+  describe('failed file metadata scrubbing', () => {
+    it('does not show schema extensions for failed files in per-file table', () => {
+      const failedFile = _makeFileResult({
+        path: '/project/src/broken.js',
+        status: 'failed',
+        spansAdded: 0,
+        schemaExtensions: ['span.myapp.rejected.operation', 'myapp.rejected.attribute'],
+        librariesNeeded: [{ package: '@traceloop/instrumentation-langchain', importName: 'LangChainInstrumentation' }],
+        reason: 'Validation failed',
+      });
+      const result = _makeRunResult({
+        fileResults: [failedFile],
+        filesSucceeded: 0,
+        filesFailed: 1,
+      });
+
+      const md = renderPrSummary(result, _makeConfig());
+
+      // Failed file's rejected extensions and libraries should not appear
+      expect(md).not.toContain('myapp.rejected.operation');
+      expect(md).not.toContain('myapp.rejected.attribute');
+      expect(md).not.toContain('instrumentation-langchain');
+    });
+
+    it('shows schema extensions for success files in per-file table', () => {
+      const successFile = _makeFileResult({
+        path: '/project/src/good.js',
+        status: 'success',
+        spansAdded: 3,
+        schemaExtensions: ['span.myapp.committed.operation'],
+        librariesNeeded: [{ package: '@opentelemetry/instrumentation-pg', importName: 'PgInstrumentation' }],
+      });
+      const result = _makeRunResult({
+        fileResults: [successFile],
+      });
+
+      const md = renderPrSummary(result, _makeConfig());
+
+      expect(md).toContain('myapp.committed.operation');
+      expect(md).toContain('instrumentation-pg');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Failed files carry `librariesNeeded`, `schemaExtensions`, and `spanCategories` from the agent's last rejected output. Showing these in the PR summary misleads reviewers into thinking they're in the committed code.

**Eval evidence (run-6)**: Summary claimed 14 schema extensions (branch had 1), listed libraries not in package.json, and showed span names from rejected attempts.

**Fix**: Filter per-file table, span category breakdown, and review sensitivity to only include data from committed files (success or partial status). Failed and skipped files show dashes for libraries and extensions.

## Test plan

- [x] Failed file's rejected extensions and libraries do not appear in summary
- [x] Success file's committed extensions and libraries still appear
- [x] Full suite: 1765 tests pass, 0 failures

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PR summaries now correctly suppress invalid file metadata for failed analyses, displaying libraries and schema extensions only for successful or partially successful files.
  * Span category reporting is filtered to exclude failed file results, improving accuracy of analysis reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->