### PR TITLE
fix: group repeated advisories and truncate agent notes in PR summary

### DIFF
--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -252,13 +252,15 @@ function filterContradictingAdvisories(
 function renderReviewSensitivity(runResult: RunResult, config: AgentConfig, display: DisplayFn): string {
   const lines: string[] = [];
 
-  // Collect advisory annotations from all files, filtering contradictions
-  const allAdvisory: Array<{ file: string; annotation: CheckResult }> = [];
+  // Collect advisory annotations from all files, filtering contradictions.
+  // Track both canonical path (for deduplication) and display path (for rendering)
+  // to avoid undercounting when different directories share basenames.
+  const allAdvisory: Array<{ filePath: string; fileDisplay: string; annotation: CheckResult }> = [];
   for (const file of runResult.fileResults) {
     if (file.advisoryAnnotations) {
       const filtered = filterContradictingAdvisories(file.advisoryAnnotations, file.notes);
       for (const ann of filtered) {
-        allAdvisory.push({ file: display(file.path), annotation: ann });
+        allAdvisory.push({ filePath: file.path, fileDisplay: display(file.path), annotation: ann });
       }
     }
   }
@@ -266,7 +268,7 @@ function renderReviewSensitivity(runResult: RunResult, config: AgentConfig, disp
   // Run-level advisory findings
   if (runResult.runLevelAdvisory.length > 0) {
     for (const ann of runResult.runLevelAdvisory) {
-      allAdvisory.push({ file: '(run-level)', annotation: ann });
+      allAdvisory.push({ filePath: '(run-level)', fileDisplay: '(run-level)', annotation: ann });
     }
   }
 
@@ -293,25 +295,32 @@ function renderReviewSensitivity(runResult: RunResult, config: AgentConfig, disp
     lines.push('### Advisory Findings');
     lines.push('');
 
-    // Group by ruleId + message to collapse repeated findings (dedupe files with Set)
-    const groups = new Map<string, { ruleId: string; message: string; files: Set<string> }>();
-    for (const { file, annotation } of allAdvisory) {
+    // Group by ruleId + message to collapse repeated findings.
+    // Use canonical filePath for deduplication, display path for rendering.
+    const groups = new Map<string, { ruleId: string; message: string; filePathSet: Set<string>; fileDisplayMap: Map<string, string> }>();
+    for (const { filePath, fileDisplay, annotation } of allAdvisory) {
       const key = `${annotation.ruleId}|${annotation.message}`;
       const existing = groups.get(key);
       if (existing) {
-        existing.files.add(file);
+        existing.filePathSet.add(filePath);
+        existing.fileDisplayMap.set(filePath, fileDisplay);
       } else {
-        groups.set(key, { ruleId: annotation.ruleId, message: annotation.message, files: new Set([file]) });
+        groups.set(key, {
+          ruleId: annotation.ruleId,
+          message: annotation.message,
+          filePathSet: new Set([filePath]),
+          fileDisplayMap: new Map([[filePath, fileDisplay]]),
+        });
       }
     }
 
-    for (const { ruleId, message, files: fileSet } of groups.values()) {
-      const files = [...fileSet];
-      if (files.length === 1) {
-        lines.push(`- **${formatRuleId(ruleId)}** (${files[0]}): ${message}`);
+    for (const { ruleId, message, filePathSet, fileDisplayMap } of groups.values()) {
+      const displayNames = [...filePathSet].map(p => fileDisplayMap.get(p) ?? p);
+      if (displayNames.length === 1) {
+        lines.push(`- **${formatRuleId(ruleId)}** (${displayNames[0]}): ${message}`);
       } else {
-        lines.push(`- **${formatRuleId(ruleId)}** (${files.length} files): ${message}`);
-        lines.push(`  Files: ${files.join(', ')}`);
+        lines.push(`- **${formatRuleId(ruleId)}** (${displayNames.length} files): ${message}`);
+        lines.push(`  Files: ${displayNames.join(', ')}`);
       }
     }
   }

--- a/test/deliverables/pr-summary.test.ts
+++ b/test/deliverables/pr-summary.test.ts
@@ -579,11 +579,15 @@ describe('renderPrSummary', () => {
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      // Should group identical advisories, not list 3 separate bullet points
+      // Should group identical advisories into exactly 1 entry, not 3 separate lines
       const advisorySection = md.split('### Advisory Findings')[1]?.split('##')[0] ?? '';
-      const cdq006Lines = advisorySection.split('\n').filter(l => l.includes('CDQ-006'));
-      expect(cdq006Lines.length).toBeLessThanOrEqual(2); // grouped, not 3 separate lines
-      expect(advisorySection).toMatch(/3 files/); // mentions file count
+      const cdq006Bullets = advisorySection.split('\n').filter(l => l.startsWith('- ') && l.includes('CDQ-006'));
+      expect(cdq006Bullets).toHaveLength(1); // exactly 1 grouped entry
+      expect(advisorySection).toContain('3 files'); // mentions file count
+      // All three files appear in the grouped output
+      expect(advisorySection).toContain('a.js');
+      expect(advisorySection).toContain('b.js');
+      expect(advisorySection).toContain('c.js');
     });
 
   describe('agent notes section', () => {
@@ -619,11 +623,15 @@ describe('renderPrSummary', () => {
       const md = renderPrSummary(result, _makeConfig());
 
       const notesSection = md.split('## Agent Notes')[1]?.split('##')[0] ?? '';
-      // Should show at most 3 notes per file, not all 10
+      // Should show exactly 3 notes, not all 10
       const noteLines = notesSection.split('\n').filter(l => l.startsWith('- Note'));
-      expect(noteLines.length).toBeLessThanOrEqual(3);
-      // Should indicate more notes exist
-      expect(notesSection).toMatch(/\d+ more/);
+      expect(noteLines).toHaveLength(3);
+      // First 3 notes present, 4th absent
+      expect(notesSection).toContain('Note 1');
+      expect(notesSection).toContain('Note 3');
+      expect(notesSection).not.toContain('Note 4 about');
+      // Should indicate 7 more notes exist
+      expect(notesSection).toContain('7 more');
     });
 
     it('skips notes section when no files have notes', () => {


### PR DESCRIPTION
## Summary

- Group identical advisory findings by rule ID + message with a file count and file list, instead of listing each occurrence separately (28 identical CDQ-006 lines → 1 grouped entry)
- Truncate agent notes to 3 per file in the PR summary with a pointer to the reasoning report for the full list
- Deduplicate file names in grouped output using Set (CodeRabbit CLI finding)

Partially addresses #253 (RUN7-9 agent notes compression + RUN7-10 advisory grouping). RUN7-7 (span count accuracy) and RUN7-8 (schema changes section) are not yet addressed.

## Test plan

- [ ] Verify 3 files with identical CDQ-006 advisories are grouped into 1 entry with "3 files" count
- [ ] Verify single-file advisories still render normally (no grouping)
- [ ] Verify files with >3 notes show first 3 plus "N more notes in reasoning report"
- [ ] Verify files with ≤3 notes render all notes without truncation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advisory findings with the same rule are grouped into a single entry showing a consolidated file count and a deduplicated file list.
  * Agent notes are limited to three per file, with a single summary line indicating how many additional notes were omitted.

* **Tests**
  * Added cases verifying advisory grouping and note truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->