### PR TITLE
fix(cov002): import-aware outbound detection and AST-based span detection

### DIFF
--- a/prds/372-typescript-provider.md
+++ b/prds/372-typescript-provider.md
@@ -160,7 +160,8 @@ Following the Part 8 checklist, Step 1:
 - [ ] `formatCode()` — Prettier (already handles TypeScript)
 - [ ] `lintCheck()` — Prettier diff (same as JavaScript)
 - [ ] File discovery: `globPattern: '**/*.{ts,tsx}'` (or `'**/*.ts'` if OD-2 defers TSX), `defaultExclude` includes `*.d.ts`, generated files, `*.test.ts`
-- [ ] `otelSemconvPackage: '@opentelemetry/semantic-conventions'` — same package as JavaScript. The correct constant naming convention and import path are in `docs/research/typescript-semconv-constants.md` (Milestone C0). Use the findings there when configuring this field.
+- [ ] `otelSemconvPackage: '@opentelemetry/semantic-conventions'` — same package as JavaScript (provider contract expects a package name string or `null`; see `otelSemconvPackage` in `src/languages/types.ts`).
+- [ ] Use findings from `docs/research/typescript-semconv-constants.md` (Milestone C0) to guide semconv constant naming and import-path instructions in prompts, checkers, and fixtures — not to change this field.
 - [ ] Register `TypeScriptProvider` in `src/languages/registry.ts` for `.ts` (and `.tsx` if OD-2 resolves to include it)
 - [ ] `npm run typecheck` passes
 - [ ] `npm test` passes

--- a/prds/372-typescript-provider.md
+++ b/prds/372-typescript-provider.md
@@ -130,7 +130,8 @@ Save the completed findings to this exact path. The file must exist and be commi
   4. Which attributes that spiny-orb's checkers care about (HTTP method, status code, URL, DB system, etc.) have stable constants vs. incubating?
   5. What does the official OTel JS documentation currently show as the idiomatic import pattern?
 - [ ] Record the recommended usage pattern (import path, constant naming, how to distinguish stable from incubating) in the file — this is what the prompt and checker milestones will consume
-- [ ] Record any gotchas (breaking changes, non-obvious migration steps, things training data gets wrong) in `~/.claude/rules/otel-semconv-gotchas.md` and reference it from `~/.claude/CLAUDE.md`
+- [ ] Record any gotchas (breaking changes, non-obvious migration steps, things training data gets wrong) as a dedicated section in `docs/research/typescript-semconv-constants.md` — this is the canonical location. Optionally also copy to `~/.claude/rules/otel-semconv-gotchas.md` for local convenience, but the repo file is the source of truth.
+- [ ] Add a metadata header at the top of `docs/research/typescript-semconv-constants.md` containing: retrieval date, exact `@opentelemetry/semantic-conventions` package version(s) documented, and links to the official sources used (OTel JS docs, GitHub release/commit, relevant spec URLs). This allows downstream milestones (C1, C3, C5) to verify whether the snapshot is still current.
 - [ ] Close issue #378 with a comment referencing this PRD and the output file path
 - [ ] Commit `docs/research/typescript-semconv-constants.md`
 

--- a/prds/372-typescript-provider.md
+++ b/prds/372-typescript-provider.md
@@ -5,7 +5,8 @@
 **GitHub Issue**: [#372](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/372)  
 **Blocked by**: PRD #371 (JavaScript extraction) must be merged first  
 **Blocks**: PRD #373 (Python provider)  
-**Created**: 2026-04-06
+**Created**: 2026-04-06  
+**Absorbs**: Issue #378 (semconv research spike folded into Milestone C0)
 
 ---
 
@@ -106,7 +107,7 @@ _Populate as decisions are made during implementation._
 
 | ID | Decision | Rationale | Date |
 |----|----------|-----------|------|
-| (none yet) | | | |
+| D-1 | Fold issue #378 (semconv research spike) into this PRD as Milestone C0 | Research is a prerequisite for the TypeScript prompt and checker work in this PRD. Running it as a standalone issue wastes context — a future agent writing the prompt would have no access to the findings. Folding it in and saving findings to a versioned file (`docs/research/typescript-semconv-constants.md`) ensures every subsequent agent reads the same ground truth before touching prompt or checker code. | 2026-04-09 |
 
 ---
 
@@ -114,7 +115,29 @@ _Populate as decisions are made during implementation._
 
 These follow the Part 8 checklist from the research doc. All items are unchecked — this PRD is a skeleton. Refine milestones after PRD #371 is merged and OD-1 through OD-4 are resolved.
 
+### Milestone C0: Research — JS/TS semconv constants
+
+**Purpose**: Answer the open questions about `@opentelemetry/semantic-conventions` before any prompt or checker code is written. The findings are saved to a versioned file that every subsequent milestone reads as its first step.
+
+**Output file**: `docs/research/typescript-semconv-constants.md`  
+Save the completed findings to this exact path. The file must exist and be committed before this milestone is marked complete. Do not put findings in a comment, PROGRESS.md, or any other location — the subsequent milestones' Step 0 instructions reference this path specifically.
+
+- [ ] Run `/research @opentelemetry/semantic-conventions` to gather current state
+- [ ] Answer all five questions from issue #378 and record them in `docs/research/typescript-semconv-constants.md`:
+  1. What is the current stable version? What naming prefix does it use?
+  2. Has there been any further migration since v1.26.0, or is the current convention stable?
+  3. What is the import pattern for stable vs. incubating attributes? Are they separate entry-points?
+  4. Which attributes that spiny-orb's checkers care about (HTTP method, status code, URL, DB system, etc.) have stable constants vs. incubating?
+  5. What does the official OTel JS documentation currently show as the idiomatic import pattern?
+- [ ] Record the recommended usage pattern (import path, constant naming, how to distinguish stable from incubating) in the file — this is what the prompt and checker milestones will consume
+- [ ] Record any gotchas (breaking changes, non-obvious migration steps, things training data gets wrong) in `~/.claude/rules/otel-semconv-gotchas.md` and reference it from `~/.claude/CLAUDE.md`
+- [ ] Close issue #378 with a comment referencing this PRD and the output file path
+- [ ] Commit `docs/research/typescript-semconv-constants.md`
+
 ### Milestone C1: Implement TypeScriptProvider
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any code. This file contains the current semconv naming convention, import pattern, and gotchas. You will need it when setting `otelSemconvPackage` and when deciding which attribute constants are safe to reference. Do not skip this step — if the file does not exist, Milestone C0 has not been completed and this milestone cannot begin.
 
 Following the Part 8 checklist, Step 1:
 
@@ -136,12 +159,15 @@ Following the Part 8 checklist, Step 1:
 - [ ] `formatCode()` — Prettier (already handles TypeScript)
 - [ ] `lintCheck()` — Prettier diff (same as JavaScript)
 - [ ] File discovery: `globPattern: '**/*.{ts,tsx}'` (or `'**/*.ts'` if OD-2 defers TSX), `defaultExclude` includes `*.d.ts`, generated files, `*.test.ts`
-- [ ] `otelSemconvPackage: '@opentelemetry/semantic-conventions'` — same package as JavaScript. **Do NOT update the prompt to use typed constants in this PRD** — the naming convention migration (`SEMATTRS_*` → `ATTR_*` at v1.26.0) requires a research spike before any prompt change is safe (see issue #378).
+- [ ] `otelSemconvPackage: '@opentelemetry/semantic-conventions'` — same package as JavaScript. The correct constant naming convention and import path are in `docs/research/typescript-semconv-constants.md` (Milestone C0). Use the findings there when configuring this field.
 - [ ] Register `TypeScriptProvider` in `src/languages/registry.ts` for `.ts` (and `.tsx` if OD-2 resolves to include it)
 - [ ] `npm run typecheck` passes
 - [ ] `npm test` passes
 
 ### Milestone C2: TypeScript-specific prompt sections
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any prompt content. The prompt will instruct the LLM to use typed semconv constants — you must know the correct import path, naming prefix, and which attributes are stable vs. incubating before writing those instructions. Do not skip this step.
 
 Following Part 8 checklist, Step 2:
 
@@ -151,6 +177,7 @@ Following Part 8 checklist, Step 2:
 - [ ] Tracer acquisition: same as JavaScript (`trace.getTracer()`)
 - [ ] Span creation idioms: same as JavaScript (`tracer.startActiveSpan()`, `tracer.startSpan()`)
 - [ ] Error handling: `try/catch` — same as JavaScript; TypeScript catch binding is `unknown` type, may need type narrowing (`if (err instanceof Error)`)
+- [ ] Semconv constants guidance: using findings from `docs/research/typescript-semconv-constants.md`, add prompt instructions covering the correct import path, naming prefix, and how to distinguish stable from incubating attributes. This replaces the raw string approach used in the JavaScript prompt.
 - [ ] At least 5 before/after TypeScript examples:
   - Async function with type annotations
   - Class method with decorator
@@ -159,6 +186,9 @@ Following Part 8 checklist, Step 2:
   - TSX component (if OD-2 includes TSX)
 
 ### Milestone C3: TypeScript Tier 2 checker implementations
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any checker code. Rules like `sch002` (attribute keys) and `cov005` (registry-defined attributes) depend on knowing which semconv constant names are valid and how they are imported. Do not skip this step.
 
 Following Part 8 checklist, Step 3:
 
@@ -201,6 +231,9 @@ describe('NDS-004: Signatures preserved', () => {
 - [ ] All consistency tests pass
 
 ### Milestone C5: Golden file tests
+
+**Step 0 — Read research findings before proceeding.**  
+Open `docs/research/typescript-semconv-constants.md` (created in Milestone C0) and read it in full before writing any fixture files. The "after" fixture files will contain instrumented TypeScript code — they must use the correct semconv import pattern and constant names as established in the research. Do not skip this step.
 
 Following Part 8 checklist, Step 4:
 

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -20,16 +20,17 @@ function escapeXmlAttr(s: string): string {
 }
 
 function formatExamplesSection(examples: Example[]): string {
-  const formatted = examples.map((ex, i) =>
-    `<example id="${i + 1}" title="${escapeXmlAttr(ex.description)}">
+  const formatted = examples.map((ex, i) => {
+    const notesPart = ex.notes ? `\n<notes>\n${ex.notes}\n</notes>` : '';
+    return `<example id="${i + 1}" title="${escapeXmlAttr(ex.description)}">
 <before>
 ${ex.before}
 </before>
 <after>
 ${ex.after}
-</after>
-</example>`,
-  ).join('\n\n');
+</after>${notesPart}
+</example>`;
+  }).join('\n\n');
 
   return `## Examples
 

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -21,7 +21,9 @@ function escapeXmlAttr(s: string): string {
 
 function formatExamplesSection(examples: Example[]): string {
   const formatted = examples.map((ex, i) => {
-    const notesPart = ex.notes ? `\n<notes>\n${ex.notes}\n</notes>` : '';
+    const notesPart = ex.notes
+      ? `\n<notes>\n${ex.notes.replace(/&/g, '&amp;').replace(/</g, '&lt;')}\n</notes>`
+      : '';
     return `<example id="${i + 1}" title="${escapeXmlAttr(ex.description)}">
 <before>
 ${ex.before}

--- a/src/languages/javascript/prompt.ts
+++ b/src/languages/javascript/prompt.ts
@@ -368,6 +368,8 @@ export async function getUsers(req, res) {
     }
   });
 }`,
+      notes: `librariesNeeded: [{ package: "@opentelemetry/instrumentation-pg", importName: "PgInstrumentation" }]
+The handler gets a manual span as a service entry point. The pg.query call is covered by auto-instrumentation.`,
     },
     {
       description: 'Async function with existing try/catch',
@@ -510,6 +512,7 @@ export async function getUsers(req, res) {
 }
 
 app.get('/users', getUsers);`,
+      notes: `Both express and pg have auto-instrumentation libraries. Recorded in librariesNeeded: [{ package: "@opentelemetry/instrumentation-express", importName: "ExpressInstrumentation" }, { package: "@opentelemetry/instrumentation-pg", importName: "PgInstrumentation" }]. The handler function getUsers still gets a manual span as a service entry point.`,
     },
   ];
 }

--- a/src/languages/javascript/rules/cov002.ts
+++ b/src/languages/javascript/rules/cov002.ts
@@ -2,7 +2,7 @@
 // ABOUTME: AST-based detection of outbound call sites (fetch, HTTP, DB, messaging) without enclosing spans.
 
 import { Project, Node, SyntaxKind } from 'ts-morph';
-import type { CallExpression, SourceFile } from 'ts-morph';
+import type { CallExpression, Identifier, SourceFile } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule, RuleInput } from '../../types.ts';
 
@@ -227,39 +227,60 @@ function isInsideSpanScope(node: CallExpression): boolean {
                 if (!Node.isPropertyAccessExpression(callee)) continue;
                 if (callee.getName() !== 'startSpan') continue;
 
-                // Extract all variable names bound by this declaration.
+                // Extract bound identifiers from this declaration, capturing
+                // both name and symbol for each. Symbol identity is used where
+                // available to avoid false matches when an inner scope shadows
+                // the span variable name.
                 // Handles simple assignments (`const span = ...`) and
                 // destructuring (`const { span } = ...`).
                 const nameNode = decl.getNameNode();
-                const boundNames: string[] = Node.isIdentifier(nameNode)
-                  ? [nameNode.getText()]
-                  : nameNode.getDescendantsOfKind(SyntaxKind.Identifier).map(id => id.getText());
+                const boundIdentifiers: Array<{ name: string; sym: ReturnType<Identifier['getSymbol']> }> =
+                  (Node.isIdentifier(nameNode)
+                    ? [nameNode]
+                    : nameNode.getDescendantsOfKind(SyntaxKind.Identifier)
+                  ).map(id => ({ name: id.getText(), sym: id.getSymbol() }));
 
-                // Skip this declaration if any bound name was ended (via .end())
+                /**
+                 * Returns true if `identifier` refers to one of the bound variables.
+                 * Uses symbol identity when both symbols are available (handles
+                 * shadowing); falls back to name comparison otherwise.
+                 */
+                function matchesBound(identifier: Identifier): boolean {
+                  const idSym = identifier.getSymbol();
+                  for (const b of boundIdentifiers) {
+                    if (b.sym !== undefined && idSym !== undefined) {
+                      if (b.sym === idSym) return true;
+                    } else if (b.name === identifier.getText()) {
+                      return true;
+                    }
+                  }
+                  return false;
+                }
+
+                // Skip this declaration if any bound variable was ended (via .end())
                 // in the statements between the declaration and this try block.
                 let alreadyEnded = false;
-                for (let j = i + 1; j < tryIndex && !alreadyEnded; j++) {
-                  statements[j].forEachDescendant((endNode) => {
-                    if (!Node.isCallExpression(endNode)) return;
+                outer: for (let j = i + 1; j < tryIndex; j++) {
+                  for (const endNode of statements[j].getDescendantsOfKind(SyntaxKind.CallExpression)) {
                     const endExpr = endNode.getExpression();
-                    if (!Node.isPropertyAccessExpression(endExpr)) return;
+                    if (!Node.isPropertyAccessExpression(endExpr)) continue;
                     const obj = endExpr.getExpression();
                     if (Node.isIdentifier(obj)
-                      && boundNames.includes(obj.getText())
+                      && matchesBound(obj)
                       && endExpr.getName() === 'end') {
                       alreadyEnded = true;
+                      break outer;
                     }
-                  });
+                  }
                 }
                 if (alreadyEnded) continue;
 
-                // Check that the bound name is referenced in the try statement
+                // Check that a bound variable is referenced in the try statement
                 // AND that no .end() call on it appears before the outbound call
-                // in the try block. This prevents a span that was ended early
-                // (before the outbound call) inside the try from being treated
-                // as still active.
+                // in the try block. Uses symbol identity to avoid attributing an
+                // inner (shadowing) span.end() to the outer span declaration.
                 const allIdentifiers = parent.getDescendantsOfKind(SyntaxKind.Identifier);
-                if (!allIdentifiers.some(id => boundNames.includes(id.getText()))) continue;
+                if (!allIdentifiers.some(id => matchesBound(id))) continue;
 
                 const outboundCallStart = node.getStart();
                 const tryBlock = parent.getFirstChildByKind(SyntaxKind.Block);
@@ -271,7 +292,7 @@ function isInsideSpanScope(node: CallExpression): boolean {
                     if (!Node.isPropertyAccessExpression(endExpr)) return;
                     const obj = endExpr.getExpression();
                     if (Node.isIdentifier(obj)
-                      && boundNames.includes(obj.getText())
+                      && matchesBound(obj)
                       && endExpr.getName() === 'end'
                       && endNode.getStart() < outboundCallStart) {
                       endedBeforeOutbound = true;

--- a/src/languages/javascript/rules/cov002.ts
+++ b/src/languages/javascript/rules/cov002.ts
@@ -3,6 +3,24 @@
 
 import { Project, Node, SyntaxKind } from 'ts-morph';
 import type { CallExpression, Identifier, SourceFile } from 'ts-morph';
+
+/**
+ * SyntaxKinds that introduce a new execution scope.
+ * When encountered during scoped traversal, iteration stops descending into
+ * that node's children — preventing closures and nested functions from being
+ * mistaken for direct callsites in the current scope.
+ */
+const SCOPE_BREAKERS = new Set([
+  SyntaxKind.ArrowFunction,
+  SyntaxKind.FunctionExpression,
+  SyntaxKind.FunctionDeclaration,
+  SyntaxKind.MethodDeclaration,
+  SyntaxKind.Constructor,
+  SyntaxKind.ClassDeclaration,
+  SyntaxKind.ClassExpression,
+  SyntaxKind.GetAccessor,
+  SyntaxKind.SetAccessor,
+]);
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule, RuleInput } from '../../types.ts';
 
@@ -259,26 +277,28 @@ function isInsideSpanScope(node: CallExpression): boolean {
 
                 // Skip this declaration if any bound variable was ended (via .end())
                 // in the statements between the declaration and this try block.
+                // Uses scoped traversal to ignore .end() calls inside closures
+                // that may not have executed yet.
                 let alreadyEnded = false;
-                outer: for (let j = i + 1; j < tryIndex; j++) {
-                  for (const endNode of statements[j].getDescendantsOfKind(SyntaxKind.CallExpression)) {
+                for (let j = i + 1; j < tryIndex; j++) {
+                  statements[j].forEachDescendant((endNode, traversal) => {
+                    if (SCOPE_BREAKERS.has(endNode.getKind())) { traversal.skip(); return; }
+                    if (!Node.isCallExpression(endNode)) return;
                     const endExpr = endNode.getExpression();
-                    if (!Node.isPropertyAccessExpression(endExpr)) continue;
+                    if (!Node.isPropertyAccessExpression(endExpr)) return;
                     const obj = endExpr.getExpression();
-                    if (Node.isIdentifier(obj)
-                      && matchesBound(obj)
-                      && endExpr.getName() === 'end') {
+                    if (Node.isIdentifier(obj) && matchesBound(obj) && endExpr.getName() === 'end') {
                       alreadyEnded = true;
-                      break outer;
+                      traversal.stop();
                     }
-                  }
+                  });
+                  if (alreadyEnded) break;
                 }
                 if (alreadyEnded) continue;
 
-                // Check that a bound variable is referenced in the try statement
-                // AND that no .end() call on it appears before the outbound call
-                // in the try block. Uses symbol identity to avoid attributing an
-                // inner (shadowing) span.end() to the outer span declaration.
+                // Check that a bound variable is referenced anywhere in the try
+                // statement (including closures) — verifies the span is actually
+                // used, not just coincidentally in scope.
                 const allIdentifiers = parent.getDescendantsOfKind(SyntaxKind.Identifier);
                 if (!allIdentifiers.some(id => matchesBound(id))) continue;
 
@@ -286,18 +306,20 @@ function isInsideSpanScope(node: CallExpression): boolean {
                 const tryBlock = parent.getFirstChildByKind(SyntaxKind.Block);
                 let endedBeforeOutbound = false;
                 if (tryBlock) {
-                  for (const endNode of tryBlock.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+                  tryBlock.forEachDescendant((endNode, traversal) => {
+                    if (SCOPE_BREAKERS.has(endNode.getKind())) { traversal.skip(); return; }
+                    if (!Node.isCallExpression(endNode)) return;
                     const endExpr = endNode.getExpression();
-                    if (!Node.isPropertyAccessExpression(endExpr)) continue;
+                    if (!Node.isPropertyAccessExpression(endExpr)) return;
                     const obj = endExpr.getExpression();
                     if (Node.isIdentifier(obj)
                       && matchesBound(obj)
                       && endExpr.getName() === 'end'
                       && endNode.getStart() < outboundCallStart) {
                       endedBeforeOutbound = true;
-                      break;
+                      traversal.stop();
                     }
-                  }
+                  });
                 }
                 if (!endedBeforeOutbound) {
                   return true;

--- a/src/languages/javascript/rules/cov002.ts
+++ b/src/languages/javascript/rules/cov002.ts
@@ -286,18 +286,18 @@ function isInsideSpanScope(node: CallExpression): boolean {
                 const tryBlock = parent.getFirstChildByKind(SyntaxKind.Block);
                 let endedBeforeOutbound = false;
                 if (tryBlock) {
-                  tryBlock.forEachDescendant((endNode) => {
-                    if (!Node.isCallExpression(endNode)) return;
+                  for (const endNode of tryBlock.getDescendantsOfKind(SyntaxKind.CallExpression)) {
                     const endExpr = endNode.getExpression();
-                    if (!Node.isPropertyAccessExpression(endExpr)) return;
+                    if (!Node.isPropertyAccessExpression(endExpr)) continue;
                     const obj = endExpr.getExpression();
                     if (Node.isIdentifier(obj)
                       && matchesBound(obj)
                       && endExpr.getName() === 'end'
                       && endNode.getStart() < outboundCallStart) {
                       endedBeforeOutbound = true;
+                      break;
                     }
-                  });
+                  }
                 }
                 if (!endedBeforeOutbound) {
                   return true;

--- a/src/languages/javascript/rules/cov002.ts
+++ b/src/languages/javascript/rules/cov002.ts
@@ -1,21 +1,26 @@
 // ABOUTME: COV-002 Tier 2 check — outbound calls have spans.
 // ABOUTME: AST-based detection of outbound call sites (fetch, HTTP, DB, messaging) without enclosing spans.
 
-import { Project, Node } from 'ts-morph';
-import type { CallExpression } from 'ts-morph';
+import { Project, Node, SyntaxKind } from 'ts-morph';
+import type { CallExpression, SourceFile } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule, RuleInput } from '../../types.ts';
 
 /**
  * Known outbound call patterns grouped by category.
- * Each entry is [objectPattern, methodPattern] where:
+ * Each entry has objectPattern, methodPattern, and label where:
  * - objectPattern is null for standalone function calls (e.g. fetch())
- * - objectPattern is a regex matching the receiver for method calls (e.g. axios.get())
+ * - objectPattern matches the receiver variable name for method calls
+ * - requiredImport, if set, means the pattern only fires when the file
+ *   imports from a matching library — prevents false positives from
+ *   generic variable names like `client`, `store`, `pool` that are
+ *   common in non-database contexts (issue #385)
  */
 const OUTBOUND_PATTERNS: Array<{
   objectPattern: RegExp | null;
   methodPattern: RegExp;
   label: string;
+  requiredImport?: RegExp;
 }> = [
   // Global/standalone functions
   { objectPattern: null, methodPattern: /^fetch$/, label: 'fetch' },
@@ -26,18 +31,50 @@ const OUTBOUND_PATTERNS: Array<{
   // HTTP clients — node:http / node:https
   { objectPattern: /^https?$/, methodPattern: /^(request|get)$/, label: 'http/https' },
 
-  // Database clients — pg (postgres), mysql, generic database
-  { objectPattern: /(?:pool|client|connection|db|database|pg|mysql|knex)/i, methodPattern: /^query$/, label: 'query' },
+  // Database clients — library-specific identifiers, always apply
+  { objectPattern: /^(?:pg|mysql|knex|db|database)$/i, methodPattern: /^query$/, label: 'query' },
+  // Database clients — generic identifiers only when a DB library is imported
+  { objectPattern: /^(?:pool|client|connection)$/i, methodPattern: /^query$/, label: 'query', requiredImport: /^(pg|postgres|mysql|mysql2|knex)/ },
 
-  // Database clients — mysql execute
-  { objectPattern: /(?:pool|client|connection|db|database|mysql|knex)/i, methodPattern: /^execute$/, label: 'execute' },
+  // Database execute — library-specific
+  { objectPattern: /^(?:mysql|knex|db|database)$/i, methodPattern: /^execute$/, label: 'execute' },
+  // Database execute — generic only when a DB library is imported
+  { objectPattern: /^(?:pool|client|connection)$/i, methodPattern: /^execute$/, label: 'execute', requiredImport: /^(mysql|mysql2|knex)/ },
 
-  // Redis
-  { objectPattern: /(?:redis|cache|store|client)/i, methodPattern: /^(get|set|del|hget|hset|hdel|lpush|rpush|lpop|rpop|sadd|srem|zadd|zrem|publish|subscribe)$/, label: 'redis' },
+  // Redis — library-specific identifier, always apply
+  { objectPattern: /^redis$/i, methodPattern: /^(get|set|del|hget|hset|hdel|lpush|rpush|lpop|rpop|sadd|srem|zadd|zrem|publish|subscribe)$/, label: 'redis' },
+  // Redis — generic identifiers only when a Redis library is imported
+  { objectPattern: /^(?:cache|store|client)$/i, methodPattern: /^(get|set|del|hget|hset|hdel|lpush|rpush|lpop|rpop|sadd|srem|zadd|zrem|publish|subscribe)$/, label: 'redis', requiredImport: /^(redis|ioredis|@redis\/)/ },
 
-  // Message queues — AMQP (RabbitMQ)
-  { objectPattern: /(?:channel|rabbit|amqp|mq|queue|exchange)/i, methodPattern: /^(publish|sendToQueue|consume|assertQueue|assertExchange)$/, label: 'amqp' },
+  // Message queues — AMQP specific identifiers, always apply
+  { objectPattern: /^(?:rabbit|amqp|amqplib|mq)$/i, methodPattern: /^(publish|sendToQueue|consume|assertQueue|assertExchange)$/, label: 'amqp' },
+  // Message queues — generic identifiers only when amqplib is imported
+  { objectPattern: /^(?:channel|queue|exchange)$/i, methodPattern: /^(publish|sendToQueue|consume|assertQueue|assertExchange)$/, label: 'amqp', requiredImport: /^(amqplib|@cloudamqp\/)/ },
 ];
+
+/**
+ * Collect all import/require source strings from a source file.
+ * Returns a Set of raw module specifier strings (e.g. 'pg', 'redis').
+ */
+function collectImportSources(sourceFile: SourceFile): Set<string> {
+  const sources = new Set<string>();
+
+  for (const imp of sourceFile.getImportDeclarations()) {
+    sources.add(imp.getModuleSpecifierValue());
+  }
+
+  sourceFile.forEachDescendant((node) => {
+    if (!Node.isCallExpression(node)) return;
+    const expr = node.getExpression();
+    if (!Node.isIdentifier(expr) || expr.getText() !== 'require') return;
+    const args = node.getArguments();
+    if (args.length > 0 && Node.isStringLiteral(args[0])) {
+      sources.add(args[0].getLiteralValue());
+    }
+  });
+
+  return sources;
+}
 
 /**
  * COV-002: Verify that outbound calls (HTTP, database, messaging) have enclosing spans.
@@ -56,13 +93,14 @@ export function checkOutboundCallSpans(code: string, filePath: string): CheckRes
     useInMemoryFileSystem: true,
   });
   const sourceFile = project.createSourceFile('check.js', code);
+  const importSources = collectImportSources(sourceFile);
 
   const unspannedCalls: Array<{ line: number; callText: string }> = [];
 
   sourceFile.forEachDescendant((node) => {
     if (!Node.isCallExpression(node)) return;
 
-    const match = matchOutboundPattern(node);
+    const match = matchOutboundPattern(node, importSources);
     if (!match) return;
 
     if (!isInsideSpanScope(node)) {
@@ -103,8 +141,10 @@ export function checkOutboundCallSpans(code: string, filePath: string): CheckRes
 /**
  * Check if a call expression matches a known outbound pattern.
  * Returns a human-readable label for the call, or null if no match.
+ * Patterns with requiredImport are only applied when the file imports
+ * from a matching library source (issue #385).
  */
-function matchOutboundPattern(callExpr: CallExpression): string | null {
+function matchOutboundPattern(callExpr: CallExpression, importSources: Set<string>): string | null {
   const expr = callExpr.getExpression();
 
   // Check standalone function calls (e.g., fetch())
@@ -124,11 +164,14 @@ function matchOutboundPattern(callExpr: CallExpression): string | null {
     const objectText = expr.getExpression().getText();
 
     for (const pattern of OUTBOUND_PATTERNS) {
-      if (pattern.objectPattern !== null
-        && pattern.objectPattern.test(objectText)
-        && pattern.methodPattern.test(methodName)) {
-        return `${objectText}.${methodName}`;
+      if (pattern.objectPattern === null) continue;
+      if (!pattern.objectPattern.test(objectText)) continue;
+      if (!pattern.methodPattern.test(methodName)) continue;
+      if (pattern.requiredImport) {
+        const hasRequiredImport = [...importSources].some(src => pattern.requiredImport!.test(src));
+        if (!hasRequiredImport) continue;
       }
+      return `${objectText}.${methodName}`;
     }
     return null;
   }
@@ -139,6 +182,10 @@ function matchOutboundPattern(callExpr: CallExpression): string | null {
 /**
  * Check if a node is enclosed in a span scope — either inside a
  * startActiveSpan callback or after a startSpan declaration in the same block.
+ *
+ * Uses AST traversal for the try-block check to avoid false positives from
+ * startSpan references in comments or string literals, and to skip stale
+ * spans that were already ended before the current try block (issue #387).
  */
 function isInsideSpanScope(node: CallExpression): boolean {
   let current = node.getParent();
@@ -154,7 +201,10 @@ function isInsideSpanScope(node: CallExpression): boolean {
       }
     }
 
-    // Pattern 2: Inside a try block that follows a startSpan declaration
+    // Pattern 2: Inside a try block that follows a startSpan declaration.
+    // Uses AST traversal (not string matching) to find real startSpan calls,
+    // extract bound variable names, and skip spans already ended before this
+    // try block.
     if (Node.isBlock(current)) {
       const parent = current.getParent();
       if (parent && Node.isTryStatement(parent)) {
@@ -163,21 +213,49 @@ function isInsideSpanScope(node: CallExpression): boolean {
           const statements = tryParent.getStatements();
           const tryIndex = statements.findIndex(s => s === parent);
           if (tryIndex > 0) {
-            // Check if preceding statement declares a span variable via startSpan
             for (let i = 0; i < tryIndex; i++) {
-              const stmtText = statements[i].getText();
-              if (stmtText.includes('.startSpan(')) {
-                // Verify the span variable is referenced in the try block
-                const spanVarMatch = stmtText.match(/(?:const|let|var)\s+(\w+)\s*=.*\.startSpan\(/);
-                if (spanVarMatch) {
-                  const spanVar = spanVarMatch[1];
-                  const tryStatementText = parent.getText();
-                  // Use word boundary to avoid matching substrings like "responseSpan." when spanVar="span"
-                  const escapedSpanVar = spanVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                  const spanUsagePattern = new RegExp(`\\b${escapedSpanVar}\\.`);
-                  if (spanUsagePattern.test(tryStatementText)) {
-                    return true;
-                  }
+              const stmt = statements[i];
+              if (!Node.isVariableStatement(stmt)) continue;
+
+              for (const decl of stmt.getDeclarationList().getDeclarations()) {
+                const init = decl.getInitializer();
+                if (!init || !Node.isCallExpression(init)) continue;
+
+                const callee = init.getExpression();
+                if (!Node.isPropertyAccessExpression(callee)) continue;
+                if (callee.getName() !== 'startSpan') continue;
+
+                // Extract all variable names bound by this declaration.
+                // Handles simple assignments (`const span = ...`) and
+                // destructuring (`const { span } = ...`).
+                const nameNode = decl.getNameNode();
+                const boundNames: string[] = Node.isIdentifier(nameNode)
+                  ? [nameNode.getText()]
+                  : nameNode.getDescendantsOfKind(SyntaxKind.Identifier).map(id => id.getText());
+
+                // Skip this declaration if any bound name was ended (via .end())
+                // in the statements between the declaration and this try block.
+                let alreadyEnded = false;
+                for (let j = i + 1; j < tryIndex && !alreadyEnded; j++) {
+                  statements[j].forEachDescendant((endNode) => {
+                    if (!Node.isCallExpression(endNode)) return;
+                    const endExpr = endNode.getExpression();
+                    if (!Node.isPropertyAccessExpression(endExpr)) return;
+                    const obj = endExpr.getExpression();
+                    if (Node.isIdentifier(obj)
+                      && boundNames.includes(obj.getText())
+                      && endExpr.getName() === 'end') {
+                      alreadyEnded = true;
+                    }
+                  });
+                }
+                if (alreadyEnded) continue;
+
+                // Check that at least one bound name is referenced anywhere in
+                // the try statement (try block, catch clause, or finally block).
+                const identifiers = parent.getDescendantsOfKind(SyntaxKind.Identifier);
+                if (identifiers.some(id => boundNames.includes(id.getText()))) {
+                  return true;
                 }
               }
             }

--- a/src/languages/javascript/rules/cov002.ts
+++ b/src/languages/javascript/rules/cov002.ts
@@ -34,22 +34,24 @@ const OUTBOUND_PATTERNS: Array<{
   // Database clients — library-specific identifiers, always apply
   { objectPattern: /^(?:pg|mysql|knex|db|database)$/i, methodPattern: /^query$/, label: 'query' },
   // Database clients — generic identifiers only when a DB library is imported
-  { objectPattern: /^(?:pool|client|connection)$/i, methodPattern: /^query$/, label: 'query', requiredImport: /^(pg|postgres|mysql|mysql2|knex)/ },
+  // (?:$|\/) ensures pg-format, postgres-js, etc. do not match
+  { objectPattern: /^(?:pool|client|connection)$/i, methodPattern: /^query$/, label: 'query', requiredImport: /^(?:pg|postgres|mysql|mysql2|knex)(?:$|\/)/ },
 
   // Database execute — library-specific
   { objectPattern: /^(?:mysql|knex|db|database)$/i, methodPattern: /^execute$/, label: 'execute' },
   // Database execute — generic only when a DB library is imported
-  { objectPattern: /^(?:pool|client|connection)$/i, methodPattern: /^execute$/, label: 'execute', requiredImport: /^(mysql|mysql2|knex)/ },
+  { objectPattern: /^(?:pool|client|connection)$/i, methodPattern: /^execute$/, label: 'execute', requiredImport: /^(?:mysql|mysql2|knex)(?:$|\/)/ },
 
   // Redis — library-specific identifier, always apply
   { objectPattern: /^redis$/i, methodPattern: /^(get|set|del|hget|hset|hdel|lpush|rpush|lpop|rpop|sadd|srem|zadd|zrem|publish|subscribe)$/, label: 'redis' },
   // Redis — generic identifiers only when a Redis library is imported
-  { objectPattern: /^(?:cache|store|client)$/i, methodPattern: /^(get|set|del|hget|hset|hdel|lpush|rpush|lpop|rpop|sadd|srem|zadd|zrem|publish|subscribe)$/, label: 'redis', requiredImport: /^(redis|ioredis|@redis\/)/ },
+  // (?:$|\/) prevents redis-smq and similar from matching
+  { objectPattern: /^(?:cache|store|client)$/i, methodPattern: /^(get|set|del|hget|hset|hdel|lpush|rpush|lpop|rpop|sadd|srem|zadd|zrem|publish|subscribe)$/, label: 'redis', requiredImport: /^(?:(?:redis|ioredis)(?:$|\/)|@redis\/)/ },
 
   // Message queues — AMQP specific identifiers, always apply
   { objectPattern: /^(?:rabbit|amqp|amqplib|mq)$/i, methodPattern: /^(publish|sendToQueue|consume|assertQueue|assertExchange)$/, label: 'amqp' },
   // Message queues — generic identifiers only when amqplib is imported
-  { objectPattern: /^(?:channel|queue|exchange)$/i, methodPattern: /^(publish|sendToQueue|consume|assertQueue|assertExchange)$/, label: 'amqp', requiredImport: /^(amqplib|@cloudamqp\/)/ },
+  { objectPattern: /^(?:channel|queue|exchange)$/i, methodPattern: /^(publish|sendToQueue|consume|assertQueue|assertExchange)$/, label: 'amqp', requiredImport: /^(?:amqplib(?:$|\/)|@cloudamqp\/)/ },
 ];
 
 /**
@@ -251,10 +253,32 @@ function isInsideSpanScope(node: CallExpression): boolean {
                 }
                 if (alreadyEnded) continue;
 
-                // Check that at least one bound name is referenced anywhere in
-                // the try statement (try block, catch clause, or finally block).
-                const identifiers = parent.getDescendantsOfKind(SyntaxKind.Identifier);
-                if (identifiers.some(id => boundNames.includes(id.getText()))) {
+                // Check that the bound name is referenced in the try statement
+                // AND that no .end() call on it appears before the outbound call
+                // in the try block. This prevents a span that was ended early
+                // (before the outbound call) inside the try from being treated
+                // as still active.
+                const allIdentifiers = parent.getDescendantsOfKind(SyntaxKind.Identifier);
+                if (!allIdentifiers.some(id => boundNames.includes(id.getText()))) continue;
+
+                const outboundCallStart = node.getStart();
+                const tryBlock = parent.getFirstChildByKind(SyntaxKind.Block);
+                let endedBeforeOutbound = false;
+                if (tryBlock) {
+                  tryBlock.forEachDescendant((endNode) => {
+                    if (!Node.isCallExpression(endNode)) return;
+                    const endExpr = endNode.getExpression();
+                    if (!Node.isPropertyAccessExpression(endExpr)) return;
+                    const obj = endExpr.getExpression();
+                    if (Node.isIdentifier(obj)
+                      && boundNames.includes(obj.getText())
+                      && endExpr.getName() === 'end'
+                      && endNode.getStart() < outboundCallStart) {
+                      endedBeforeOutbound = true;
+                    }
+                  });
+                }
+                if (!endedBeforeOutbound) {
                   return true;
                 }
               }

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -176,6 +176,8 @@ export interface Example {
   before: string;
   /** Source code after instrumentation. */
   after: string;
+  /** Optional explanation of non-obvious decisions (librariesNeeded, skip rationale, etc.). */
+  notes?: string;
 }
 
 /**

--- a/test/languages/javascript/rules/cov002.test.ts
+++ b/test/languages/javascript/rules/cov002.test.ts
@@ -68,7 +68,9 @@ describe('checkOutboundCallSpans (COV-002)', () => {
       const code = [
         'const { trace } = require("@opentelemetry/api");',
         'const tracer = trace.getTracer("svc");',
-        'async function getUsers(pool) {',
+        'const { Pool } = require("pg");',
+        'const pool = new Pool();',
+        'async function getUsers() {',
         '  return tracer.startActiveSpan("getUsers", async (span) => {',
         '    try {',
         '      return await pool.query("SELECT * FROM users");',
@@ -119,7 +121,9 @@ describe('checkOutboundCallSpans (COV-002)', () => {
 
     it('fails when pool.query() has no enclosing span', () => {
       const code = [
-        'async function getUsers(pool) {',
+        'const { Pool } = require("pg");',
+        'const pool = new Pool();',
+        'async function getUsers() {',
         '  return await pool.query("SELECT * FROM users");',
         '}',
       ].join('\n');
@@ -225,6 +229,7 @@ describe('checkOutboundCallSpans (COV-002)', () => {
 
     it('detects amqp channel.publish() as outbound', () => {
       const code = [
+        'const amqplib = require("amqplib");',
         'async function sendMessage(channel, msg) {',
         '  channel.publish("exchange", "key", Buffer.from(msg));',
         '}',
@@ -237,6 +242,7 @@ describe('checkOutboundCallSpans (COV-002)', () => {
 
     it('detects channel.sendToQueue() as outbound', () => {
       const code = [
+        'const amqplib = require("amqplib");',
         'async function enqueue(channel, msg) {',
         '  channel.sendToQueue("my-queue", Buffer.from(msg));',
         '}',
@@ -245,6 +251,165 @@ describe('checkOutboundCallSpans (COV-002)', () => {
       const results = checkOutboundCallSpans(code, filePath);
       expect(results).toHaveLength(1);
       expect(results[0].passed).toBe(false);
+    });
+  });
+
+  describe('import-aware detection — issue #385', () => {
+    it('does not flag store.get() as a redis outbound call without a redis import', () => {
+      const code = [
+        'function getPrefs(store, userId) {',
+        '  return store.get(`user.${userId}.prefs`);',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('does not flag client.get() as an outbound call without a redis/db import', () => {
+      const code = [
+        'async function fetchUser(client, id) {',
+        '  return await client.get(`/users/${id}`);',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('does not flag pool.query() as outbound without a database import', () => {
+      const code = [
+        'async function search(pool, term) {',
+        '  return await pool.query(term);',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('does not flag channel.publish() as outbound without an amqplib import', () => {
+      const code = [
+        'async function broadcast(channel, msg) {',
+        '  channel.publish("events", "key", Buffer.from(msg));',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('flags store.get() as a redis outbound call when redis is imported', () => {
+      const code = [
+        'const redis = require("redis");',
+        'const store = redis.createClient();',
+        'async function getPrefs(userId) {',
+        '  return await store.get(`user.${userId}.prefs`);',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
+    it('flags client.query() as outbound when pg is imported', () => {
+      const code = [
+        'const { Client } = require("pg");',
+        'const client = new Client();',
+        'async function getUser(id) {',
+        '  return await client.query("SELECT * FROM users WHERE id = $1", [id]);',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
+    it('flags channel.publish() as outbound when amqplib is imported', () => {
+      const code = [
+        'const amqplib = require("amqplib");',
+        'async function sendMessage(channel, msg) {',
+        '  channel.publish("exchange", "key", Buffer.from(msg));',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
+    it('flags outbound calls with ES module imports too', () => {
+      const code = [
+        'import { createClient } from "redis";',
+        'const cache = createClient();',
+        'async function get(key) {',
+        '  return await cache.get(key);',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+  });
+
+  describe('stale span detection — issue #387', () => {
+    it('does not treat a startSpan that was already ended as covering a later outbound call', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function handleRequest() {',
+        '  const span = tracer.startSpan("outer");',
+        '  try {',
+        '    // outer work',
+        '  } finally {',
+        '    span.end();',
+        '  }',
+        '  // span is now ended — the fetch below is not covered',
+        '  try {',
+        '    const res = await fetch("/api/data");',
+        '    span.setAttribute("done", true);',
+        '    return res;',
+        '  } finally {}',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
+    it('correctly detects a live startSpan covering an outbound call when a prior span was ended', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function handleRequest() {',
+        '  const outerSpan = tracer.startSpan("outer");',
+        '  try {',
+        '    // outer work',
+        '  } finally {',
+        '    outerSpan.end();',
+        '  }',
+        '  const innerSpan = tracer.startSpan("inner");',
+        '  try {',
+        '    const res = await fetch("/api/data");',
+        '    innerSpan.setAttribute("result", res.status);',
+        '    return res;',
+        '  } finally {',
+        '    innerSpan.end();',
+        '  }',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
     });
   });
 

--- a/test/languages/javascript/rules/cov002.test.ts
+++ b/test/languages/javascript/rules/cov002.test.ts
@@ -404,6 +404,30 @@ describe('checkOutboundCallSpans (COV-002)', () => {
       expect(results[0].passed).toBe(false);
     });
 
+    it('is not fooled by span.end() on a shadowing inner variable with the same name', () => {
+      // The outer span is still active during fetch — only the inner (shadowing)
+      // span was ended. The fetch should be treated as covered.
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function handleRequest() {',
+        '  const span = tracer.startSpan("outer");',
+        '  try {',
+        '    const span = tracer.startSpan("inner");',
+        '    span.end();',
+        '    const res = await fetch("/api");',
+        '    return res;',
+        '  } finally {',
+        '    span.end();',
+        '  }',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
     it('correctly detects a live startSpan covering an outbound call when a prior span was ended', () => {
       const code = [
         'const { trace } = require("@opentelemetry/api");',

--- a/test/languages/javascript/rules/cov002.test.ts
+++ b/test/languages/javascript/rules/cov002.test.ts
@@ -385,6 +385,25 @@ describe('checkOutboundCallSpans (COV-002)', () => {
       expect(results[0].passed).toBe(false);
     });
 
+    it('does not treat a span as active after span.end() inside the same try block', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function handleRequest() {',
+        '  const span = tracer.startSpan("op");',
+        '  try {',
+        '    span.end();',
+        '    const res = await fetch("/api/data");',
+        '    return res;',
+        '  } finally {}',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+
     it('correctly detects a live startSpan covering an outbound call when a prior span was ended', () => {
       const code = [
         'const { trace } = require("@opentelemetry/api");',

--- a/test/languages/javascript/rules/cov002.test.ts
+++ b/test/languages/javascript/rules/cov002.test.ts
@@ -404,6 +404,26 @@ describe('checkOutboundCallSpans (COV-002)', () => {
       expect(results[0].passed).toBe(false);
     });
 
+    it('does not treat span.end() inside an unexecuted closure as ending the span', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function handleRequest() {',
+        '  const span = tracer.startSpan("op");',
+        '  try {',
+        '    const cleanup = () => span.end();',
+        '    const res = await fetch("/api");',
+        '    cleanup();',
+        '    return res;',
+        '  } finally {}',
+        '}',
+      ].join('\n');
+
+      const results = checkOutboundCallSpans(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
     it('is not fooled by span.end() on a shadowing inner variable with the same name', () => {
       // The outer span is still active during fetch — only the inner (shadowing)
       // span was ended. The fetch should be treated as covered.


### PR DESCRIPTION
## Summary

Fixes two bugs in the COV-002 outbound call detection rule. Closes #385, closes #387.

- **#385 — False positives from generic variable names**: Generic identifiers (`client`, `pool`, `connection`, `cache`, `store`, `channel`, `queue`, `exchange`) now only trigger outbound detection when the file imports the matching library (pg, redis/ioredis, amqplib, etc.). Library-specific identifiers (`axios`, `redis`, `pg`, `mysql`, `knex`, `amqp`) remain always-on. Prevents false positives on codebases that happen to use these common names for non-database purposes.

- **#387 — Fragile string-based span detection**: Replaces `stmtText.includes('.startSpan(')` and regex extraction with AST traversal. Finds real `startSpan` `CallExpression` nodes in preceding `VariableStatement`s, extracts bound names from the declaration `nameNode` (handles destructuring), and skips declarations where the span was already ended before the current try block to prevent stale spans from masking uncovered outbound calls.

## Test plan

- [ ] New false-positive tests pass: `store.get()`, `client.get()`, `pool.query()`, `channel.publish()` without matching imports are not flagged
- [ ] New true-positive tests pass: same calls WITH imports are flagged
- [ ] New stale-span test passes: ended span does not cover subsequent outbound call
- [ ] Updated existing tests: `pool.query`, `channel.publish`, `channel.sendToQueue` tests now include the required library import
- [ ] Full test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound-call detection to be import-aware and to more accurately determine whether calls are covered by an active span, reducing false positives and missed cases.

* **Documentation**
  * Product guidance and milestone gates now reference a mandatory research findings file that standardizes semconv constant names, imports, usage guidance, and gotchas.

* **New Features**
  * Examples can include optional explanatory notes; prompt examples updated to surface library/coverage guidance.

* **Tests**
  * Added/updated tests for import-aware detection and stale-span scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->