### PR TITLE
fix: pass --head to gh pr create for URL-based push compatibility

### DIFF
--- a/src/deliverables/git-workflow.ts
+++ b/src/deliverables/git-workflow.ts
@@ -52,7 +52,7 @@ export interface GitWorkflowDeps {
   pushBranch: (dir: string, branchName: string) => Promise<void>;
   renderPrSummary: (runResult: RunResult, config: AgentConfig, projectDir?: string) => string;
   writePrSummary: (projectDir: string, content: string) => Promise<string>;
-  createPr: (projectDir: string, title: string, body: string, options?: { draft?: boolean }) => Promise<string>;
+  createPr: (projectDir: string, title: string, body: string, options?: { draft?: boolean; head?: string }) => Promise<string>;
   checkGhAvailable: () => Promise<boolean | { available: boolean; warning?: string }>;
   stderr: (msg: string) => void;
 }
@@ -193,7 +193,7 @@ export async function runGitWorkflow(
       const testsFailed = typeof runResult.endOfRunValidation === 'string' &&
         runResult.endOfRunValidation.toUpperCase().startsWith('FAIL');
       try {
-        prUrl = await deps.createPr(projectDir, title, prBody, { draft: testsFailed });
+        prUrl = await deps.createPr(projectDir, title, prBody, { draft: testsFailed, head: branchName });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         deps.stderr(`PR creation failed: ${msg}`);
@@ -263,11 +263,14 @@ export async function createPr(
   projectDir: string,
   title: string,
   body: string,
-  options?: { draft?: boolean },
+  options?: { draft?: boolean; head?: string },
 ): Promise<string> {
   const args = ['pr', 'create', '--title', title, '--body', body];
   if (options?.draft) {
     args.push('--draft');
+  }
+  if (options?.head) {
+    args.push('--head', options.head);
   }
   return new Promise((fulfill, reject) => {
     execFile(

--- a/test/deliverables/git-workflow.test.ts
+++ b/test/deliverables/git-workflow.test.ts
@@ -330,7 +330,7 @@ describe('runGitWorkflow', () => {
         '/project',
         expect.stringContaining('Add OpenTelemetry instrumentation'),
         expect.stringContaining('Mock summary'),
-        { draft: false },
+        expect.objectContaining({ draft: false, head: expect.any(String) }),
       );
     });
 
@@ -348,7 +348,7 @@ describe('runGitWorkflow', () => {
         '/project',
         expect.stringContaining('Add OpenTelemetry instrumentation'),
         expect.stringContaining('Mock summary'),
-        { draft: true },
+        expect.objectContaining({ draft: true, head: expect.any(String) }),
       );
     });
 


### PR DESCRIPTION
## Summary

The deliverables acceptance gate test has never passed in CI since it was added (commit 76bfa96, March 19). Every run fails with:

```
gh pr create failed: you must first push the current branch to a remote, or use the --head flag
```

**Root cause**: `pushBranch()` embeds GITHUB_TOKEN into the push URL in CI. `git push <URL> <branch> -u` doesn't set upstream tracking (requires a named remote). `gh pr create` then fails because it can't find the upstream.

**Fix**: Always pass `--head <branchName>` to `gh pr create`. Works regardless of upstream tracking state.

## Test plan

- [x] git-workflow unit tests pass with new `head` option
- [x] PR creation tests verify `head` is passed
- [x] Full suite: 1765 tests pass, 0 failures
- [ ] CI acceptance gate deliverables job should now pass (verify after merge)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request creation now supports specifying a custom target branch, enabling more granular control over your workflow and PR configuration alongside draft mode capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->