### PR TITLE
fix(cov003): detect missing error recording in manual startSpan catch blocks; add process.exit() and SSH remote fixes

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -221,7 +221,7 @@ Your output is scored against these rules. Violating gate rules causes immediate
 
 ### Code Quality
 
-- **CDQ-001**: Every span MUST be closed — \`span.end()\` in a \`finally\` block or use the \`startActiveSpan\` callback pattern. Do NOT place \`span.end()\` inside a \`try\` block — if an exception is thrown before it runs, the span leaks. Do NOT wrap \`process.exit()\` calls in span instrumentation; replace \`process.exit()\` with \`return\` so the span's \`finally\` block can execute. If the function genuinely must terminate the process, leave \`process.exit()\` untouched and document it in advisory notes rather than adding instrumentation around it.
+- **CDQ-001**: Every span MUST be closed — \`span.end()\` in a \`finally\` block or use the \`startActiveSpan\` callback pattern. Do NOT place \`span.end()\` inside a \`try\` block — if an exception is thrown before it runs, the span leaks. Do NOT add span instrumentation around \`process.exit()\` calls — leave \`process.exit()\` untouched (modifying control flow violates NDS-003). If a function contains \`process.exit()\`, skip instrumentation of that call site and report it in advisory notes as a refactor suggestion (e.g., extract the logic before the exit into an instrumented wrapper).
 - **CDQ-002**: Acquire tracer with \`trace.getTracer()\` including a library name string.
 - **CDQ-003**: Record errors with \`span.recordException(error)\` + \`span.setStatus({ code: SpanStatusCode.ERROR })\`. Do NOT use ad-hoc \`setAttribute('error', ...)\`. (Exception: expected-condition catches — see Error Handling section.)
 - **CDQ-005**: For manual spans (\`startSpan\`), use \`context.with()\` to maintain async context.

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -221,7 +221,7 @@ Your output is scored against these rules. Violating gate rules causes immediate
 
 ### Code Quality
 
-- **CDQ-001**: Every span MUST be closed — \`span.end()\` in a \`finally\` block or use the \`startActiveSpan\` callback pattern.
+- **CDQ-001**: Every span MUST be closed — \`span.end()\` in a \`finally\` block or use the \`startActiveSpan\` callback pattern. Do NOT place \`span.end()\` inside a \`try\` block — if an exception is thrown before it runs, the span leaks. Do NOT wrap \`process.exit()\` calls in span instrumentation; replace \`process.exit()\` with \`return\` so the span's \`finally\` block can execute. If the function genuinely must terminate the process, leave \`process.exit()\` untouched and document it in advisory notes rather than adding instrumentation around it.
 - **CDQ-002**: Acquire tracer with \`trace.getTracer()\` including a library name string.
 - **CDQ-003**: Record errors with \`span.recordException(error)\` + \`span.setStatus({ code: SpanStatusCode.ERROR })\`. Do NOT use ad-hoc \`setAttribute('error', ...)\`. (Exception: expected-condition catches — see Error Handling section.)
 - **CDQ-005**: For manual spans (\`startSpan\`), use \`context.with()\` to maintain async context.

--- a/src/git/git-wrapper.ts
+++ b/src/git/git-wrapper.ts
@@ -263,6 +263,13 @@ export async function validateCredentials(dir: string): Promise<void> {
     );
   }
 
+  // SSH and non-HTTP remotes (git://, file://) use key-based auth — there is
+  // no token to validate. If the key is not configured, the push will fail with
+  // a clear SSH error at that point.
+  if (remoteUrl && !remoteUrl.startsWith('http://') && !remoteUrl.startsWith('https://')) {
+    return;
+  }
+
   try {
     await git.listRemote(['--heads']);
   } catch (err) {

--- a/src/git/git-wrapper.ts
+++ b/src/git/git-wrapper.ts
@@ -263,9 +263,9 @@ export async function validateCredentials(dir: string): Promise<void> {
     );
   }
 
-  // SSH and non-HTTP remotes (git://, file://) use key-based auth — there is
-  // no token to validate. If the key is not configured, the push will fail with
-  // a clear SSH error at that point.
+  // Non-HTTP remotes (e.g., SSH scp-style URLs, git://, file://) are skipped here
+  // because GITHUB_TOKEN-based HTTPS validation does not apply to them.
+  // Auth/connectivity errors for these transports will surface at push time.
   if (remoteUrl && !remoteUrl.startsWith('http://') && !remoteUrl.startsWith('https://')) {
     return;
   }

--- a/src/languages/javascript/rules/cov003.ts
+++ b/src/languages/javascript/rules/cov003.ts
@@ -66,10 +66,11 @@ export function checkErrorVisibility(code: string, filePath: string): CheckResul
             container = container.getParent();
           }
           if (container && (Node.isBlock(container) || Node.isSourceFile(container))) {
-            // Check each TryStatement individually — same logic as startActiveSpan.
-            // getDescendantsOfKind traverses nested blocks, so catch blocks inside
-            // callbacks (e.g., context.with) are found correctly.
-            const tryStatements = container.getDescendantsOfKind(SyntaxKind.TryStatement);
+            // Only check TryStatements that reference the span variable — this filters out
+            // unrelated try/catch blocks that happen to be in the same container block
+            // (e.g., code before the span is created, or independent helper functions).
+            const tryStatements = container.getDescendantsOfKind(SyntaxKind.TryStatement)
+              .filter((t) => t.getText().includes(spanVarName));
             for (const tryStmt of tryStatements) {
               const catchClause = tryStmt.getCatchClause();
               if (catchClause && !isExpectedConditionCatch(catchClause)) {

--- a/src/languages/javascript/rules/cov003.ts
+++ b/src/languages/javascript/rules/cov003.ts
@@ -54,28 +54,30 @@ export function checkErrorVisibility(code: string, filePath: string): CheckResul
     // For startSpan (non-callback style), check sibling scope for error recording
     if (!spanParam) {
       if (text.endsWith('.startSpan')) {
-        // Find the span variable name from the declaration
+        // Use AST to get the variable name — VariableDeclaration.getName() is reliable;
+        // getText() omits the const/let/var keyword so regex matching fails there.
         const parentNode = node.getParent();
-        if (parentNode) {
-          const declText = parentNode.getText();
-          const varMatch = declText.match(/(?:const|let|var)\s+(\w+)\s*=/);
-          if (varMatch) {
-            const spanVarName = varMatch[1];
-            // Walk up to find the containing block and check for error recording
-            let container = parentNode.getParent();
-            while (container && !Node.isBlock(container) && !Node.isSourceFile(container)) {
-              container = container.getParent();
-            }
-            if (container && (Node.isBlock(container) || Node.isSourceFile(container))) {
-              // Use AST to find try/catch — avoids false positives from "try"/"catch" in strings or identifiers
-              const hasTryCatch = container.getDescendantsOfKind(SyntaxKind.TryStatement)
-                .some((t) => t.getCatchClause() !== undefined);
-              if (hasTryCatch) {
-                const blockText = container.getText();
-                if (!hasErrorRecording(blockText, spanVarName)) {
+        if (Node.isVariableDeclaration(parentNode)) {
+          const spanVarName = parentNode.getName();
+          // Walk up to find the containing block.
+          // Typed as Node to allow reassignment through getParent() up the tree.
+          let container: import('ts-morph').Node | undefined = parentNode.getParent();
+          while (container && !Node.isBlock(container) && !Node.isSourceFile(container)) {
+            container = container.getParent();
+          }
+          if (container && (Node.isBlock(container) || Node.isSourceFile(container))) {
+            // Check each TryStatement individually — same logic as startActiveSpan.
+            // getDescendantsOfKind traverses nested blocks, so catch blocks inside
+            // callbacks (e.g., context.with) are found correctly.
+            const tryStatements = container.getDescendantsOfKind(SyntaxKind.TryStatement);
+            for (const tryStmt of tryStatements) {
+              const catchClause = tryStmt.getCatchClause();
+              if (catchClause && !isExpectedConditionCatch(catchClause)) {
+                const catchText = catchClause.getText();
+                if (!hasErrorRecording(catchText, spanVarName)) {
                   issues.push({
-                    line: node.getStartLineNumber(),
-                    description: `startSpan "${spanVarName}" — catch block does not record error on span`,
+                    line: tryStmt.getStartLineNumber(),
+                    description: `startSpan "${spanVarName}" — catch block at line ${catchClause.getStartLineNumber()} does not record error on span`,
                   });
                 }
               }

--- a/test/fix-loop/refactor-recommendation-integration.test.ts
+++ b/test/fix-loop/refactor-recommendation-integration.test.ts
@@ -153,7 +153,7 @@ describe('instrumentWithRetry — refactor recommendation integration', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('produces actionable refactor recommendation when NDS-003 persists across retry attempts', async () => {
+  it('produces actionable refactor recommendation when NDS-003 persists across retry attempts', { timeout: 30000 }, async () => {
     // Mock instrumentFile to return realistic instrumented code with const-extraction
     // that triggers NDS-003. Use real validateFile to detect the violation naturally.
     const deps: InstrumentWithRetryDeps = {

--- a/test/languages/javascript/rules/cov003.test.ts
+++ b/test/languages/javascript/rules/cov003.test.ts
@@ -398,12 +398,14 @@ describe('checkErrorVisibility (COV-003)', () => {
 
   describe('manual startSpan (span variable) pattern', () => {
     it('flags manual span with catch that rethrows but lacks error recording', () => {
+      // Uses the correct OTel JS API: trace.setSpan(context.active(), span)
       const code = [
         'const { trace, context } = require("@opentelemetry/api");',
         'const tracer = trace.getTracer("svc");',
         'async function fetchData() {',
         '  const span = tracer.startSpan("fetchData");',
-        '  return context.with(context.with(context.active(), span), async () => {',
+        '  const ctxWithSpan = trace.setSpan(context.active(), span);',
+        '  return context.with(ctxWithSpan, async () => {',
         '    try {',
         '      const result = await fetch("/api/data");',
         '      return result.json();',
@@ -428,7 +430,8 @@ describe('checkErrorVisibility (COV-003)', () => {
         'const tracer = trace.getTracer("svc");',
         'async function fetchData() {',
         '  const span = tracer.startSpan("fetchData");',
-        '  return context.with(context.with(context.active(), span), async () => {',
+        '  const ctxWithSpan = trace.setSpan(context.active(), span);',
+        '  return context.with(ctxWithSpan, async () => {',
         '    try {',
         '      const result = await fetch("/api/data");',
         '      return result.json();',
@@ -454,7 +457,8 @@ describe('checkErrorVisibility (COV-003)', () => {
         'const tracer = trace.getTracer("svc");',
         'async function tryLoadConfig(path) {',
         '  const span = tracer.startSpan("tryLoadConfig");',
-        '  return context.with(context.with(context.active(), span), async () => {',
+        '  const ctxWithSpan = trace.setSpan(context.active(), span);',
+        '  return context.with(ctxWithSpan, async () => {',
         '    try {',
         '      return JSON.parse(await readFile(path, "utf8"));',
         '    } catch (err) {',
@@ -477,11 +481,14 @@ describe('checkErrorVisibility (COV-003)', () => {
         'const tracer = trace.getTracer("svc");',
         'async function maybeLoad(path) {',
         '  const span = tracer.startSpan("maybeLoad");',
-        '  return context.with(context.with(context.active(), span), async () => {',
+        '  const ctxWithSpan = trace.setSpan(context.active(), span);',
+        '  return context.with(ctxWithSpan, async () => {',
         '    try {',
         '      return await readFile(path);',
-        '    } catch {}',
-        '    span.end();',
+        '    } catch {',
+        '    } finally {',
+        '      span.end();',
+        '    }',
         '  });',
         '}',
       ].join('\n');

--- a/test/languages/javascript/rules/cov003.test.ts
+++ b/test/languages/javascript/rules/cov003.test.ts
@@ -396,6 +396,102 @@ describe('checkErrorVisibility (COV-003)', () => {
     });
   });
 
+  describe('manual startSpan (span variable) pattern', () => {
+    it('flags manual span with catch that rethrows but lacks error recording', () => {
+      const code = [
+        'const { trace, context } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function fetchData() {',
+        '  const span = tracer.startSpan("fetchData");',
+        '  return context.with(context.with(context.active(), span), async () => {',
+        '    try {',
+        '      const result = await fetch("/api/data");',
+        '      return result.json();',
+        '    } catch (error) {',
+        '      console.error(error);',
+        '      throw error;',
+        '    } finally {',
+        '      span.end();',
+        '    }',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkErrorVisibility(code, filePath);
+      expect(results.some((r) => !r.passed)).toBe(true);
+      expect(results.some((r) => r.ruleId === 'COV-003' && !r.passed)).toBe(true);
+    });
+
+    it('passes when manual span catch has recordException', () => {
+      const code = [
+        'const { trace, context, SpanStatusCode } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function fetchData() {',
+        '  const span = tracer.startSpan("fetchData");',
+        '  return context.with(context.with(context.active(), span), async () => {',
+        '    try {',
+        '      const result = await fetch("/api/data");',
+        '      return result.json();',
+        '    } catch (error) {',
+        '      span.recordException(error);',
+        '      span.setStatus({ code: SpanStatusCode.ERROR });',
+        '      throw error;',
+        '    } finally {',
+        '      span.end();',
+        '    }',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkErrorVisibility(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when manual span catch swallows error (expected-condition, no rethrow)', () => {
+      const code = [
+        'const { trace, context } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function tryLoadConfig(path) {',
+        '  const span = tracer.startSpan("tryLoadConfig");',
+        '  return context.with(context.with(context.active(), span), async () => {',
+        '    try {',
+        '      return JSON.parse(await readFile(path, "utf8"));',
+        '    } catch (err) {',
+        '      return {};',
+        '    } finally {',
+        '      span.end();',
+        '    }',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkErrorVisibility(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when manual span catch is empty (control flow)', () => {
+      const code = [
+        'const { trace, context } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'async function maybeLoad(path) {',
+        '  const span = tracer.startSpan("maybeLoad");',
+        '  return context.with(context.with(context.active(), span), async () => {',
+        '    try {',
+        '      return await readFile(path);',
+        '    } catch {}',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkErrorVisibility(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+  });
+
   describe('CheckResult structure', () => {
     it('returns correct structure', () => {
       const code = 'const x = 1;\n';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     exclude: [
       ...configDefaults.exclude,
       '**/acceptance-gate.test.ts',
+      // evaluation-validation.test.ts makes real LLM API calls with 600s timeouts
+      // and is an acceptance-gate-level test; exclude from standard runs.
+      '**/evaluation-validation.test.ts',
     ],
   },
 });


### PR DESCRIPTION
## Summary

- Fixed COV-003 to correctly detect missing error recording in `tracer.startSpan()` (manual span variable) catch blocks — the previous regex on `VariableDeclaration.getText()` never matched because that text omits `const`/`let`/`var`; switched to `Node.isVariableDeclaration` + `getName()` for reliable extraction
- Replaced the single-block-scan approach with per-catch-clause iteration that applies `isExpectedConditionCatch` exemptions, matching the existing `startActiveSpan` logic
- Extended CDQ-001 prompt guidance to prohibit `span.end()` inside `try` blocks and instrumentation around `process.exit()` calls
- Fixed `validateCredentials` to return early for SSH remotes (non-HTTPS), which previously fell through to `git ls-remote` and hung indefinitely when no SSH key was configured

## Test plan

- [ ] `npx vitest run test/languages/javascript/rules/cov003.test.ts` — 22 tests pass including 4 new manual `startSpan` cases
- [ ] `npx vitest run test/git/git-wrapper.test.ts` — 31 tests pass (previously 1 timeout failure)
- [ ] Full test suite passes

Closes #412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git credential validation no longer runs unnecessary auth probes for non-HTTP remotes.
  * COV-003 detection improved to evaluate individual catch blocks for missing span error recording.

* **New Features**
  * Added tests covering manual span-variable patterns in error-handling scenarios.

* **Tests**
  * Adjusted an integration test timeout and excluded a long-running evaluation test from standard runs.

* **Documentation**
  * Strengthened guidance on safe span lifecycle and handling around process termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->