### PR TITLE
fix: add reassembly validation diagnostics and fix pushurl restoration

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -881,8 +881,18 @@ async function functionLevelFallback(
     };
   }
 
-  // Reassembly validation failed — fall back to partial results:
-  // keep only the functions that passed individual validation
+  // Reassembly validation failed — log which rules failed for diagnostics.
+  // Without this, "Reassembly validation failed" is opaque and undebuggable.
+  const failedRules = validation.blockingFailures
+    .filter(r => !r.passed)
+    .map(r => `${r.ruleId}: ${r.message.split('\n')[0]}`);
+
+  // Record failing rules in error progression for structured diagnostics
+  if (failedRules.length > 0) {
+    errorProgression.push(`reassembly: ${failedRules.join('; ')}`);
+  }
+
+  // Fall back to partial results: keep only the functions that passed individual validation
   await writeFile(filePath, originalCode, 'utf-8');
 
   const partialResults = fnResults.map(r =>
@@ -916,7 +926,11 @@ async function functionLevelFallback(
     validationAttempts: wholeFileResult.validationAttempts,
     validationStrategyUsed: wholeFileResult.validationStrategyUsed,
     errorProgression,
-    notes: [...notes, ...extensionWarnings, 'Reassembly validation failed — using partial results'],
+    notes: [
+      ...notes,
+      ...extensionWarnings,
+      `Reassembly validation failed — using partial results. Failing rules: ${failedRules.length > 0 ? failedRules.join('; ') : 'unknown'}`,
+    ],
     advisoryAnnotations: partialValidation.advisoryFindings.length > 0
       ? partialValidation.advisoryFindings
       : undefined,

--- a/src/git/git-wrapper.ts
+++ b/src/git/git-wrapper.ts
@@ -124,11 +124,13 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
       const authUrl = resolveAuthenticatedUrl(remoteUrl, token);
       if (authUrl !== remoteUrl) {
         // Check if a dedicated push URL already exists (vs inheriting from fetch URL).
-        // We need to know this to clean up correctly after push.
-        let hadPushUrl = false;
+        // Preserve the actual value so we can restore it exactly after push.
+        let originalPushUrl: string | undefined;
         try {
           const pushUrlConfig = await git.raw(['config', '--get', `remote.${remote}.pushurl`]);
-          hadPushUrl = pushUrlConfig.trim().length > 0;
+          if (pushUrlConfig.trim().length > 0) {
+            originalPushUrl = pushUrlConfig.trim();
+          }
         } catch {
           // config --get exits non-zero when key doesn't exist — no push URL configured
         }
@@ -148,8 +150,7 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
           // If a push URL existed before, restore it; otherwise remove the
           // pushurl entry entirely to avoid leaving config artifacts.
           try {
-            if (hadPushUrl) {
-              const originalPushUrl = resolveAuthenticatedUrl(remoteUrl, undefined);
+            if (originalPushUrl) {
               await git.remote(['set-url', '--push', remote, originalPushUrl]);
             } else {
               await git.raw(['config', '--unset-all', `remote.${remote}.pushurl`]);


### PR DESCRIPTION
## Summary
- **Reassembly diagnostics**: When reassembly validation fails, log which specific rules failed (rule ID + first line of message) in both notes and errorProgression. Previously only emitted "Reassembly validation failed" with no detail, making non-deterministic failures on complex files (journal-graph.js) undiagnosable.
- **pushurl restoration**: Preserve and restore the original push URL value instead of using the fetch URL, which would corrupt config on repos with separate push/fetch URLs.

## Test plan
- [x] All 141 existing tests pass (29 git-wrapper + 112 retry)
- [ ] Next eval run: if journal-graph.js goes partial, the verbose output will show which rule(s) failed

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation error reporting now includes specific details about failed rules, providing better diagnostic information for troubleshooting reassembly issues.
  * Git authentication operations now correctly preserve and restore URL configurations for authenticated remotes, improving operational reliability and system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->