### PR TITLE
Add short presentation deck and fix LLM terminology in slides

### DIFF
--- a/prds/372-typescript-provider.md
+++ b/prds/372-typescript-provider.md
@@ -130,7 +130,8 @@ Save the completed findings to this exact path. The file must exist and be commi
   4. Which attributes that spiny-orb's checkers care about (HTTP method, status code, URL, DB system, etc.) have stable constants vs. incubating?
   5. What does the official OTel JS documentation currently show as the idiomatic import pattern?
 - [ ] Record the recommended usage pattern (import path, constant naming, how to distinguish stable from incubating) in the file — this is what the prompt and checker milestones will consume
-- [ ] Record any gotchas (breaking changes, non-obvious migration steps, things training data gets wrong) in `~/.claude/rules/otel-semconv-gotchas.md` and reference it from `~/.claude/CLAUDE.md`
+- [ ] Record any gotchas (breaking changes, non-obvious migration steps, things training data gets wrong) as a dedicated section in `docs/research/typescript-semconv-constants.md` — this is the canonical location. Optionally also copy to `~/.claude/rules/otel-semconv-gotchas.md` for local convenience, but the repo file is the source of truth.
+- [ ] Add a metadata header at the top of `docs/research/typescript-semconv-constants.md` containing: retrieval date, exact `@opentelemetry/semantic-conventions` package version(s) documented, and links to the official sources used (OTel JS docs, GitHub release/commit, relevant spec URLs). This allows downstream milestones (C1, C3, C5) to verify whether the snapshot is still current.
 - [ ] Close issue #378 with a comment referencing this PRD and the output file path
 - [ ] Commit `docs/research/typescript-semconv-constants.md`
 

--- a/prds/372-typescript-provider.md
+++ b/prds/372-typescript-provider.md
@@ -5,7 +5,8 @@
 **GitHub Issue**: [#372](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/372)  
 **Blocked by**: PRD #371 (JavaScript extraction) must be merged first  
 **Blocks**: PRD #373 (Python provider)  
-**Created**: 2026-04-06
+**Created**: 2026-04-06  
+**Absorbs**: Issue #378 (semconv research spike folded into Milestone C0)
 
 ---
 
@@ -106,7 +107,7 @@ _Populate as decisions are made during implementation._
 
 | ID | Decision | Rationale | Date |
 |----|----------|-----------|------|
-| (none yet) | | | |
+| D-1 | Fold issue #378 (semconv research spike) into this PRD as Milestone C0 | Research is a prerequisite for the TypeScript prompt and checker work in this PRD. Running it as a standalone issue wastes context — a future agent writing the prompt would have no access to the findings. Folding it in and saving findings to a versioned file (`docs/research/typescript-semconv-constants.md`) ensures every subsequent agent reads the same ground truth before touching prompt or checker code. | 2026-04-09 |
 
 ---
 
@@ -114,7 +115,29 @@ _Populate as decisions are made during implementation._
 
 These follow the Part 8 checklist from the research doc. All items are unchecked — this PRD is a skeleton. Refine milestones after PRD #371 is merged and OD-1 through OD-4 are resolved.
 
+### Milestone C0: Research — JS/TS semconv constants
+
+**Purpose**: Answer the open questions about `@opentelemetry/semantic-conventions` before any prompt or checker code is written. The findings are saved to a versioned file that every subsequent milestone reads as its first step.
+
+**Output file**: `docs/research/typescript-semconv-constants.md`  
+Save the completed findings to this exact path. The file must exist and be committed before this milestone is marked complete. Do not put findings in a comment, PROGRESS.md, or any other location — the subsequent milestones' Step 0 instructions reference this path specifically.
+
+- [ ] Run `/research @opentelemetry/semantic-conventions` to gather current state
+- [ ] Answer all five questions from issue #378 and record them in `docs/research/typescript-semconv-constants.md`:
+  1. What is the current stable version? What naming prefix does it use?
+  2. Has there been any further migration since v1.26.0, or is the current convention stable?
+  3. What is the import pattern for stable vs. incubating attributes? Are they separate entry-points?
+  4. Which attributes that spiny-orb's checkers care about (HTTP method, status code, URL, DB system, etc.) have stable constants vs. incubating?
+  5. What does the official OTel JS documentation currently show as the idiomatic import pattern?
+- [ ] Record the recommended usage pattern (import path, constant naming, how to distinguish stable from incubating) in the file — this is what the prompt and checker milestones will consume
+- [ ] Record any gotchas (breaking changes, non-obvious migration steps, things training data gets wrong) in `~/.claude/rules/otel-semconv-gotchas.md` and reference it from `~/.claude/CLAUDE.md`
+- [ ] Close issue #378 with a comment referencing this PRD and the output file path
+- [ ] Commit `docs/research/typescript-semconv-constants.md`
+
 ### Milestone C1: Implement TypeScriptProvider
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any code. This file contains the current semconv naming convention, import pattern, and gotchas. You will need it when setting `otelSemconvPackage` and when deciding which attribute constants are safe to reference. Do not skip this step — if the file does not exist, Milestone C0 has not been completed and this milestone cannot begin.
 
 Following the Part 8 checklist, Step 1:
 
@@ -136,12 +159,15 @@ Following the Part 8 checklist, Step 1:
 - [ ] `formatCode()` — Prettier (already handles TypeScript)
 - [ ] `lintCheck()` — Prettier diff (same as JavaScript)
 - [ ] File discovery: `globPattern: '**/*.{ts,tsx}'` (or `'**/*.ts'` if OD-2 defers TSX), `defaultExclude` includes `*.d.ts`, generated files, `*.test.ts`
-- [ ] `otelSemconvPackage: '@opentelemetry/semantic-conventions'` — same package as JavaScript. **Do NOT update the prompt to use typed constants in this PRD** — the naming convention migration (`SEMATTRS_*` → `ATTR_*` at v1.26.0) requires a research spike before any prompt change is safe (see issue #378).
+- [ ] `otelSemconvPackage: '@opentelemetry/semantic-conventions'` — same package as JavaScript. The correct constant naming convention and import path are in `docs/research/typescript-semconv-constants.md` (Milestone C0). Use the findings there when configuring this field.
 - [ ] Register `TypeScriptProvider` in `src/languages/registry.ts` for `.ts` (and `.tsx` if OD-2 resolves to include it)
 - [ ] `npm run typecheck` passes
 - [ ] `npm test` passes
 
 ### Milestone C2: TypeScript-specific prompt sections
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any prompt content. The prompt will instruct the LLM to use typed semconv constants — you must know the correct import path, naming prefix, and which attributes are stable vs. incubating before writing those instructions. Do not skip this step.
 
 Following Part 8 checklist, Step 2:
 
@@ -151,6 +177,7 @@ Following Part 8 checklist, Step 2:
 - [ ] Tracer acquisition: same as JavaScript (`trace.getTracer()`)
 - [ ] Span creation idioms: same as JavaScript (`tracer.startActiveSpan()`, `tracer.startSpan()`)
 - [ ] Error handling: `try/catch` — same as JavaScript; TypeScript catch binding is `unknown` type, may need type narrowing (`if (err instanceof Error)`)
+- [ ] Semconv constants guidance: using findings from `docs/research/typescript-semconv-constants.md`, add prompt instructions covering the correct import path, naming prefix, and how to distinguish stable from incubating attributes. This replaces the raw string approach used in the JavaScript prompt.
 - [ ] At least 5 before/after TypeScript examples:
   - Async function with type annotations
   - Class method with decorator
@@ -159,6 +186,9 @@ Following Part 8 checklist, Step 2:
   - TSX component (if OD-2 includes TSX)
 
 ### Milestone C3: TypeScript Tier 2 checker implementations
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any checker code. Rules like `sch002` (attribute keys) and `cov005` (registry-defined attributes) depend on knowing which semconv constant names are valid and how they are imported. Do not skip this step.
 
 Following Part 8 checklist, Step 3:
 
@@ -201,6 +231,9 @@ describe('NDS-004: Signatures preserved', () => {
 - [ ] All consistency tests pass
 
 ### Milestone C5: Golden file tests
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any fixture files. The "after" fixture files will contain instrumented TypeScript code — they must use the correct semconv import pattern and constant names as established in the research. Do not skip this step.
 
 Following Part 8 checklist, Step 4:
 

--- a/talk/slides-short/.gitignore
+++ b/talk/slides-short/.gitignore
@@ -1,0 +1,6 @@
+_output/
+.quarto/
+index_files/
+
+/.quarto/
+**/*.quarto_ipynb

--- a/talk/slides-short/_quarto.yml
+++ b/talk/slides-short/_quarto.yml
@@ -1,0 +1,12 @@
+project:
+  type: default
+  output-dir: _output
+
+format:
+  revealjs:
+    theme: [default, custom.scss]
+    slide-number: true
+    transition: none
+    mermaid-format: svg
+    mermaid:
+      theme: neutral

--- a/talk/slides-short/custom.scss
+++ b/talk/slides-short/custom.scss
@@ -1,0 +1,30 @@
+/*-- scss:defaults --*/
+$font-family-sans-serif: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$presentation-font-size-root: 42px;
+$link-color: #00897B;
+
+/*-- scss:rules --*/
+.reveal .slide-number {
+  font-size: 0.6em;
+}
+
+.reveal .r-fit-text {
+  color: $link-color;
+}
+
+.spaced {
+  line-height: 1.8;
+}
+
+.big-text {
+  font-size: 1.4em;
+  line-height: 1.6;
+}
+
+/* Rainbow accent colors for build-up slides */
+.rainbow-1 { color: #E91E63; } /* pink */
+.rainbow-2 { color: #F57C00; } /* orange — projector-safe */
+.rainbow-3 { color: #2E7D32; } /* green — projector-safe */
+.rainbow-4 { color: #2196F3; } /* blue */
+.rainbow-5 { color: #9C27B0; } /* purple */
+.rainbow-6 { color: #0097A7; } /* cyan — projector-safe */

--- a/talk/slides-short/index.qmd
+++ b/talk/slides-short/index.qmd
@@ -1,0 +1,342 @@
+---
+format: revealjs
+---
+
+## {.center}
+
+::: {.big-text}
+Auto-instrumentation covers the stack. The problem is...
+:::
+
+::: {.notes}
+Auto-instrumentation covers the framework layer — HTTP servers, databases, LLM clients. Libraries that patch your framework internals and create spans automatically.
+:::
+
+## {.center}
+
+::: {.r-fit-text}
+Business logic stays uninstrumented.
+:::
+
+::: {.notes}
+Auto-instrumentation knows "an LLM call happened" but not "we were generating a daily summary for March 15th." That context requires manual instrumentation — and that's the part nobody wants to do.
+:::
+
+## {background-color="#00897B" .center}
+
+[Spinybacked Orbweaver]{style="font-size: 2.5em; font-weight: bold; color: #fff;"}
+
+::: {.notes}
+Spinybacked Orbweaver. Before I get into how it works, I want to make sure you know about OpenTelemetry Weaver — the foundation it's built on.
+:::
+
+## OpenTelemetry Weaver {.center}
+
+::: {.notes}
+OpenTelemetry Weaver.
+:::
+
+## OpenTelemetry Weaver {.center}
+
+::: {.big-text .spaced}
+[Define your telemetry conventions]{.rainbow-1}
+:::
+
+::: {.notes}
+With Weaver, you define your spans, attributes, and groups in a registry.
+:::
+
+## OpenTelemetry Weaver {.center}
+
+::: {.big-text .spaced}
+[Define your telemetry conventions]{.rainbow-1}
+
+[Validate them]{.rainbow-2}
+:::
+
+::: {.notes}
+Weaver validates your registry for correctness and consistency — naming conventions, attribute types, stability rules.
+:::
+
+## OpenTelemetry Weaver {.center}
+
+::: {.big-text .spaced}
+[Define your telemetry conventions]{.rainbow-1}
+
+[Validate them]{.rainbow-2}
+
+[Extend them]{.rainbow-3}
+:::
+
+::: {.notes}
+You can extend your conventions over time and import other registries as dependencies.
+:::
+
+## OpenTelemetry Weaver {.center}
+
+::: {.big-text .spaced}
+[Define your telemetry conventions]{.rainbow-1}
+
+[Validate them]{.rainbow-2}
+
+[Extend them]{.rainbow-3}
+
+[The registry is the contract]{.rainbow-4}
+:::
+
+::: {.notes}
+The registry is the contract the LLM reads, follows, and extends.
+:::
+
+## {background-color="#00897B" .center}
+
+[Spinybacked Orbweaver]{style="font-size: 2.5em; font-weight: bold; color: #fff;"}
+
+::: {.notes}
+Spinybacked Orbweaver.
+:::
+
+## Spinybacked Orbweaver {.center}
+
+::: {.notes}
+Here's what it takes in and what it gives you.
+:::
+
+## Spinybacked Orbweaver {.center}
+
+:::: {.columns}
+::: {.column width="45%"}
+**In**
+
+[Your JavaScript code]{.rainbow-1}
+:::
+::: {.column width="55%"}
+:::
+::::
+
+::: {.notes}
+You give it your JavaScript code...
+:::
+
+## Spinybacked Orbweaver {.center}
+
+:::: {.columns}
+::: {.column width="45%"}
+**In**
+
+[Your JavaScript code]{.rainbow-1}
+
+[Your Weaver registry]{.rainbow-2}
+:::
+::: {.column width="55%"}
+:::
+::::
+
+::: {.notes}
+...and your Weaver registry.
+:::
+
+## Spinybacked Orbweaver {.center}
+
+:::: {.columns}
+::: {.column width="45%"}
+**In**
+
+[Your JavaScript code]{.rainbow-1}
+
+[Your Weaver registry]{.rainbow-2}
+:::
+::: {.column width="55%"}
+**Out**
+
+[Instrumented files (on a branch)]{.rainbow-3}
+:::
+::::
+
+::: {.notes}
+It gives you instrumented files on a new branch...
+:::
+
+## Spinybacked Orbweaver {.center}
+
+:::: {.columns}
+::: {.column width="45%"}
+**In**
+
+[Your JavaScript code]{.rainbow-1}
+
+[Your Weaver registry]{.rainbow-2}
+:::
+::: {.column width="55%"}
+**Out**
+
+[Instrumented files (on a branch)]{.rainbow-3}
+
+[Reasoning reports]{.rainbow-4}
+:::
+::::
+
+::: {.notes}
+...companion reasoning files explaining every decision...
+:::
+
+## Spinybacked Orbweaver {.center}
+
+:::: {.columns}
+::: {.column width="45%"}
+**In**
+
+[Your JavaScript code]{.rainbow-1}
+
+[Your Weaver registry]{.rainbow-2}
+:::
+::: {.column width="55%"}
+**Out**
+
+[Instrumented files (on a branch)]{.rainbow-3}
+
+[Reasoning reports]{.rainbow-4}
+
+[Extended Weaver schema]{.rainbow-5}
+:::
+::::
+
+::: {.notes}
+...an extended Weaver schema with any new conventions the LLM invented...
+:::
+
+## Spinybacked Orbweaver {.center}
+
+:::: {.columns}
+::: {.column width="45%"}
+**In**
+
+[Your JavaScript code]{.rainbow-1}
+
+[Your Weaver registry]{.rainbow-2}
+:::
+::: {.column width="55%"}
+**Out**
+
+[Instrumented files (on a branch)]{.rainbow-3}
+
+[Reasoning reports]{.rainbow-4}
+
+[Extended Weaver schema]{.rainbow-5}
+
+[PR-ready overview]{.rainbow-6}
+:::
+::::
+
+::: {.notes}
+...and a PR-ready overview.
+:::
+
+## {.center}
+
+::: {.r-fit-text}
+The architecture
+:::
+
+::: {.notes}
+Here's how it works.
+:::
+
+## {.center}
+
+```{mermaid}
+flowchart LR
+  O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
+  O -->|"loads"| F["Source File"]
+
+  style O fill:#e8f5f3,stroke:#00897B,stroke-width:2px
+  style S fill:none,stroke:#9C27B0
+  style F fill:none,stroke:#E91E63
+```
+
+::: {.notes}
+The orchestrator loads the resolved schema and loads the file to be instrumented.
+:::
+
+## {.center}
+
+```{mermaid}
+flowchart LR
+  O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
+  O -->|"loads"| F["Source File"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
+
+  style O fill:#e8f5f3,stroke:#00897B,stroke-width:2px
+  style S fill:none,stroke:#9C27B0
+  style F fill:none,stroke:#E91E63
+  style A fill:#e8f5f3,stroke:#2196F3,stroke-width:2px
+```
+
+::: {.notes}
+It sends both plus instrumentation rules to a fresh LLM call.
+:::
+
+## {.center}
+
+```{mermaid}
+flowchart LR
+  O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
+  O -->|"loads"| F["Source File"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
+  A -->|"instruments"| V["Validator"]
+
+  style O fill:#e8f5f3,stroke:#00897B,stroke-width:2px
+  style S fill:none,stroke:#9C27B0
+  style F fill:none,stroke:#E91E63
+  style A fill:#e8f5f3,stroke:#2196F3,stroke-width:2px
+  style V fill:#e8f5f3,stroke:#FF9800,stroke-width:2px
+```
+
+::: {.notes}
+The LLM instruments the code. A validator checks the output against quality rules.
+:::
+
+## {.center}
+
+```{mermaid}
+flowchart LR
+  O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
+  O -->|"loads"| F["Source File"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
+  A -->|"instruments"| V["Validator"]
+  V -->|"feedback"| A
+
+  style O fill:#e8f5f3,stroke:#00897B,stroke-width:2px
+  style S fill:none,stroke:#9C27B0
+  style F fill:none,stroke:#E91E63
+  style A fill:#e8f5f3,stroke:#2196F3,stroke-width:2px
+  style V fill:#e8f5f3,stroke:#FF9800,stroke-width:2px
+```
+
+::: {.notes}
+If it fails, the LLM gets feedback and tries again.
+:::
+
+## {.center}
+
+```{mermaid}
+flowchart LR
+  O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
+  O -->|"loads"| F["Source File"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
+  A -->|"instruments"| V["Validator"]
+  V -->|"feedback"| A
+  V -->|"passes"| R["Results"]
+  R -->|"code + notes + schema"| O
+
+  style O fill:#e8f5f3,stroke:#00897B,stroke-width:2px
+  style S fill:none,stroke:#9C27B0
+  style F fill:none,stroke:#E91E63
+  style A fill:#e8f5f3,stroke:#2196F3,stroke-width:2px
+  style V fill:#e8f5f3,stroke:#FF9800,stroke-width:2px
+  style R fill:none,stroke:#4CAF50
+```
+
+::: {.notes}
+Once it passes, results go back to the orchestrator — instrumented code, reasoning notes, and schema extensions. The schema is updated so the next file inherits any new conventions. Files are processed one at a time so the schema evolves across the run.
+:::

--- a/talk/slides/index.qmd
+++ b/talk/slides/index.qmd
@@ -678,7 +678,7 @@ The orchestrator loads the resolved schema and loads the file that's going to be
 flowchart LR
   O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
   O -->|"loads"| F["Source File"]
-  O -->|"sends both + rules"| A["Fresh Agent"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
 
   style O fill:#e8f5f3,stroke:#00897B,stroke-width:2px
   style S fill:none,stroke:#9C27B0
@@ -687,7 +687,7 @@ flowchart LR
 ```
 
 ::: {.notes}
-It sends that plus instructions to a brand new agent. Those instructions include rules about what makes good instrumentation — inspired by community best practices.
+It sends that plus instructions to a brand new LLM call. Those instructions include rules about what makes good instrumentation — inspired by community best practices.
 :::
 
 ## {.center}
@@ -696,7 +696,7 @@ It sends that plus instructions to a brand new agent. Those instructions include
 flowchart LR
   O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
   O -->|"loads"| F["Source File"]
-  O -->|"sends both + rules"| A["Fresh Agent"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
   A -->|"instruments"| V["Validator"]
 
   style O fill:#e8f5f3,stroke:#00897B,stroke-width:2px
@@ -707,7 +707,7 @@ flowchart LR
 ```
 
 ::: {.notes}
-The agent instruments the code, and there's a validator that checks the output.
+The LLM instruments the code, and there's a validator that checks the output.
 :::
 
 ## {.center}
@@ -716,7 +716,7 @@ The agent instruments the code, and there's a validator that checks the output.
 flowchart LR
   O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
   O -->|"loads"| F["Source File"]
-  O -->|"sends both + rules"| A["Fresh Agent"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
   A -->|"instruments"| V["Validator"]
   V -->|"feedback"| A
 
@@ -728,7 +728,7 @@ flowchart LR
 ```
 
 ::: {.notes}
-If it fails, the agent gets a chance to try again — it's told what exactly failed. If it fails a second time, it gets a fresh, whole new agent with the same instructions plus advice about how not to fail in those specific ways. If the whole-file approach fails after all retries, it falls back to instrumenting function by function.
+If it fails, the LLM gets a chance to try again — it's told what exactly failed. If it fails a second time, it gets a fresh LLM call with the same instructions plus advice about how not to fail in those specific ways. If the whole-file approach fails after all retries, it falls back to instrumenting function by function.
 :::
 
 ## {.center}
@@ -737,7 +737,7 @@ If it fails, the agent gets a chance to try again — it's told what exactly fai
 flowchart LR
   O["Orchestrator"] -->|"loads"| S["Resolved Schema"]
   O -->|"loads"| F["Source File"]
-  O -->|"sends both + rules"| A["Fresh Agent"]
+  O -->|"sends both + rules"| A["Fresh LLM"]
   A -->|"instruments"| V["Validator"]
   V -->|"feedback"| A
   V -->|"passes"| R["Results"]
@@ -752,7 +752,7 @@ flowchart LR
 ```
 
 ::: {.notes}
-Once the agent instruments the code in a way that passes the validator, the results go back to the orchestrator — the instrumented code, the notes, schema extensions, and any recommended auto-instrumentation libraries. The orchestrator saves them, creates the companion file, and updates the Weaver registry so the next file gets the updated schema.
+Once the LLM instruments the code in a way that passes the validator, the results go back to the orchestrator — the instrumented code, the notes, schema extensions, and any recommended auto-instrumentation libraries. The orchestrator saves them, creates the companion file, and updates the Weaver registry so the next file gets the updated schema.
 :::
 
 ## {.center}
@@ -762,7 +762,7 @@ Files are instrumented one at a time. The schema evolves!
 :::
 
 ::: {.notes}
-That's why all these files cannot be instrumented in parallel. We're building one source of truth that they're all working from. If one agent makes up a convention for my journal summary functions, we want every agent that comes after to use that exact same convention.
+That's why all these files cannot be instrumented in parallel. We're building one source of truth that they're all working from. If one LLM makes up a convention for my journal summary functions, we want every LLM that comes after to use that exact same convention.
 :::
 
 ## {.center}


### PR DESCRIPTION
## Summary

- Adds `talk/slides-short/` — a condensed deck for 5-minute presentations, with progressive unrolling of the problem statement, Weaver context, spiny-orb inputs/outputs, and architecture diagram
- Fixes `talk/slides/index.qmd` — renames "Fresh Agent" to "Fresh LLM" throughout the architecture diagram sequence and speaker notes; the instrumentation call is a direct Messages API call, not an autonomous agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PRD decision log and Milestone C0 with concrete research-and-deliverables workflow for TypeScript semantic conventions.
  * Introduced mandatory "Step 0" research-read requirement before prompt/checker/fixture work.

* **New Content**
  * Added a new reveal-style slide deck detailing the OpenTelemetry Weaver auto-instrumentation flow and diagrams.

* **Updates**
  * Clarified wording to emphasize LLM-based instrumentation.

* **Chores**
  * Added slide styling, theme config, and ignore rules for generated presentation artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->