### PR TITLE
fix: add optional chaining guard guidance to CDQ-007

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -55,7 +55,16 @@ export function buildSystemPrompt(resolvedSchema: object, projectName?: string):
 - The \`instrumentedCode\` field must contain the complete file — not a diff, not a partial file. Files containing placeholder comments (\`// ...\`, \`// existing code\`, \`// rest of function\`, \`/* ... */\`) will be rejected by validation.
 - Do not add comments explaining the instrumentation. The code speaks for itself.
 - Do not add, modify, or duplicate JSDoc comments. Preserve existing JSDoc exactly as-is. If a function has a JSDoc block, keep it unchanged — do not regenerate or rewrite it.
-- Do not add null/undefined checks around \`span.setAttribute()\` calls. Pass attribute values directly — the OpenTelemetry API handles null and undefined safely. Adding guards is a non-instrumentation change that will be rejected.
+- Do not add null/undefined checks around \`span.setAttribute()\` calls for values that are always defined. However, when accessing optional properties with \`?.\` (optional chaining), the result may be \`undefined\` — guard these with an \`if\` check before \`setAttribute\`:
+  \`\`\`javascript
+  // WRONG — entries?.length may be undefined
+  span.setAttribute('result.count', entries?.length);
+
+  // CORRECT — guard optional values
+  if (entries !== undefined) {
+    span.setAttribute('result.count', entries.length);
+  }
+  \`\`\`
 - **Return-value capture is allowed.** When you need to call \`setAttribute\` on a return value, you may extract the expression to a \`const\`:
   \`\`\`javascript
   // Original: return computeResult();
@@ -231,7 +240,7 @@ Your output is scored against these rules. Violating gate rules causes immediate
 - **CDQ-003**: Record errors with \`span.recordException(error)\` + \`span.setStatus({ code: SpanStatusCode.ERROR })\`. Do NOT use ad-hoc \`setAttribute('error', ...)\`. (Exception: expected-condition catches — see Error Handling section.)
 - **CDQ-005**: For manual spans (\`startSpan\`), use \`context.with()\` to maintain async context.
 - **CDQ-006**: Guard expensive attribute computation (\`JSON.stringify\`, \`.map\`, \`.reduce\`) with \`span.isRecording()\`.
-- **CDQ-007**: Do NOT set unbounded attributes (full object spreads, unsized arrays), PII fields (\`email\`, \`password\`, \`ssn\`), or undefined values.
+- **CDQ-007**: Do NOT set unbounded attributes (full object spreads, unsized arrays), PII fields (\`email\`, \`password\`, \`ssn\`), or undefined values. Watch for optional chaining (\`?.\`) in \`setAttribute\` value arguments — these can produce \`undefined\`. Guard with an \`if\` check.
 - **CDQ-008**: Use the same tracer naming convention across all files. Do NOT vary the pattern.
 
 ## Auto-Instrumentation Library Allowlist

--- a/test/helpers/rubric-checks.test.ts
+++ b/test/helpers/rubric-checks.test.ts
@@ -341,6 +341,21 @@ span.setAttribute('db.row_count', result.rows.length);`;
     const result = checkAttributeSafety('function foo() { return 1; }');
     expect(result.passed).toBe(true);
   });
+
+  it('fails with optional chaining in setAttribute value', () => {
+    const code = `span.setAttribute('result.count', entries?.length);`;
+    const result = checkAttributeSafety(code);
+    expect(result.passed).toBe(false);
+    expect(result.details).toContain('optional chaining');
+  });
+
+  it('passes with guarded optional chaining before setAttribute', () => {
+    const code = `if (entries !== undefined) {
+  span.setAttribute('result.count', entries.length);
+}`;
+    const result = checkAttributeSafety(code);
+    expect(result.passed).toBe(true);
+  });
 });
 
 describe('NDS-005b: checkNds005bNotViolated', () => {

--- a/test/helpers/rubric-checks.ts
+++ b/test/helpers/rubric-checks.ts
@@ -407,6 +407,12 @@ export function checkAttributeSafety(code: string): RubricCheckResult {
     }
   }
 
+  // Check for optional chaining in setAttribute value arguments
+  const optionalChainRegex = /\.setAttribute\s*\([^,]+,\s*[^)]*\?\./g;
+  if (optionalChainRegex.test(code)) {
+    issues.push('setAttribute uses optional chaining (?.) — value may be undefined');
+  }
+
   if (issues.length === 0) {
     return { passed: true };
   }


### PR DESCRIPTION
## Summary

- Reconcile contradictory prompt rules: blanket "no guards around setAttribute" now distinguishes always-defined values from optional chaining
- Add WRONG/CORRECT code example to prompt showing how to guard `?.` values
- Expand CDQ-007 rule description to explicitly mention optional chaining
- Add `?.` detection to `checkAttributeSafety` rubric check so acceptance gates catch it

Fixes #330

## Test plan

- [ ] 2 new rubric check tests: optional chaining detection fails, guarded version passes
- [ ] All 35 rubric check tests pass
- [ ] All 65 prompt tests pass
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection of optional chaining patterns in attribute-setting operations.

* **Tests**
  * Added test cases validating optional chaining detection and guarding scenarios.

* **Chores**
  * Updated safety constraint rules for conditional checks with optional chaining expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->