### PR TITLE
fix: detect boolean attributes in schema accumulator type correction

### DIFF
--- a/src/coordinator/schema-extensions.ts
+++ b/src/coordinator/schema-extensions.ts
@@ -175,6 +175,16 @@ export async function writeSchemaExtensions(
       attr.type = 'int';
     }
 
+    // Correct boolean attribute types: names containing is_, has_, should_, or
+    // ending with .force indicate boolean semantics. The schema accumulator
+    // defaults these to string, but they should be boolean.
+    if (!isSpan && attr.type === 'string') {
+      const lastSegment = id.split('.').pop() ?? '';
+      if (/^(is|has|should)_/.test(lastSegment) || lastSegment === 'force') {
+        attr.type = 'boolean';
+      }
+    }
+
     if (isSpan) {
       validSpans.push(attr);
     } else {

--- a/test/coordinator/schema-extensions.test.ts
+++ b/test/coordinator/schema-extensions.test.ts
@@ -427,6 +427,51 @@ describe('writeSchemaExtensions', () => {
     const attr = parsed.groups[0].attributes[0];
     expect(attr.type).toBe('string');
   });
+
+  it('corrects boolean attributes from type: string to type: boolean', async () => {
+    const extensions = [
+      '- id: myapp.commit.is_merge\n  type: string\n  stability: development\n  brief: Whether commit is a merge',
+      '- id: myapp.summarize.force\n  type: string\n  stability: development\n  brief: Force override flag',
+    ];
+
+    await writeSchemaExtensions(registryDir, extensions);
+
+    const content = await readFile(join(registryDir, 'agent-extensions.yaml'), 'utf-8');
+    const parsed = parse(content) as { groups: Array<{ attributes: Array<{ id: string; type: string }> }> };
+    const isMerge = parsed.groups[0].attributes.find((a) => a.id === 'myapp.commit.is_merge');
+    const force = parsed.groups[0].attributes.find((a) => a.id === 'myapp.summarize.force');
+    expect(isMerge?.type).toBe('boolean');
+    expect(force?.type).toBe('boolean');
+  });
+
+  it('corrects has_ and should_ prefixed attributes to type: boolean', async () => {
+    const extensions = [
+      '- id: myapp.request.has_auth\n  type: string\n  stability: development\n  brief: Whether request has auth',
+      '- id: myapp.request.should_retry\n  type: string\n  stability: development\n  brief: Whether to retry',
+    ];
+
+    await writeSchemaExtensions(registryDir, extensions);
+
+    const content = await readFile(join(registryDir, 'agent-extensions.yaml'), 'utf-8');
+    const parsed = parse(content) as { groups: Array<{ attributes: Array<{ id: string; type: string }> }> };
+    const hasAuth = parsed.groups[0].attributes.find((a) => a.id === 'myapp.request.has_auth');
+    const shouldRetry = parsed.groups[0].attributes.find((a) => a.id === 'myapp.request.should_retry');
+    expect(hasAuth?.type).toBe('boolean');
+    expect(shouldRetry?.type).toBe('boolean');
+  });
+
+  it('does not change boolean attributes that already have type: boolean', async () => {
+    const extensions = [
+      '- id: myapp.commit.is_merge\n  type: boolean\n  stability: development\n  brief: Whether commit is a merge',
+    ];
+
+    await writeSchemaExtensions(registryDir, extensions);
+
+    const content = await readFile(join(registryDir, 'agent-extensions.yaml'), 'utf-8');
+    const parsed = parse(content) as { groups: Array<{ attributes: Array<{ id: string; type: string }> }> };
+    const attr = parsed.groups[0].attributes[0];
+    expect(attr.type).toBe('boolean');
+  });
 });
 
 describe('snapshotExtensionsFile', () => {


### PR DESCRIPTION
## Summary

- Extend schema accumulator type correction to detect boolean attributes
- Attributes whose last segment starts with `is_`, `has_`, `should_` or equals `force` are corrected from `type: string` to `type: boolean`
- Same pattern as the existing `*_count` → `int` correction (PRs #267, #270, #286)

Fixes #329

## Test plan

- [ ] 3 new tests: boolean correction for is_/has_/should_/force patterns, already-boolean passthrough
- [ ] All 44 schema-extensions tests pass
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attribute types are now automatically corrected to boolean for attributes matching standard naming patterns (is_, has_, should_ prefixes, and force), ensuring proper schema classification without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->