### PR TITLE
docs(prd-99): close PRD #99 - deferred to JS language provider

### DIFF
--- a/prds/done/99-configurable-auto-instrumentation.md
+++ b/prds/done/99-configurable-auto-instrumentation.md
@@ -1,7 +1,7 @@
 # PRD: Configurable Auto-Instrumentation Allowlist
 
 **Issue**: [#99](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/99)
-**Status**: Draft
+**Status**: Closed — 2026-04-06
 **Priority**: Medium
 **Created**: 2026-03-14
 


### PR DESCRIPTION
Closes #99 — archiving PRD to prds/done/. Deferred to the JS language provider during multi-language expansion. See issue comment for full rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation status for the Configurable Auto-Instrumentation feature, marking it as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->