### PR TITLE
fix: use remote URL swap for token-authenticated push

### DIFF
--- a/src/git/git-wrapper.ts
+++ b/src/git/git-wrapper.ts
@@ -123,10 +123,19 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
     if (remoteUrl) {
       const authUrl = resolveAuthenticatedUrl(remoteUrl, token);
       if (authUrl !== remoteUrl) {
-        // Temporarily swap the remote push URL to include the token, push using
+        // Check if a dedicated push URL already exists (vs inheriting from fetch URL).
+        // We need to know this to clean up correctly after push.
+        let hadPushUrl = false;
+        try {
+          const pushUrlConfig = await git.raw(['config', '--get', `remote.${remote}.pushurl`]);
+          hadPushUrl = pushUrlConfig.trim().length > 0;
+        } catch {
+          // config --get exits non-zero when key doesn't exist — no push URL configured
+        }
+
+        // Temporarily set the remote push URL to include the token, push using
         // the remote name (not a bare URL). This ensures --set-upstream works
         // correctly and avoids issues with how simple-git handles URL arguments.
-        // Uses --push flag to only modify the push URL, preserving separate fetch URLs.
         let pushError: Error | undefined;
         try {
           await git.remote(['set-url', '--push', remote, authUrl]);
@@ -135,12 +144,18 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
           const msg = err instanceof Error ? err.message : String(err);
           pushError = new Error(sanitizeTokenFromError(msg));
         } finally {
-          // Restore the original push URL to avoid persisting the token in git config
+          // Clean up: remove the token-bearing push URL from git config.
+          // If a push URL existed before, restore it; otherwise remove the
+          // pushurl entry entirely to avoid leaving config artifacts.
           try {
-            await git.remote(['set-url', '--push', remote, remoteUrl]);
+            if (hadPushUrl) {
+              const originalPushUrl = resolveAuthenticatedUrl(remoteUrl, undefined);
+              await git.remote(['set-url', '--push', remote, originalPushUrl]);
+            } else {
+              await git.raw(['config', '--unset-all', `remote.${remote}.pushurl`]);
+            }
           } catch (restoreErr) {
             const restoreMsg = restoreErr instanceof Error ? restoreErr.message : String(restoreErr);
-            // Token may be persisted in git config — surface this to the caller
             const warning = `Failed to restore remote push URL after push: ${restoreMsg}`;
             if (pushError) {
               pushError = new Error(`${pushError.message}\n${warning}`);

--- a/test/git/git-wrapper.test.ts
+++ b/test/git/git-wrapper.test.ts
@@ -307,10 +307,17 @@ describe('git-wrapper', () => {
         // credentials were actually sent (vs "Password authentication is not supported")
         expect((err as Error).message).toMatch(/Authentication failed|Invalid username/);
 
-        // Verify remote URL is restored (token not persisted in git config)
+        // Verify remote fetch URL is unchanged
         const restoredUrl = (await git.remote(['get-url', 'origin']))?.trim();
         expect(restoredUrl).toBe('https://github.com/owner/repo.git');
         expect(restoredUrl).not.toContain('ghp_test_token');
+
+        // Verify no pushurl config entry was left behind
+        let pushUrlConfig: string | undefined;
+        try {
+          pushUrlConfig = await git.raw(['config', '--get', 'remote.origin.pushurl']);
+        } catch { /* config --get exits non-zero when key doesn't exist */ }
+        expect(pushUrlConfig?.trim() ?? '').toBe('');
       } finally {
         process.env.GITHUB_TOKEN = originalToken;
       }


### PR DESCRIPTION
## Summary
- Replace `git.push(authUrl, branch)` (URL as first arg) with a remote URL swap approach: temporarily set the remote URL to include the token, push using the remote name, restore in a finally block
- Fixes 6-consecutive push auth failures in eval runs where the token was present but the push used the bare URL
- The URL swap naturally fixes upstream tracking (`--set-upstream` works with named remotes) and is verified to restore the original URL even on failure (no token leak)

## Root cause hypothesis
Pushing to a URL as the first argument to `git push` via simple-git may not embed credentials the same way as pushing to a named remote. The eval logs showed "Pushing to https://github.com/..." (bare URL) despite GITHUB_TOKEN being present and `validateCredentials()` passing.

## Test plan
- [x] All 29 git-wrapper tests pass
- [x] Token push test verifies auth credentials are sent (error says "Invalid username" not "Password auth not supported")
- [x] Token push test verifies remote URL is restored after failure (no token in git config)
- [ ] Acceptance gate: deliverables E2E PR creation should now succeed

Fixes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures remote push URL is temporarily updated for authenticated HTTPS pushes and always restored afterward to prevent persistent credential leakage; improves error reporting by surfacing push errors alongside any restoration warnings.

* **Tests**
  * Expanded tests to confirm remote URLs are restored and do not retain credential strings after failed authenticated pushes, and that no leftover push-url config remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->