### PR TITLE
Smart checkpoint rollback: revert only stack-trace-identified failing files

### DIFF
--- a/src/coordinator/coordinate.ts
+++ b/src/coordinator/coordinate.ts
@@ -43,7 +43,7 @@ import { hasTestSuite as defaultHasTestSuite } from './test-suite-detection.ts';
 export function executeProjectTests(
   projectDir: string,
   testCommand: string,
-): Promise<{ passed: boolean; error?: string }> {
+): Promise<{ passed: boolean; error?: string; output?: string }> {
   const cmd = process.platform === 'win32' ? 'cmd.exe' : 'sh';
   const args = process.platform === 'win32' ? ['/c', testCommand] : ['-c', testCommand];
 
@@ -52,10 +52,11 @@ export function executeProjectTests(
       cwd: projectDir,
       timeout: 300_000,
       maxBuffer: 10 * 1024 * 1024,
-    }, (error, _stdout, stderr) => {
+    }, (error, stdout, stderr) => {
       if (error) {
         const errorMsg = stderr?.trim() || error.message;
-        resolve({ passed: false, error: errorMsg });
+        const combined = [stdout?.trim(), stderr?.trim()].filter(Boolean).join('\n');
+        resolve({ passed: false, error: errorMsg, output: combined || undefined });
         return;
       }
       resolve({ passed: true });
@@ -116,7 +117,7 @@ export interface CoordinateDeps {
   /** Injectable test suite detection for checkpoint test wiring. */
   hasTestSuite?: (testCommand: string, projectDir?: string) => Promise<boolean>;
   /** Injectable test runner for checkpoint tests. Runs test command without OTLP overrides. */
-  executeProjectTests?: (projectDir: string, testCommand: string) => Promise<{ passed: boolean; error?: string }>;
+  executeProjectTests?: (projectDir: string, testCommand: string) => Promise<{ passed: boolean; error?: string; output?: string }>;
   /** Write file content for end-of-run rollback. Defaults to fs/promises writeFile. */
   writeFileForRollback?: (filePath: string, content: string) => Promise<void>;
   /** Restore schema extensions file from snapshot for end-of-run rollback. */

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -57,6 +57,49 @@ export async function validateRegistryCheck(
 }
 
 /**
+ * Parse stack trace output to identify which source files in the checkpoint window caused a
+ * test failure. Matches "at ..." stack frame lines against the absolute paths of window files.
+ *
+ * Handles both absolute paths (`/abs/path/file.js:line`) and relative paths (`src/file.js:line`).
+ * Skips Node.js internal frames (node: prefix). Test files in stack traces are still traversed;
+ * if a test file appears, the src file one frame deeper is also checked.
+ *
+ * @param output - Combined stdout + stderr from the test runner
+ * @param windowPaths - Absolute paths of files in the current checkpoint window
+ * @returns Subset of windowPaths that appear in the stack trace, deduplicated, in window order
+ */
+export function parseFailingSourceFiles(output: string, windowPaths: string[]): string[] {
+  if (!output || windowPaths.length === 0) return [];
+
+  // Match "at ..." stack frame file references. Captures the path before `:linenum`.
+  // [^\s(]+\s+\(  — optional "FunctionName (" prefix
+  // [^\s():]+     — file path (stops at colon, so line numbers are not included)
+  // (?=:\d)       — lookahead: must be followed by :digits (confirms it's a file:line reference)
+  const framePattern = /\bat\s+(?:[^\s(]+\s+\()?([^\s():]+\.(?:js|ts|mjs|cjs))(?=:\d)/g;
+
+  const foundPaths = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = framePattern.exec(output)) !== null) {
+    foundPaths.add(match[1]);
+  }
+
+  if (foundPaths.size === 0) return [];
+
+  const matched: string[] = [];
+  for (const windowPath of windowPaths) {
+    for (const found of foundPaths) {
+      // Match if exact (absolute path) or if window path ends with the relative found path
+      if (windowPath === found || windowPath.endsWith(`/${found}`)) {
+        matched.push(windowPath);
+        break;
+      }
+    }
+  }
+
+  return matched;
+}
+
+/**
  * Patterns that indicate a file already has OpenTelemetry instrumentation.
  * Uses string/regex matching (no AST) for speed — this is an optimization
  * to avoid wasting LLM calls on obviously-instrumented files.
@@ -158,7 +201,7 @@ interface DispatchFilesOptions {
   /** When true, revert every file after processing and skip schema checkpoints. */
   dryRun?: boolean;
   /** Injectable test runner for checkpoint test execution (NDS-002). */
-  runTestCommand?: (projectDir: string, testCommand: string) => Promise<{ passed: boolean; error?: string }>;
+  runTestCommand?: (projectDir: string, testCommand: string) => Promise<{ passed: boolean; error?: string; output?: string }>;
   /** Whether baseline tests passed before instrumentation. When false, checkpoint test failure does not trigger rollback. */
   baselineTestPassed?: boolean;
   /** Mutable output — populated at end of dispatch with checkpoint window state for end-of-run rollback. */
@@ -503,12 +546,14 @@ export async function dispatchFiles(
           // Run BEFORE firing callback so the callback receives a composite result.
           let checkpointPassed = checkpointResult.passed;
           let testFailedAtCheckpoint = false;
+          let lastTestOutput: string | undefined;
           if (checkpointResult.passed && options?.runTestCommand && await hasTestSuite(config.testCommand, projectDir)) {
             try {
               const testResult = await options.runTestCommand(projectDir, config.testCommand);
               if (!testResult.passed) {
                 checkpointPassed = false;
                 testFailedAtCheckpoint = true;
+                lastTestOutput = testResult.output;
                 if (extWarnings) {
                   extWarnings.push(
                     `Checkpoint test run failed at file ${i + 1}/${total} ` +
@@ -552,37 +597,94 @@ export async function dispatchFiles(
             locSinceLastCheckpoint = 0;
             lastCheckpointResultIndex = results.length;
           } else if (testFailedAtCheckpoint && options?.baselineTestPassed === true) {
-            // Test failure with passing baseline — roll back files in checkpoint window
-            for (const tracked of checkpointWindowFiles) {
+            // Test failure with passing baseline — attempt smart (targeted) rollback first.
+            // Parse stack trace to identify which window files caused the failure.
+            // Only revert those files and re-run; fall back to full rollback on re-run failure
+            // or when no failing files can be identified from the output.
+            const failingFiles = lastTestOutput
+              ? parseFailingSourceFiles(lastTestOutput, checkpointWindowFiles.map(f => f.path))
+              : [];
+
+            let didSmartRollback = false;
+            if (failingFiles.length > 0 && options.runTestCommand) {
+              // Step 1: Revert only the identified failing files
+              for (const tracked of checkpointWindowFiles) {
+                if (failingFiles.includes(tracked.path)) {
+                  try {
+                    await writeFile(tracked.path, tracked.originalContent, 'utf-8');
+                  } catch { /* best-effort file restore */ }
+                  results[tracked.resultIndex].status = 'failed';
+                  results[tracked.resultIndex].reason =
+                    `Smart rollback: identified as failing file in checkpoint test at file ${i + 1}/${total}`;
+                }
+              }
+
+              // Step 2: Re-run tests to verify remaining window files are clean
+              let reRunPassed = false;
               try {
-                await writeFile(tracked.path, tracked.originalContent, 'utf-8');
-              } catch { /* best-effort file restore */ }
-              results[tracked.resultIndex].status = 'failed';
-              results[tracked.resultIndex].reason =
-                `Rolled back: checkpoint test failure at file ${i + 1}/${total}`;
+                const reRunResult = await options.runTestCommand(projectDir, config.testCommand);
+                reRunPassed = reRunResult.passed;
+              } catch { /* re-run infrastructure failure → treat as still failing */ }
+
+              if (reRunPassed) {
+                // Targeted rollback succeeded — remaining window files are clean
+                didSmartRollback = true;
+                try {
+                  callbacks?.onCheckpointRollback?.(failingFiles);
+                } catch { /* callback failure must not abort dispatch */ }
+                if (extWarnings) {
+                  const keptCount = checkpointWindowFiles.length - failingFiles.length;
+                  extWarnings.push(
+                    `Smart rollback: reverted ${failingFiles.length} file(s) at checkpoint ` +
+                    `(file ${i + 1}/${total}), ${keptCount} file(s) kept`,
+                  );
+                }
+              } else {
+                // Re-run still fails — revert remaining (not yet rolled back) window files
+                for (const tracked of checkpointWindowFiles) {
+                  if (!failingFiles.includes(tracked.path)) {
+                    try {
+                      await writeFile(tracked.path, tracked.originalContent, 'utf-8');
+                    } catch { /* best-effort file restore */ }
+                    results[tracked.resultIndex].status = 'failed';
+                    results[tracked.resultIndex].reason =
+                      `Rolled back: checkpoint test failure (smart rollback fallback) at file ${i + 1}/${total}`;
+                  }
+                }
+              }
             }
 
-            // Restore schema extensions to last passing checkpoint state
-            if (registryDir && checkpointExtensionsSnapshot !== undefined) {
-              accumulatedExtensions.length = checkpointAccumulatorLength;
-              seenExtensions.clear();
-              for (const ext of accumulatedExtensions) seenExtensions.add(ext);
-              try {
-                await restoreFn(registryDir, checkpointExtensionsSnapshot);
-              } catch { /* best-effort restore */ }
+            if (!didSmartRollback && failingFiles.length === 0) {
+              // No stack trace match — full window rollback
+              for (const tracked of checkpointWindowFiles) {
+                try {
+                  await writeFile(tracked.path, tracked.originalContent, 'utf-8');
+                } catch { /* best-effort file restore */ }
+                results[tracked.resultIndex].status = 'failed';
+                results[tracked.resultIndex].reason =
+                  `Rolled back: checkpoint test failure at file ${i + 1}/${total}`;
+              }
             }
 
-            // Fire rollback callback
-            try {
-              callbacks?.onCheckpointRollback?.(checkpointWindowFiles.map(f => f.path));
-            } catch { /* callback failure must not abort dispatch */ }
-
-            // Surface rollback in warnings
-            if (extWarnings) {
-              extWarnings.push(
-                `Rolled back ${checkpointWindowFiles.length} file(s) at checkpoint ` +
-                `(file ${i + 1}/${total}) due to test failure`,
-              );
+            if (!didSmartRollback) {
+              // Full rollback path: restore schema extensions and fire callback
+              if (registryDir && checkpointExtensionsSnapshot !== undefined) {
+                accumulatedExtensions.length = checkpointAccumulatorLength;
+                seenExtensions.clear();
+                for (const ext of accumulatedExtensions) seenExtensions.add(ext);
+                try {
+                  await restoreFn(registryDir, checkpointExtensionsSnapshot);
+                } catch { /* best-effort restore */ }
+              }
+              try {
+                callbacks?.onCheckpointRollback?.(checkpointWindowFiles.map(f => f.path));
+              } catch { /* callback failure must not abort dispatch */ }
+              if (extWarnings) {
+                extWarnings.push(
+                  `Rolled back ${checkpointWindowFiles.length} file(s) at checkpoint ` +
+                  `(file ${i + 1}/${total}) due to test failure`,
+                );
+              }
             }
 
             // Reset window and take new snapshot — always continue after rollback

--- a/test/coordinator/dispatch-checkpoint-rollback.test.ts
+++ b/test/coordinator/dispatch-checkpoint-rollback.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for checkpoint test failure rollback in the dispatch loop.
-// ABOUTME: Verifies file content restoration, result status updates, schema extension rollback, and continuation after rollback.
+// ABOUTME: Verifies file content restoration, result status updates, schema extension rollback, and smart targeted rollback.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises';
@@ -8,7 +8,7 @@ import { tmpdir } from 'node:os';
 import type { FileResult } from '../../src/fix-loop/types.ts';
 import type { AgentConfig } from '../../src/config/schema.ts';
 
-import { dispatchFiles } from '../../src/coordinator/dispatch.ts';
+import { dispatchFiles, parseFailingSourceFiles } from '../../src/coordinator/dispatch.ts';
 import type { DispatchFilesDeps, CoordinatorCallbacks, DispatchCheckpointConfig } from '../../src/coordinator/types.ts';
 
 const FIXTURES_DIR = resolve(import.meta.dirname, '../fixtures/weaver-registry');
@@ -404,5 +404,280 @@ describe('dispatchFiles — checkpoint test failure rollback', () => {
       expect(rollbackWarning).toBeDefined();
       expect(warnings.some(w => w.includes('ReferenceError: tracer is not defined'))).toBe(true);
     });
+  });
+});
+
+describe('parseFailingSourceFiles', () => {
+  it('extracts absolute path from stack frame with function name', () => {
+    const output = `
+  ● Test › foo
+
+    ReferenceError: tracer is not defined
+
+      at Object.<anonymous> (/project/src/summary-graph.js:45:12)
+      at processTicksAndRejections (node:internal/process/task_queues:95:5)
+    `;
+    const windowPaths = ['/project/src/summary-graph.js', '/project/src/other.js'];
+    expect(parseFailingSourceFiles(output, windowPaths)).toEqual(['/project/src/summary-graph.js']);
+  });
+
+  it('extracts bare absolute path stack frame', () => {
+    const output = `at /project/src/journal-manager.js:123:45`;
+    const windowPaths = ['/project/src/journal-manager.js', '/project/src/unrelated.js'];
+    expect(parseFailingSourceFiles(output, windowPaths)).toEqual(['/project/src/journal-manager.js']);
+  });
+
+  it('extracts relative path matched against window absolute paths', () => {
+    const output = `at src/summary-graph.js:45:12`;
+    const windowPaths = ['/project/src/summary-graph.js', '/project/src/other.js'];
+    expect(parseFailingSourceFiles(output, windowPaths)).toEqual(['/project/src/summary-graph.js']);
+  });
+
+  it('skips test file frames and finds src frame one level deeper', () => {
+    const output = `
+      at /project/test/summary-graph.test.js:12:3
+      at Object.<anonymous> (/project/src/summary-graph.js:45:12)
+    `;
+    const windowPaths = ['/project/src/summary-graph.js'];
+    expect(parseFailingSourceFiles(output, windowPaths)).toEqual(['/project/src/summary-graph.js']);
+  });
+
+  it('returns multiple matching files when multiple appear in stack trace', () => {
+    const output = `
+      at /project/src/file-a.js:10:5
+      at /project/src/file-b.js:20:5
+    `;
+    const windowPaths = ['/project/src/file-a.js', '/project/src/file-b.js', '/project/src/file-c.js'];
+    const result = parseFailingSourceFiles(output, windowPaths);
+    expect(result).toContain('/project/src/file-a.js');
+    expect(result).toContain('/project/src/file-b.js');
+    expect(result).not.toContain('/project/src/file-c.js');
+  });
+
+  it('returns empty array when no window files appear in stack trace', () => {
+    const output = `at node:internal/process/task_queues:95:5`;
+    const windowPaths = ['/project/src/summary-graph.js'];
+    expect(parseFailingSourceFiles(output, windowPaths)).toEqual([]);
+  });
+
+  it('returns empty array for empty output', () => {
+    expect(parseFailingSourceFiles('', ['/project/src/foo.js'])).toEqual([]);
+  });
+
+  it('returns empty array for empty window paths', () => {
+    expect(parseFailingSourceFiles('at /project/src/foo.js:1:1', [])).toEqual([]);
+  });
+
+  it('does not duplicate a file appearing multiple times in stack trace', () => {
+    const output = `
+      at /project/src/foo.js:10:5
+      at /project/src/foo.js:20:5
+    `;
+    const result = parseFailingSourceFiles(output, ['/project/src/foo.js']);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('dispatchFiles — smart checkpoint rollback (targeted revert)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'smart-rollback-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function createFile(name: string, content = 'function x() {}'): Promise<string> {
+    const filePath = join(tmpDir, name);
+    await writeFile(filePath, content, 'utf-8');
+    return filePath;
+  }
+
+  function makeDepsWithDiskWrite(overrides: Partial<DispatchFilesDeps> = {}): DispatchFilesDeps {
+    return {
+      resolveSchema: vi.fn().mockResolvedValue({ resolved: true }),
+      instrumentWithRetry: vi.fn().mockImplementation(async (filePath: string) => {
+        await writeFile(filePath, '// INSTRUMENTED', 'utf-8');
+        return {
+          path: filePath,
+          status: 'success' as const,
+          spansAdded: 1,
+          librariesNeeded: [],
+          schemaExtensions: [],
+          attributesCreated: 0,
+          validationAttempts: 1,
+          validationStrategyUsed: 'initial-generation' as const,
+          tokenUsage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        };
+      }),
+      ...overrides,
+    };
+  }
+
+  const passingCheckpointConfig: DispatchCheckpointConfig = {
+    registryDir: resolve(import.meta.dirname, '../fixtures/weaver-registry/valid-modified'),
+    baselineSnapshotDir: resolve(import.meta.dirname, '../fixtures/weaver-registry/baseline'),
+  };
+
+  it('reverts only the identified failing file, leaving other window files instrumented', async () => {
+    const originalA = 'function a() {}';
+    const originalB = 'function b() {}';
+    const files = await Promise.all([
+      createFile('a.js', originalA),
+      createFile('b.js', originalB),
+    ]);
+
+    const config = makeConfig({ schemaCheckpointInterval: 2, testCommand: 'npm test' });
+
+    // First test run fails with b.js in the stack trace; re-run passes
+    let callCount = 0;
+    await dispatchFiles(files, tmpDir, config, undefined, {
+      deps: makeDepsWithDiskWrite(),
+      checkpoint: passingCheckpointConfig,
+      runTestCommand: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            passed: false,
+            error: 'ReferenceError',
+            output: `at Object.<anonymous> (${files[1]}:10:5)`,
+          };
+        }
+        // Re-run after targeted rollback passes
+        return { passed: true };
+      },
+      baselineTestPassed: true,
+    });
+
+    // a.js should remain instrumented (not rolled back)
+    const contentA = await readFile(files[0], 'utf-8');
+    expect(contentA).toBe('// INSTRUMENTED');
+
+    // b.js should be reverted to original
+    const contentB = await readFile(files[1], 'utf-8');
+    expect(contentB).toBe(originalB);
+  });
+
+  it('marks only the identified failing file as failed, other window files stay succeeded', async () => {
+    const files = await Promise.all([
+      createFile('a.js'),
+      createFile('b.js'),
+    ]);
+
+    const config = makeConfig({ schemaCheckpointInterval: 2, testCommand: 'npm test' });
+
+    let callCount = 0;
+    const results = await dispatchFiles(files, tmpDir, config, undefined, {
+      deps: makeDepsWithDiskWrite(),
+      checkpoint: passingCheckpointConfig,
+      runTestCommand: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            passed: false,
+            error: 'ReferenceError',
+            output: `at Object.<anonymous> (${files[1]}:10:5)`,
+          };
+        }
+        return { passed: true };
+      },
+      baselineTestPassed: true,
+    });
+
+    expect(results[0].status).toBe('success');
+    expect(results[1].status).toBe('failed');
+    expect(results[1].reason).toMatch(/smart rollback|targeted rollback/i);
+  });
+
+  it('falls back to full window rollback when re-run still fails after targeted revert', async () => {
+    const originalA = 'function a() {}';
+    const originalB = 'function b() {}';
+    const files = await Promise.all([
+      createFile('a.js', originalA),
+      createFile('b.js', originalB),
+    ]);
+
+    const config = makeConfig({ schemaCheckpointInterval: 2, testCommand: 'npm test' });
+
+    let callCount = 0;
+    const results = await dispatchFiles(files, tmpDir, config, undefined, {
+      deps: makeDepsWithDiskWrite(),
+      checkpoint: passingCheckpointConfig,
+      runTestCommand: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            passed: false,
+            error: 'ReferenceError',
+            output: `at Object.<anonymous> (${files[1]}:10:5)`,
+          };
+        }
+        // Re-run after targeted rollback ALSO fails — full fallback
+        return { passed: false, error: 'Still failing' };
+      },
+      baselineTestPassed: true,
+    });
+
+    // Both files should be rolled back (full fallback)
+    const contentA = await readFile(files[0], 'utf-8');
+    expect(contentA).toBe(originalA);
+    expect(results[0].status).toBe('failed');
+    expect(results[1].status).toBe('failed');
+  });
+
+  it('falls back to full window rollback when no failing files identified in stack trace', async () => {
+    const originalA = 'function a() {}';
+    const originalB = 'function b() {}';
+    const files = await Promise.all([
+      createFile('a.js', originalA),
+      createFile('b.js', originalB),
+    ]);
+
+    const config = makeConfig({ schemaCheckpointInterval: 2, testCommand: 'npm test' });
+
+    const results = await dispatchFiles(files, tmpDir, config, undefined, {
+      deps: makeDepsWithDiskWrite(),
+      checkpoint: passingCheckpointConfig,
+      runTestCommand: async () => ({
+        passed: false,
+        error: 'Some error',
+        output: 'at node:internal/process/task_queues:95:5',
+      }),
+      baselineTestPassed: true,
+    });
+
+    // No files identified → full rollback
+    const contentA = await readFile(files[0], 'utf-8');
+    const contentB = await readFile(files[1], 'utf-8');
+    expect(contentA).toBe(originalA);
+    expect(contentB).toBe(originalB);
+    expect(results[0].status).toBe('failed');
+    expect(results[1].status).toBe('failed');
+  });
+
+  it('falls back to full window rollback when output field is absent', async () => {
+    const originalA = 'function a() {}';
+    const files = await Promise.all([
+      createFile('a.js', originalA),
+      createFile('b.js', originalA),
+    ]);
+
+    const config = makeConfig({ schemaCheckpointInterval: 2, testCommand: 'npm test' });
+
+    const results = await dispatchFiles(files, tmpDir, config, undefined, {
+      deps: makeDepsWithDiskWrite(),
+      checkpoint: passingCheckpointConfig,
+      runTestCommand: async () => ({
+        passed: false,
+        error: 'ReferenceError: tracer is not defined',
+        // No output field — old runner interface
+      }),
+      baselineTestPassed: true,
+    });
+
+    expect(results[0].status).toBe('failed');
+    expect(results[1].status).toBe('failed');
   });
 });


### PR DESCRIPTION
## Summary

- Parses test failure output for `at src/...js:NNN` stack frames to identify which files in the checkpoint window caused the failure
- Reverts only those files and re-runs tests; if the re-run passes, the remaining window files are kept as successful
- Falls back to full window rollback when no files are identified, or when the re-run still fails after targeted revert
- Captures stdout from `executeProjectTests` so stack traces (typically on stdout) are available alongside stderr

## Test plan

- [ ] `parseFailingSourceFiles` unit tests: absolute paths, relative paths, multiple files, no matches, test file frames, dedup
- [ ] Smart rollback dispatch tests: targeted revert leaves innocent files intact, full fallback on re-run failure, full fallback when no output
- [ ] All 2026 existing tests still pass
- [ ] Typecheck clean

Closes #437