### PR TITLE
fix: add code-path diagnostics to pushBranch (#295)

### DIFF
--- a/src/git/git-wrapper.ts
+++ b/src/git/git-wrapper.ts
@@ -127,7 +127,11 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
     const remoteUrl = (await git.remote(['get-url', remote]))?.trim();
     if (remoteUrl) {
       const authUrl = resolveAuthenticatedUrl(remoteUrl, token);
-      if (authUrl !== remoteUrl) {
+      const urlChanged = authUrl !== remoteUrl;
+      try {
+        process.stderr.write(`pushBranch: urlChanged=${urlChanged}, path=${urlChanged ? 'token-swap' : 'bare-push'}\n`);
+      } catch { /* diagnostic only — never block push */ }
+      if (urlChanged) {
         // Check if a dedicated push URL already exists (vs inheriting from fetch URL).
         // Preserve the actual value so we can restore it exactly after push.
         let originalPushUrl: string | undefined;
@@ -176,6 +180,9 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
     }
   }
 
+  try {
+    process.stderr.write(`pushBranch: path=bare-push, reason=${token ? 'url-unchanged' : 'no-token'}\n`);
+  } catch { /* diagnostic only — never block push */ }
   await git.push(remote, branchName, ['--set-upstream']);
 }
 

--- a/test/git/git-wrapper.test.ts
+++ b/test/git/git-wrapper.test.ts
@@ -244,6 +244,66 @@ describe('git-wrapper', () => {
       await rm(bareDir, { recursive: true, force: true });
     });
 
+    it('logs path=bare-push when no GITHUB_TOKEN is set', async () => {
+      const originalToken = process.env.GITHUB_TOKEN;
+      const stderrChunks: string[] = [];
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        stderrChunks.push(String(chunk));
+        return originalWrite(chunk);
+      }) as typeof process.stderr.write;
+
+      try {
+        delete process.env.GITHUB_TOKEN;
+
+        await createBranch(repoDir, 'spiny-orb/test-diag-bare');
+        await writeFile(join(repoDir, 'diag-test.js'), 'const x = 1;\n');
+        await stageFiles(repoDir, ['diag-test.js']);
+        await commit(repoDir, 'test diagnostic bare push');
+
+        await pushBranch(repoDir, 'spiny-orb/test-diag-bare');
+
+        const diagnosticOutput = stderrChunks.join('');
+        expect(diagnosticOutput).toContain('path=bare-push');
+      } finally {
+        process.env.GITHUB_TOKEN = originalToken;
+        process.stderr.write = originalWrite;
+      }
+    });
+
+    it('logs path=token-swap when GITHUB_TOKEN is set and URL is HTTPS', async () => {
+      const originalToken = process.env.GITHUB_TOKEN;
+      const stderrChunks: string[] = [];
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        stderrChunks.push(String(chunk));
+        return originalWrite(chunk);
+      }) as typeof process.stderr.write;
+
+      try {
+        process.env.GITHUB_TOKEN = 'ghp_test_token_for_diagnostic_test';
+
+        const git = simpleGit(repoDir);
+        await git.removeRemote('origin');
+        await git.addRemote('origin', 'https://github.com/owner/repo.git');
+
+        await createBranch(repoDir, 'spiny-orb/test-diag-token');
+        await writeFile(join(repoDir, 'diag-token-test.js'), 'const x = 1;\n');
+        await stageFiles(repoDir, ['diag-token-test.js']);
+        await commit(repoDir, 'test diagnostic token push');
+
+        // Push will fail (fake token), but we only care about diagnostic output
+        await pushBranch(repoDir, 'spiny-orb/test-diag-token').catch(() => {});
+
+        const diagnosticOutput = stderrChunks.join('');
+        expect(diagnosticOutput).toContain('path=token-swap');
+        expect(diagnosticOutput).toContain('urlChanged=true');
+      } finally {
+        process.env.GITHUB_TOKEN = originalToken;
+        process.stderr.write = originalWrite;
+      }
+    });
+
     it('pushes successfully to a local remote without token', async () => {
       await createBranch(repoDir, 'spiny-orb/test-push');
       await writeFile(join(repoDir, 'push-test.js'), 'const x = 1;\n');


### PR DESCRIPTION
## Summary

- Adds diagnostic logging to `pushBranch()` that records which code path executed: `token-swap` (URL was rewritten with embedded token) vs `bare-push` (fell through to unmodified push)
- Logs `urlChanged=true/false` after `resolveAuthenticatedUrl()` to show whether the URL swap actually triggered
- Logs the reason for bare-push fallback: `no-token` or `url-unchanged`
- This is the missing diagnostic needed to investigate why 7 consecutive eval runs failed at push despite the PR #272 URL swap fix

Closes #295

## Test plan

- [x] New test: verifies `path=bare-push` appears in stderr when no GITHUB_TOKEN set
- [x] New test: verifies `path=token-swap` and `urlChanged=true` appear when GITHUB_TOKEN set with HTTPS URL
- [x] All 31 git-wrapper tests pass
- [x] Full suite: 1820 passed, 3 skipped, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced diagnostic output for push operations to aid in troubleshooting.
  * Optimized token handling logic during push operations.

* **Tests**
  * Added diagnostic validation tests for push operations with various authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->