### PR TITLE
fix: expand rule codes in agent notes and add verbose output separation

### DIFF
--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -8,7 +8,7 @@ import type { CheckResult } from '../validation/types.ts';
 import { tokensToDollars, ceilingToDollars, formatDollars } from './cost-formatting.ts';
 import { writeFile } from 'node:fs/promises';
 import { relative, basename, join } from 'node:path';
-import { formatRuleId } from '../validation/rule-names.ts';
+import { formatRuleId, expandRuleCodesInText } from '../validation/rule-names.ts';
 
 /** A function that converts a file path to a display string. */
 type DisplayFn = (filePath: string) => string;
@@ -390,7 +390,7 @@ function renderAgentNotes(runResult: RunResult, display: DisplayFn): string {
     lines.push(`**${display(file.path)}**:`);
     const shown = file.notes!.slice(0, MAX_NOTES_PER_FILE);
     for (const note of shown) {
-      lines.push(`- ${note}`);
+      lines.push(`- ${expandRuleCodesInText(note)}`);
     }
     if (file.notes!.length > MAX_NOTES_PER_FILE) {
       lines.push(`- *... ${file.notes!.length - MAX_NOTES_PER_FILE} more notes in reasoning report*`);

--- a/src/interfaces/instrument-handler.ts
+++ b/src/interfaces/instrument-handler.ts
@@ -8,7 +8,7 @@ import type { CoordinatorCallbacks, RunResult } from '../coordinator/types.ts';
 import { CoordinatorAbortError } from '../coordinator/coordinate.ts';
 import type { GitWorkflowDeps, GitWorkflowResult } from '../deliverables/git-workflow.ts';
 import { ceilingToDollars, formatDollars } from '../deliverables/cost-formatting.ts';
-import { formatRuleId } from '../validation/rule-names.ts';
+import { formatRuleId, expandRuleCodesInText } from '../validation/rule-names.ts';
 import type { CoordinateDeps } from '../coordinator/coordinate.ts';
 
 /** Options parsed from CLI arguments for the instrument command. */
@@ -167,12 +167,13 @@ export async function handleInstrument(
         if (result.schemaExtensions.length > 0) {
           deps.stderr(`    Extensions: ${result.schemaExtensions.join(', ')}`);
         }
-        // Show all agent notes in verbose mode
+        // Show all agent notes in verbose mode with rule codes expanded
         if (result.notes && result.notes.length > 0) {
           for (const note of result.notes) {
-            deps.stderr(`    Note: ${note}`);
+            deps.stderr(`    Note: ${expandRuleCodesInText(note)}`);
           }
         }
+        deps.stderr('');
       }
     },
     onRunComplete: (results) => {

--- a/src/validation/rule-names.ts
+++ b/src/validation/rule-names.ts
@@ -72,3 +72,19 @@ export function formatRuleId(ruleId: string): string {
   const name = RULE_NAMES[ruleId];
   return name ? `${ruleId} (${name})` : ruleId;
 }
+
+/**
+ * Expand bare rule codes in free text to include human-readable labels.
+ * Transforms "skipped per RST-001" to "skipped per RST-001 (No Utility Spans)".
+ * Skips codes that are already expanded (followed by " (").
+ *
+ * @param text - Free text that may contain bare rule codes
+ * @returns Text with known rule codes expanded to include labels
+ */
+export function expandRuleCodesInText(text: string): string {
+  // Match rule codes (e.g., RST-001, NDS-005b) NOT already followed by " ("
+  return text.replace(/\b([A-Z]{2,4}-\d{3}[a-z]?)\b(?! \()/g, (match) => {
+    const name = RULE_NAMES[match];
+    return name ? `${match} (${name})` : match;
+  });
+}

--- a/test/deliverables/pr-summary.test.ts
+++ b/test/deliverables/pr-summary.test.ts
@@ -634,6 +634,19 @@ describe('renderPrSummary', () => {
       expect(notesSection).toContain('7 more');
     });
 
+    it('expands rule codes in notes to include labels', () => {
+      const result = _makeRunResult({
+        fileResults: [
+          _makeFileResult({ notes: ['skipped per RST-001, RST-003'] }),
+        ],
+      });
+      const md = renderPrSummary(result, _makeConfig());
+
+      const notesSection = md.split('## Agent Notes')[1]?.split('##')[0] ?? '';
+      expect(notesSection).toContain('RST-001 (No Utility Spans)');
+      expect(notesSection).toContain('RST-003 (No Thin Wrapper Spans)');
+    });
+
     it('skips notes section when no files have notes', () => {
       const result = _makeRunResult({
         fileResults: [

--- a/test/interfaces/instrument-handler.test.ts
+++ b/test/interfaces/instrument-handler.test.ts
@@ -563,6 +563,39 @@ describe('handleInstrument', () => {
       expect(stderrCalls.some((s: string) => s.includes('more notes'))).toBe(false);
     });
 
+    it('expands rule codes in agent notes to include labels', async () => {
+      const deps = makeDeps();
+      await handleInstrument(makeOptions({ verbose: true }), deps);
+      const callbacks = getCallbacks(deps);
+
+      (deps.stderr as ReturnType<typeof vi.fn>).mockClear();
+
+      const result = makeFileResult({
+        notes: ['skipped per RST-001, RST-003'],
+      });
+      callbacks.onFileComplete!(result, 0, 1);
+
+      const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0]);
+      const noteLine = stderrCalls.find((s: string) => s.includes('Note:'));
+      expect(noteLine).toContain('RST-001 (No Utility Spans)');
+      expect(noteLine).toContain('RST-003 (No Thin Wrapper Spans)');
+    });
+
+    it('prints blank line after file output for visual separation', async () => {
+      const deps = makeDeps();
+      await handleInstrument(makeOptions({ verbose: true }), deps);
+      const callbacks = getCallbacks(deps);
+
+      (deps.stderr as ReturnType<typeof vi.fn>).mockClear();
+
+      const result = makeFileResult({ notes: ['a note'] });
+      callbacks.onFileComplete!(result, 0, 2);
+
+      const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0]);
+      // Last call should be an empty string (blank line separator)
+      expect(stderrCalls[stderrCalls.length - 1]).toBe('');
+    });
+
     it('formats rule codes with human-readable labels in refactor output', async () => {
       const fileResult = makeFileResult({
         suggestedRefactors: [

--- a/test/validation/rule-names.test.ts
+++ b/test/validation/rule-names.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Verifies getRuleName and formatRuleId for known and unknown rule IDs.
 
 import { describe, it, expect } from 'vitest';
-import { getRuleName, formatRuleId } from '../../src/validation/rule-names.ts';
+import { getRuleName, formatRuleId, expandRuleCodesInText } from '../../src/validation/rule-names.ts';
 
 describe('getRuleName', () => {
   it('returns human-readable name for known rule IDs', () => {
@@ -26,5 +26,41 @@ describe('formatRuleId', () => {
 
   it('returns unknown rules unchanged', () => {
     expect(formatRuleId('UNKNOWN-999')).toBe('UNKNOWN-999');
+  });
+});
+
+describe('expandRuleCodesInText', () => {
+  it('expands a single known rule code in free text', () => {
+    const text = 'skipped per RST-001';
+    expect(expandRuleCodesInText(text)).toBe('skipped per RST-001 (No Utility Spans)');
+  });
+
+  it('expands multiple rule codes in one string', () => {
+    const text = 'synchronous helpers (RST-001, RST-003)';
+    expect(expandRuleCodesInText(text)).toBe(
+      'synchronous helpers (RST-001 (No Utility Spans), RST-003 (No Thin Wrapper Spans))',
+    );
+  });
+
+  it('leaves unknown rule codes unchanged', () => {
+    const text = 'violated UNKNOWN-999 and RST-001';
+    expect(expandRuleCodesInText(text)).toBe(
+      'violated UNKNOWN-999 and RST-001 (No Utility Spans)',
+    );
+  });
+
+  it('does not double-expand already-expanded codes', () => {
+    const text = 'RST-001 (No Utility Spans)';
+    expect(expandRuleCodesInText(text)).toBe('RST-001 (No Utility Spans)');
+  });
+
+  it('returns text unchanged when no rule codes present', () => {
+    const text = 'This note has no rule references';
+    expect(expandRuleCodesInText(text)).toBe(text);
+  });
+
+  it('handles NDS-005b variant', () => {
+    const text = 'check NDS-005b compliance';
+    expect(expandRuleCodesInText(text)).toBe('check NDS-005b (Control Flow Preserved) compliance');
   });
 });


### PR DESCRIPTION
## Summary
- Add `expandRuleCodesInText()` that post-processes free text to expand bare rule codes (e.g., `RST-001`) into labeled form (`RST-001 (No Utility Spans)`) using the existing `RULE_NAMES` registry
- Wire into both CLI verbose output and PR summary agent notes sections
- Add blank line between file blocks in verbose mode for visual separation

## Test plan
- [x] Unit tests for `expandRuleCodesInText`: single code, multiple codes, unknown codes, already-expanded codes, NDS-005b variant
- [x] Integration test: verbose output expands rule codes in notes
- [x] Integration test: blank line printed after each file block
- [x] PR summary test: notes section expands rule codes

Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation rule codes in agent notes are now expanded to display human-readable rule names (e.g., "RST-001 (No Utility Spans)") for improved clarity.
  * Added improved spacing in verbose output for better readability.

* **Tests**
  * Added comprehensive test coverage for rule-code expansion in notes and verbose logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->