### PR TITLE
fix: add token diagnostic logging for push auth debugging

### DIFF
--- a/src/deliverables/git-workflow.ts
+++ b/src/deliverables/git-workflow.ts
@@ -92,6 +92,8 @@ export async function runGitWorkflow(
   // Step 0: Validate git credentials before spending time/tokens on file processing.
   // Skip when output won't be pushed (dry-run or --no-pr).
   if (!dryRun && !noPr) {
+    // Diagnostic: log token presence at validation time to compare with push time
+    deps.stderr(`validateCredentials: GITHUB_TOKEN present=${!!process.env.GITHUB_TOKEN}`);
     await deps.validateCredentials(projectDir);
   }
 


### PR DESCRIPTION
## Summary
Add GITHUB_TOKEN presence logging at validation time (start of workflow) to complement the push-time logging from PR #292. This will show in run-10 whether the token disappears during the 40+ minute run.

Investigation ruled out:
- `.env` overwrite: commit-story-v2 has no `.env`; Node 24 `loadEnvFile` doesn't overwrite existing vars anyway
- Expired PAT in eval repo `.env`: confirmed 401, but `loadEnvFile` doesn't overwrite
- Code modifying `process.env`: nothing in spiny-orb touches GITHUB_TOKEN after reading it

Run-10 output will show:
```
validateCredentials: GITHUB_TOKEN present=true  (or false)
... 40 minutes of processing ...
pushBranch: GITHUB_TOKEN present=true  (or false)
```

## Test plan
- [x] Non-blocking diagnostic only — no behavior change

Relates to #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging during workflow execution to report the presence of GitHub authentication credentials. This improvement provides better visibility for troubleshooting credential validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->