### PR TITLE
refactor: derive source filename from filePath in Tier 2 rule validators

### DIFF
--- a/src/languages/javascript/rules/api001.ts
+++ b/src/languages/javascript/rules/api001.ts
@@ -1,6 +1,8 @@
 // ABOUTME: API-001/003/004 combined Tier 2 check — forbidden import detection.
 // ABOUTME: Scans for OTel SDK internals, vendor-specific SDKs, and OTel non-API packages.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule } from '../../types.ts';
@@ -108,7 +110,7 @@ export function checkForbiddenImports(code: string, filePath: string): CheckResu
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const violations: Array<{
     line: number;

--- a/src/languages/javascript/rules/cdq006.ts
+++ b/src/languages/javascript/rules/cdq006.ts
@@ -1,6 +1,8 @@
 // ABOUTME: CDQ-006 Tier 2 check — expensive attribute computation guarded.
 // ABOUTME: Flags setAttribute calls with expensive values lacking span.isRecording() guard.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
@@ -38,7 +40,7 @@ export function checkIsRecordingGuard(code: string, filePath: string): CheckResu
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const unguarded: Array<{ line: number; detail: string }> = [];
 

--- a/src/languages/javascript/rules/cov001.ts
+++ b/src/languages/javascript/rules/cov001.ts
@@ -1,6 +1,8 @@
 // ABOUTME: COV-001 Tier 2 check — entry points have spans.
 // ABOUTME: Detects Express/Fastify/http.createServer handlers and exported async functions without spans.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
@@ -61,7 +63,7 @@ export function checkEntryPointSpans(code: string, filePath: string): CheckResul
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const unspanned: Array<{ line: number; description: string }> = [];
 

--- a/src/languages/javascript/rules/cov002.ts
+++ b/src/languages/javascript/rules/cov002.ts
@@ -1,6 +1,8 @@
 // ABOUTME: COV-002 Tier 2 check — outbound calls have spans.
 // ABOUTME: AST-based detection of outbound call sites (fetch, HTTP, DB, messaging) without enclosing spans.
 
+import { basename } from 'node:path';
+
 import { Project, Node, SyntaxKind } from 'ts-morph';
 import type { CallExpression, Identifier, SourceFile } from 'ts-morph';
 
@@ -112,7 +114,7 @@ export function checkOutboundCallSpans(code: string, filePath: string): CheckRes
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
   const importSources = collectImportSources(sourceFile);
 
   const unspannedCalls: Array<{ line: number; callText: string }> = [];

--- a/src/languages/javascript/rules/cov003.ts
+++ b/src/languages/javascript/rules/cov003.ts
@@ -1,6 +1,8 @@
 // ABOUTME: COV-003 Tier 2 check — failable operations have error visibility.
 // ABOUTME: Verifies that spans around failable operations include error recording (recordException/setStatus).
 
+import { basename } from 'node:path';
+
 import { Project, Node, SyntaxKind } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule, RuleInput } from '../../types.ts';
@@ -37,7 +39,7 @@ export function checkErrorVisibility(code: string, filePath: string): CheckResul
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const issues: Array<{ line: number; description: string }> = [];
 

--- a/src/languages/javascript/rules/cov004.ts
+++ b/src/languages/javascript/rules/cov004.ts
@@ -1,6 +1,8 @@
 // ABOUTME: COV-004 Tier 2 check — async operations have spans.
 // ABOUTME: Flags async functions and functions containing await without enclosing spans.
 
+import { basename } from 'node:path';
+
 import { Project, Node, SyntaxKind } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule, RuleInput } from '../../types.ts';
@@ -26,7 +28,7 @@ export function checkAsyncOperationSpans(code: string, filePath: string): CheckR
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
   const fileHasInstrumentation = hasSpanCall(code);
 
   const flagged: Array<{ name: string; line: number; reason: string; exported: boolean }> = [];

--- a/src/languages/javascript/rules/cov005.ts
+++ b/src/languages/javascript/rules/cov005.ts
@@ -1,6 +1,8 @@
 // ABOUTME: COV-005 Tier 2 check — domain-specific attributes present.
 // ABOUTME: Compares setAttribute calls against registry-defined required/recommended attributes per span.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type { CheckResult, RegistrySpanDefinition } from '../../../validation/types.ts';
@@ -47,7 +49,7 @@ export function checkDomainAttributes(
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   // Build a lookup from span name to registry definition
   const registryByName = new Map<string, RegistrySpanDefinition>();

--- a/src/languages/javascript/rules/cov006.ts
+++ b/src/languages/javascript/rules/cov006.ts
@@ -1,6 +1,8 @@
 // ABOUTME: COV-006 Tier 2 check — auto-instrumentation preferred over manual spans.
 // ABOUTME: Flags manual spans on operations covered by known auto-instrumentation libraries.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
@@ -54,7 +56,7 @@ export function checkAutoInstrumentationPreference(code: string, filePath: strin
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const flagged: Array<{ line: number; library: string; spanName: string }> = [];
 

--- a/src/languages/javascript/rules/rst002.ts
+++ b/src/languages/javascript/rules/rst002.ts
@@ -1,6 +1,8 @@
 // ABOUTME: RST-002 Tier 2 check — no spans on trivial accessors.
 // ABOUTME: Flags spans on get/set accessor declarations and trivial property accessor methods.
 
+import { basename } from 'node:path';
+
 import { Project, Node, SyntaxKind } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule } from '../../types.ts';
@@ -32,7 +34,7 @@ export function checkTrivialAccessorSpans(code: string, filePath: string): Check
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const flagged: Array<{ name: string; line: number; kind: string }> = [];
 

--- a/src/languages/javascript/rules/rst003.ts
+++ b/src/languages/javascript/rules/rst003.ts
@@ -1,6 +1,8 @@
 // ABOUTME: RST-003 Tier 2 check — no duplicate spans on thin wrappers.
 // ABOUTME: Flags spans on functions whose body is a single return delegating to another function.
 
+import { basename } from 'node:path';
+
 import { Project, Node, SyntaxKind } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule } from '../../types.ts';
@@ -24,7 +26,7 @@ export function checkThinWrapperSpans(code: string, filePath: string): CheckResu
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const flagged: Array<{ name: string; line: number }> = [];
 

--- a/src/languages/javascript/rules/rst004.ts
+++ b/src/languages/javascript/rules/rst004.ts
@@ -1,6 +1,8 @@
 // ABOUTME: RST-004 Tier 2 check — no spans on internal implementation details.
 // ABOUTME: Flags spans on unexported functions and private class methods, exempting I/O boundaries.
 
+import { basename } from 'node:path';
+
 import { Project, Node, SyntaxKind } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
 import type { ValidationRule } from '../../types.ts';
@@ -40,7 +42,7 @@ export function checkInternalDetailSpans(code: string, filePath: string): CheckR
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const flagged: Array<{ name: string; line: number; kind: string }> = [];
 

--- a/src/languages/javascript/rules/sch001.ts
+++ b/src/languages/javascript/rules/sch001.ts
@@ -1,6 +1,8 @@
 // ABOUTME: SCH-001 Tier 2 check — span names match registry operations.
 // ABOUTME: Compares span name literals against span definitions in the resolved Weaver registry.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type Anthropic from '@anthropic-ai/sdk';
@@ -65,7 +67,7 @@ export async function checkSpanNamesMatchRegistry(
   const spanDefs = getSpanDefinitions(registry);
 
   // Extract span info in a single AST pass
-  const { literalNames: spanNames, nonLiteralCount, zeroArgCount } = extractSpanInfo(code);
+  const { literalNames: spanNames, nonLiteralCount, zeroArgCount } = extractSpanInfo(code, filePath);
 
   if (spanNames.length === 0 && nonLiteralCount === 0 && zeroArgCount === 0) {
     return { results: [pass(filePath, 'No span calls found to check.')], judgeTokenUsage: [] };
@@ -357,12 +359,12 @@ interface SpanInfo {
  * Extract span info from startActiveSpan/startSpan calls in a single AST pass.
  * Returns both literal span name entries and a count of non-literal (dynamic) span names.
  */
-function extractSpanInfo(code: string): SpanInfo {
+function extractSpanInfo(code: string, filePath: string): SpanInfo {
   const project = new Project({
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const literalNames: SpanNameEntry[] = [];
   let nonLiteralCount = 0;

--- a/src/languages/javascript/rules/sch002.ts
+++ b/src/languages/javascript/rules/sch002.ts
@@ -1,6 +1,8 @@
 // ABOUTME: SCH-002 Tier 2 check — attribute keys match registry names.
 // ABOUTME: Compares setAttribute/setAttributes key strings against the resolved Weaver registry.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type { CheckResult } from '../../../validation/types.ts';
@@ -46,7 +48,7 @@ export function checkAttributeKeysMatchRegistry(
     return [pass(filePath, 'No registry attributes to check against.')];
   }
 
-  const usedAttributes = extractAttributeKeys(code);
+  const usedAttributes = extractAttributeKeys(code, filePath);
 
   if (usedAttributes.length === 0) {
     return [pass(filePath, 'No setAttribute/setAttributes calls found to check.')];
@@ -91,12 +93,12 @@ interface AttributeKeyEntry {
 /**
  * Extract attribute keys from setAttribute and setAttributes calls.
  */
-function extractAttributeKeys(code: string): AttributeKeyEntry[] {
+function extractAttributeKeys(code: string, filePath: string): AttributeKeyEntry[] {
   const project = new Project({
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const entries: AttributeKeyEntry[] = [];
 

--- a/src/languages/javascript/rules/sch003.ts
+++ b/src/languages/javascript/rules/sch003.ts
@@ -1,6 +1,8 @@
 // ABOUTME: SCH-003 Tier 2 check — attribute values conform to registry types.
 // ABOUTME: Verifies setAttribute values match type constraints (enum members, int, string, boolean).
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type { Expression } from 'ts-morph';
@@ -44,7 +46,7 @@ export function checkAttributeValuesConformToTypes(
     return [pass(filePath, 'No registry type definitions to check against.')];
   }
 
-  const violations = findTypeViolations(code, attrDefs);
+  const violations = findTypeViolations(code, attrDefs, filePath);
 
   if (violations.length === 0) {
     return [pass(filePath, 'All attribute values conform to registry type definitions.')];
@@ -69,12 +71,13 @@ export function checkAttributeValuesConformToTypes(
 function findTypeViolations(
   code: string,
   attrDefs: Map<string, ResolvedRegistryAttribute>,
+  filePath: string,
 ): TypeViolation[] {
   const project = new Project({
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const violations: TypeViolation[] = [];
 

--- a/src/languages/javascript/rules/sch004.ts
+++ b/src/languages/javascript/rules/sch004.ts
@@ -1,6 +1,8 @@
 // ABOUTME: SCH-004 Tier 2 check — no redundant schema entries.
 // ABOUTME: Flags agent-added attribute keys that are near-duplicates of existing registry entries.
 
+import { basename } from 'node:path';
+
 import { Project, Node } from 'ts-morph';
 import type { CallExpression } from 'ts-morph';
 import type Anthropic from '@anthropic-ai/sdk';
@@ -64,7 +66,7 @@ export async function checkNoRedundantSchemaEntries(
     return { results: [pass(filePath, 'No registry attributes to check for redundancy.')], judgeTokenUsage: [] };
   }
 
-  const usedKeys = extractAttributeKeys(code);
+  const usedKeys = extractAttributeKeys(code, filePath);
 
   if (usedKeys.length === 0) {
     return { results: [pass(filePath, 'No setAttribute calls found to check.')], judgeTokenUsage: [] };
@@ -209,12 +211,12 @@ interface AttributeKeyEntry {
 /**
  * Extract attribute keys from setAttribute calls.
  */
-function extractAttributeKeys(code: string): AttributeKeyEntry[] {
+function extractAttributeKeys(code: string, filePath: string): AttributeKeyEntry[] {
   const project = new Project({
     compilerOptions: { allowJs: true },
     useInMemoryFileSystem: true,
   });
-  const sourceFile = project.createSourceFile('check.js', code);
+  const sourceFile = project.createSourceFile(basename(filePath), code);
 
   const entries: AttributeKeyEntry[] = [];
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary

- Replaces hardcoded `'check.js'` with `basename(filePath)` in all 15 validators in `src/languages/javascript/rules/`
- Four helper functions (`extractSpanInfo`, `extractAttributeKeys` ×2, `findTypeViolations`) required `filePath` to be threaded through their signatures to make it available at the `createSourceFile` call site
- ts-morph now receives the correct file extension, enabling proper TypeScript parsing when `.ts` files are passed to these validators

## Test plan

- [x] All 2012 existing tests pass
- [x] Build, typecheck, and lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal source file naming consistency during analysis across all JavaScript validation rules. The analyzer now uses actual file basenames instead of generic identifiers when processing code, enhancing internal traceability and alignment with file system conventions without changing detection logic or output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->