### PR TITLE
fix: NDS-003 recognizes defined-value guards as instrumentation

### DIFF
--- a/src/validation/tier2/nds003.ts
+++ b/src/validation/tier2/nds003.ts
@@ -31,8 +31,12 @@ const INSTRUMENTATION_PATTERNS: RegExp[] = [
   /^\s*\}\s*$/,                 // standalone closing brace
   /^\s*\);?\s*$/,               // standalone closing paren with optional semicolon
   /^\s*\}\);?\s*$/,             // standalone closing brace+paren (end of callback)
-  // Defined-value guards wrapping setAttribute calls (CDQ-007 compliance)
+  // Defined-value guards wrapping setAttribute calls (CDQ-007 compliance).
   // Matches: if (x !== undefined) {, if (x != null) {, if (typeof x !== 'undefined') {
+  // Trade-off: this also filters guards wrapping business logic, which is a known
+  // limitation. The agent only generates these guards around span.setAttribute() calls,
+  // so false negatives from guard-wrapped business logic don't arise in practice.
+  // The same trade-off exists for standalone `}` (line 31) — accepted since v1.
   /^\s*if\s*\(\s*(?:typeof\s+)?\w+(?:\.\w+)*\s*!==?\s*(?:undefined|null|['"]undefined['"])\s*\)\s*\{?\s*$/,
   // Re-throw of caught exception (after recording exception on span)
   /^\s*throw\s+(?:err|error|e|ex|exception)\s*;/,

--- a/test/validation/tier2/nds003.test.ts
+++ b/test/validation/tier2/nds003.test.ts
@@ -582,6 +582,35 @@ describe('checkNonInstrumentationDiff (NDS-003)', () => {
     });
   });
 
+  describe('known limitations', () => {
+    it('guard wrapping business logic is not detected (accepted trade-off)', () => {
+      // This documents a known limitation: if the agent wrapped existing business
+      // logic in a defined-value guard (not instrumentation), NDS-003 would not
+      // catch it because the if-line matches the guard pattern. In practice this
+      // doesn't happen — the agent only generates guards around span.setAttribute().
+      const original = [
+        'function processMessage(messages) {',
+        '  doWork(messages);',
+        '}',
+      ].join('\n');
+
+      const instrumented = [
+        'function processMessage(messages) {',
+        '  if (messages !== undefined) {',
+        '    doWork(messages);',
+        '  }',
+        '}',
+      ].join('\n');
+
+      const results = checkNonInstrumentationDiff(original, instrumented, filePath);
+      const failures = results.filter((r) => !r.passed);
+      // This PASSES (not detected) — the guard pattern matches the if-line,
+      // and the standalone } is also filtered. This is the same trade-off as
+      // standalone } filtering for try/catch/finally wrapping.
+      expect(failures).toHaveLength(0);
+    });
+  });
+
   describe('edge cases', () => {
     it('handles empty original', () => {
       const results = checkNonInstrumentationDiff('', 'const x = 1;\n', filePath);


### PR DESCRIPTION
## Summary

- NDS-003 now recognizes `if (x !== undefined) {` guard blocks as instrumentation patterns, preventing false positives when CDQ-007 requires these guards instead of optional chaining in `setAttribute`
- Covers `!== undefined`, `!= null`, `typeof !== 'undefined'`, and nested property access variants
- Adds 4 test cases for guard patterns; all 1866 existing tests pass with no regressions

## Test plan

- [x] 4 new tests written (TDD — confirmed failure before fix, pass after)
- [x] Full test suite passes (1866 tests, 0 failures)
- [ ] Re-evaluate NDS-003 rule on eval corpus to confirm guard blocks no longer flagged

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added four new test cases covering various guard-style conditional patterns and one known-limitation case to ensure no false positives.

* **Validation**
  * Improved pattern recognition to treat additional guard-style conditionals as instrumentation-related, reducing spurious reports of business-logic additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->