### PR TITLE
SCH-004 judge: type-based pre-filtering and post-validation to eliminate false positives

### DIFF
--- a/src/languages/javascript/rules/sch004.ts
+++ b/src/languages/javascript/rules/sch004.ts
@@ -10,8 +10,116 @@ import type { CheckResult } from '../../../validation/types.ts';
 import type { TokenUsage } from '../../../agent/schema.ts';
 import { callJudge } from '../../../validation/judge.ts';
 import type { JudgeOptions } from '../../../validation/judge.ts';
-import { parseResolvedRegistry, getAllAttributeNames } from '../../../validation/tier2/registry-types.ts';
+import {
+  parseResolvedRegistry,
+  getAllAttributeNames,
+  getAttributeDefinitions,
+  isEnumType,
+} from '../../../validation/tier2/registry-types.ts';
+import type { ResolvedRegistryAttribute } from '../../../validation/tier2/registry-types.ts';
 import type { ValidationRule } from '../../types.ts';
+
+/**
+ * Inferred value type of a span.setAttribute(key, value) value expression.
+ * 'unknown' means the type could not be determined from the AST.
+ */
+type InferredType = 'string' | 'int' | 'double' | 'boolean' | 'unknown';
+
+/**
+ * Infer the value type from a ts-morph AST node for the setAttribute value argument.
+ * Handles literals, .length property access, and common call expression patterns.
+ * Returns 'unknown' when the type cannot be determined statically.
+ */
+function inferValueType(valueNode: Node): InferredType {
+  // String literals: "foo", 'bar'
+  if (Node.isStringLiteral(valueNode)) return 'string';
+
+  // Template literals: `${x}` or `literal`
+  if (Node.isTemplateExpression(valueNode) || Node.isNoSubstitutionTemplateLiteral(valueNode)) {
+    return 'string';
+  }
+
+  // Numeric literals: 42 → int, 3.14 → double
+  if (Node.isNumericLiteral(valueNode)) {
+    return valueNode.getText().includes('.') ? 'double' : 'int';
+  }
+
+  // Boolean literals: true, false
+  const text = valueNode.getText();
+  if (text === 'true' || text === 'false') return 'boolean';
+
+  // Property access ending in .length: arr.length → int
+  if (Node.isPropertyAccessExpression(valueNode) && valueNode.getName() === 'length') {
+    return 'int';
+  }
+
+  // Prefix unary negation: !x → boolean
+  if (Node.isPrefixUnaryExpression(valueNode) && valueNode.getText().startsWith('!')) {
+    return 'boolean';
+  }
+
+  // Call expressions: parseInt, parseFloat, Number, Boolean, String, .toString()
+  if (Node.isCallExpression(valueNode)) {
+    const exprText = valueNode.getExpression().getText();
+    if (exprText === 'parseInt' || exprText === 'Math.round' || exprText === 'Math.floor' ||
+        exprText === 'Math.ceil' || exprText === 'Number') {
+      return 'int';
+    }
+    if (exprText === 'parseFloat') return 'double';
+    if (exprText === 'Boolean') return 'boolean';
+    if (exprText === 'String' || exprText.endsWith('.toString') || exprText.endsWith('.join') ||
+        exprText.endsWith('.trim') || exprText.endsWith('.toUpperCase') ||
+        exprText.endsWith('.toLowerCase')) {
+      return 'string';
+    }
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Normalize a registry attribute type to a comparable string.
+ * Enum types normalize to 'string' (enum values are strings).
+ * Array types like 'string[]' normalize to 'string'.
+ */
+function normalizeRegistryType(type: ResolvedRegistryAttribute['type']): string | undefined {
+  if (!type) return undefined;
+  if (isEnumType(type)) return 'string';
+  if (type === 'string[]') return 'string';
+  return type;
+}
+
+/**
+ * Check whether a novel attribute's inferred type is compatible with a registry attribute type.
+ * 'unknown' inferred type is always compatible (can't determine → don't pre-filter).
+ * int and double are mutually compatible (both numeric).
+ */
+function isTypeCompatible(
+  novelType: InferredType,
+  registryAttrType: ResolvedRegistryAttribute['type'],
+): boolean {
+  if (novelType === 'unknown') return true;
+  const registryType = normalizeRegistryType(registryAttrType);
+  if (!registryType) return true;
+
+  // Numeric types are compatible with each other
+  if ((novelType === 'int' || novelType === 'double') &&
+      (registryType === 'int' || registryType === 'double')) {
+    return true;
+  }
+
+  return novelType === registryType;
+}
+
+/**
+ * Attempt to extract a registry attribute name from a judge suggestion string.
+ * Suggestions typically read: 'Use "attr.name" instead of ...'
+ * Returns the first quoted dotted-identifier found, or null if none.
+ */
+function extractAttributeFromSuggestion(suggestion: string): string | null {
+  const match = suggestion.match(/["']([a-z][a-z0-9._-]*)["']/);
+  return match?.[1] ?? null;
+}
 
 interface RedundancyFlag {
   key: string;
@@ -125,13 +233,28 @@ export async function checkNoRedundantSchemaEntries(
   const judgeTokenUsage: TokenUsage[] = [];
 
   if (judgeDeps && unflaggedNovelKeys.length > 0) {
+    // Build attribute definitions map once for pre-filtering and post-validation
+    const attrDefs = getAttributeDefinitions(registry);
+
     for (const entry of unflaggedNovelKeys) {
+      // Pre-filter: only pass registry attributes whose value type is compatible with the novel
+      // attribute's inferred type. Prevents the judge from flagging type-incompatible pairs
+      // (e.g., a string label vs. an integer count) as semantic duplicates.
+      const typedCandidates = registryNameList.filter(name => {
+        const def = attrDefs.get(name);
+        return isTypeCompatible(entry.inferredType, def?.type);
+      });
+
+      // If no compatible candidates exist, this novel attribute cannot be a semantic
+      // duplicate of any registry attribute with a compatible value type — skip the judge.
+      if (typedCandidates.length === 0) continue;
+
       const result = await callJudge(
         {
           ruleId: 'SCH-004',
           context: `Novel attribute key "${entry.key}" at line ${entry.line} is not in the registry and has no high token-similarity match.`,
-          question: `Is attribute "${entry.key}" semantically distinct from all registered attribute keys? Answer true if it captures a unique concept not already represented in the registry. Answer false if it is a semantic duplicate of an existing key — and if so, which registered key should be used instead? Important: respect domain boundaries. Application-domain attributes (e.g., generated_count, section_count) are NOT duplicates of OTel semantic convention fields (e.g., gen_ai.usage.output_tokens) even if they share similar words. Only flag as duplicates when the keys measure the same thing in the same domain.`,
-          candidates: registryNameList,
+          question: `Is attribute "${entry.key}" semantically distinct from all registered attribute keys? Answer true if it captures a unique concept not already represented in the registry. Answer false if it is a semantic duplicate of an existing key — and if so, which registered key should be used instead? Important: respect domain boundaries. Application-domain attributes (e.g., generated_count, section_count) are NOT duplicates of OTel semantic convention fields (e.g., gen_ai.usage.output_tokens) even if they share similar words. Only flag as duplicates when the keys measure the same thing in the same domain. Attributes with different value types (e.g., a string label vs. an integer count) are NOT semantic duplicates even if they describe the same concept.`,
+          candidates: typedCandidates,
         },
         judgeDeps.client,
         judgeDeps.options,
@@ -146,6 +269,19 @@ export async function checkNoRedundantSchemaEntries(
         }
 
         if (!result.verdict.answer && result.verdict.confidence >= 0.7) {
+          // Post-validate: check that the matched registry attribute is type-compatible.
+          // Safety net for edge cases where the judge suggests an attribute outside the
+          // pre-filtered candidates (e.g., hallucination pointing to a filtered-out attr).
+          const suggestionText = result.verdict.suggestion ?? '';
+          const matchedName = extractAttributeFromSuggestion(suggestionText);
+          if (matchedName) {
+            const matchedAttr = attrDefs.get(matchedName);
+            if (matchedAttr && !isTypeCompatible(entry.inferredType, matchedAttr.type)) {
+              // Type mismatch — discard verdict to prevent false positive finding
+              continue;
+            }
+          }
+
           // Judge says this IS a semantic duplicate (with sufficient confidence)
           const suggestion = result.verdict.suggestion ?? 'Use the matching registry key.';
           judgeResults.push({
@@ -206,6 +342,7 @@ function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
 interface AttributeKeyEntry {
   key: string;
   line: number;
+  inferredType: InferredType;
 }
 
 /**
@@ -240,7 +377,7 @@ function extractAttributeKeys(code: string, filePath: string): AttributeKeyEntry
 }
 
 /**
- * Extract attribute key from span.setAttribute("key", value).
+ * Extract attribute key and infer value type from span.setAttribute("key", value).
  */
 function extractFromSetAttribute(
   callExpr: CallExpression,
@@ -255,7 +392,8 @@ function extractFromSetAttribute(
     const key = firstArg.getLiteralValue();
     if (!seen.has(key)) {
       seen.add(key);
-      entries.push({ key, line: callExpr.getStartLineNumber() });
+      const inferredType = inferValueType(args[1]);
+      entries.push({ key, line: callExpr.getStartLineNumber(), inferredType });
     }
   }
 }

--- a/src/languages/javascript/rules/sch004.ts
+++ b/src/languages/javascript/rules/sch004.ts
@@ -80,12 +80,11 @@ function inferValueType(valueNode: Node): InferredType {
 /**
  * Normalize a registry attribute type to a comparable string.
  * Enum types normalize to 'string' (enum values are strings).
- * Array types like 'string[]' normalize to 'string'.
+ * Collection types like 'string[]' are kept distinct from scalar types.
  */
 function normalizeRegistryType(type: ResolvedRegistryAttribute['type']): string | undefined {
   if (!type) return undefined;
   if (isEnumType(type)) return 'string';
-  if (type === 'string[]') return 'string';
   return type;
 }
 

--- a/test/languages/javascript/rules/sch004-judge.test.ts
+++ b/test/languages/javascript/rules/sch004-judge.test.ts
@@ -223,7 +223,10 @@ describe('SCH-004 judge integration', () => {
   });
 
   describe('judge question construction', () => {
-    it('passes registry attribute names as candidates', async () => {
+    it('passes only type-compatible registry attribute names as candidates', async () => {
+      // codeWithTrulyNovelKey uses span.setAttribute("completely.different.attribute", "value")
+      // "value" is a string literal → inferred type 'string'
+      // Pre-filter: only string-typed registry attributes should be candidates
       const client = makeMockClient({
         verdict: { answer: true, confidence: 0.85 },
         tokenUsage: judgeTokenUsage,
@@ -236,14 +239,35 @@ describe('SCH-004 judge integration', () => {
         { client: client as any },
       );
 
-      // Verify the judge was called with correct candidates
+      // Verify the judge was called with only string-typed candidates
       expect(client._parseFn).toHaveBeenCalledTimes(1);
       const callArgs = client._parseFn.mock.calls[0][0];
       const userMessage = callArgs.messages.find((m: any) => m.role === 'user')?.content;
+      // String-typed attributes included
       expect(userMessage).toContain('http.request.method');
-      expect(userMessage).toContain('http.request.duration');
-      expect(userMessage).toContain('http.response.status_code');
       expect(userMessage).toContain('myapp.order.id');
+      // Non-string attributes filtered out
+      expect(userMessage).not.toContain('http.request.duration');  // double
+      expect(userMessage).not.toContain('http.response.status_code');  // int
+    });
+
+    it('judge question includes type constraint about value type differences', async () => {
+      const client = makeMockClient({
+        verdict: { answer: true, confidence: 0.85 },
+        tokenUsage: judgeTokenUsage,
+      });
+
+      await checkNoRedundantSchemaEntries(
+        codeWithTrulyNovelKey,
+        filePath,
+        resolvedSchema,
+        { client: client as any },
+      );
+
+      expect(client._parseFn).toHaveBeenCalledTimes(1);
+      const callArgs = client._parseFn.mock.calls[0][0];
+      const userMessage = callArgs.messages.find((m: any) => m.role === 'user')?.content;
+      expect(userMessage).toContain('different value types');
     });
   });
 
@@ -404,5 +428,354 @@ describe('SCH-004 judge integration', () => {
       expect(results[0].message).toContain('http_request_duration');
       expect(results[0].message).toContain('http.request.duration');
     });
+  });
+});
+
+describe('SCH-004 type-based pre-filtering', () => {
+  /** Schema with only int-typed registry attributes. */
+  const intOnlySchema = {
+    groups: [{
+      id: 'registry.test',
+      type: 'attribute_group',
+      attributes: [
+        { name: 'db.query.count', type: 'int' },
+        { name: 'http.response.status_code', type: 'int' },
+        { name: 'week.count', type: 'int' },
+      ],
+    }],
+  };
+
+  /** Schema with only string-typed registry attributes. */
+  const stringOnlySchema = {
+    groups: [{
+      id: 'registry.test',
+      type: 'attribute_group',
+      attributes: [
+        { name: 'db.system.name', type: 'string' },
+        { name: 'http.request.method', type: 'string' },
+        { name: 'week.label', type: 'string' },
+      ],
+    }],
+  };
+
+  /** Schema with mixed types. */
+  const mixedSchema = {
+    groups: [{
+      id: 'registry.test',
+      type: 'attribute_group',
+      attributes: [
+        { name: 'week.label', type: 'string' },
+        { name: 'year.label', type: 'string' },
+        { name: 'week.count', type: 'int' },
+      ],
+    }],
+  };
+
+  const filePath = '/tmp/test-file.js';
+
+  function makeMockClient(response: JudgeCallResult | null) {
+    const parseFn = vi.fn().mockResolvedValue(
+      response
+        ? {
+            parsed_output: response.verdict ? {
+              answer: response.verdict.answer,
+              suggestion: response.verdict.suggestion ?? null,
+              confidence: response.verdict.confidence,
+            } : null,
+            usage: {
+              input_tokens: response.tokenUsage.inputTokens,
+              output_tokens: response.tokenUsage.outputTokens,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+            },
+          }
+        : { parsed_output: null, usage: { input_tokens: 0, output_tokens: 0 } },
+    );
+    return { messages: { parse: parseFn }, _parseFn: parseFn };
+  }
+
+  const judgeTokenUsage: TokenUsage = {
+    inputTokens: 100, outputTokens: 40, cacheCreationInputTokens: 0, cacheReadInputTokens: 0,
+  };
+
+  it('does not call judge when boolean attribute has no boolean-typed registry candidates', async () => {
+    // true is a boolean literal → inferred type 'boolean'
+    // intOnlySchema has no boolean attrs → filtered candidates = [] → judge not called
+    const code = [
+      'const { trace } = require("@opentelemetry/api");',
+      'const tracer = trace.getTracer("svc");',
+      'function doWork() {',
+      '  return tracer.startActiveSpan("doWork", (span) => {',
+      '    try {',
+      '      span.setAttribute("summarize.force", true);',
+      '      return 1;',
+      '    } finally { span.end(); }',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const client = makeMockClient({
+      verdict: { answer: false, suggestion: 'Use "week.count"', confidence: 0.9 },
+      tokenUsage: judgeTokenUsage,
+    });
+
+    const { results } = await checkNoRedundantSchemaEntries(
+      code, filePath, intOnlySchema, { client: client as any },
+    );
+
+    expect(client._parseFn).not.toHaveBeenCalled();
+    expect(results[0].passed).toBe(true);
+  });
+
+  it('does not call judge when string attribute has no string-typed registry candidates', async () => {
+    // "2026-W09" is a string literal → inferred type 'string'
+    // intOnlySchema has no string attrs → filtered candidates = [] → judge not called
+    const code = [
+      'const { trace } = require("@opentelemetry/api");',
+      'const tracer = trace.getTracer("svc");',
+      'function doWork() {',
+      '  return tracer.startActiveSpan("doWork", (span) => {',
+      '    try {',
+      '      span.setAttribute("week.label.novel", "2026-W09");',
+      '      return 1;',
+      '    } finally { span.end(); }',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const client = makeMockClient({
+      verdict: { answer: false, suggestion: 'Use "week.count"', confidence: 0.9 },
+      tokenUsage: judgeTokenUsage,
+    });
+
+    const { results } = await checkNoRedundantSchemaEntries(
+      code, filePath, intOnlySchema, { client: client as any },
+    );
+
+    expect(client._parseFn).not.toHaveBeenCalled();
+    expect(results[0].passed).toBe(true);
+  });
+
+  it('does not call judge when .length attribute has no numeric registry candidates', async () => {
+    // dates.length is a .length property access → inferred type 'int'
+    // stringOnlySchema has no int/double attrs → filtered candidates = [] → judge not called
+    const code = [
+      'const { trace } = require("@opentelemetry/api");',
+      'const tracer = trace.getTracer("svc");',
+      'function doWork(dates) {',
+      '  return tracer.startActiveSpan("doWork", (span) => {',
+      '    try {',
+      '      span.setAttribute("date.count.novel", dates.length);',
+      '      return 1;',
+      '    } finally { span.end(); }',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const client = makeMockClient({
+      verdict: { answer: false, suggestion: 'Use "week.label"', confidence: 0.9 },
+      tokenUsage: judgeTokenUsage,
+    });
+
+    const { results } = await checkNoRedundantSchemaEntries(
+      code, filePath, stringOnlySchema, { client: client as any },
+    );
+
+    expect(client._parseFn).not.toHaveBeenCalled();
+    expect(results[0].passed).toBe(true);
+  });
+
+  it('calls judge with only string-compatible candidates when novel attribute is string-typed', async () => {
+    // "2026-W09" is a string literal → inferred type 'string'
+    // "period.identifier" has low Jaccard similarity to all registry attrs → goes to judge tier
+    // Pre-filter: only string-typed candidates should be in the judge's candidates list
+    const code = [
+      'const { trace } = require("@opentelemetry/api");',
+      'const tracer = trace.getTracer("svc");',
+      'function doWork() {',
+      '  return tracer.startActiveSpan("doWork", (span) => {',
+      '    try {',
+      '      span.setAttribute("period.identifier", "2026-W09");',
+      '      return 1;',
+      '    } finally { span.end(); }',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const client = makeMockClient({
+      verdict: { answer: true, confidence: 0.85 },
+      tokenUsage: judgeTokenUsage,
+    });
+
+    await checkNoRedundantSchemaEntries(
+      code, filePath, mixedSchema, { client: client as any },
+    );
+
+    expect(client._parseFn).toHaveBeenCalledTimes(1);
+    const callArgs = client._parseFn.mock.calls[0][0];
+    const userMessage = callArgs.messages.find((m: any) => m.role === 'user')?.content;
+    // String candidates included
+    expect(userMessage).toContain('week.label');
+    expect(userMessage).toContain('year.label');
+    // Int candidates filtered out
+    expect(userMessage).not.toContain('week.count');
+  });
+
+  it('numeric novel attribute (int) is compatible with double registry candidates', async () => {
+    // 42 is a numeric literal → inferred type 'int'
+    // double is compatible with int (both numeric)
+    const doubleSchema = {
+      groups: [{
+        id: 'registry.test',
+        type: 'attribute_group',
+        attributes: [{ name: 'response.time', type: 'double' }],
+      }],
+    };
+
+    const code = [
+      'const { trace } = require("@opentelemetry/api");',
+      'const tracer = trace.getTracer("svc");',
+      'function doWork() {',
+      '  return tracer.startActiveSpan("doWork", (span) => {',
+      '    try {',
+      '      span.setAttribute("request.duration.ms", 42);',
+      '      return 1;',
+      '    } finally { span.end(); }',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const client = makeMockClient({
+      verdict: { answer: true, confidence: 0.85 },
+      tokenUsage: judgeTokenUsage,
+    });
+
+    await checkNoRedundantSchemaEntries(
+      code, filePath, doubleSchema, { client: client as any },
+    );
+
+    // Judge should be called since int and double are compatible
+    expect(client._parseFn).toHaveBeenCalledTimes(1);
+    const callArgs = client._parseFn.mock.calls[0][0];
+    const userMessage = callArgs.messages.find((m: any) => m.role === 'user')?.content;
+    expect(userMessage).toContain('response.time');
+  });
+});
+
+describe('SCH-004 post-verdict type validation', () => {
+  const filePath = '/tmp/test-file.js';
+
+  function makeMockClient(verdict: JudgeCallResult) {
+    const parseFn = vi.fn().mockResolvedValue({
+      parsed_output: verdict.verdict ? {
+        answer: verdict.verdict.answer,
+        suggestion: verdict.verdict.suggestion ?? null,
+        confidence: verdict.verdict.confidence,
+      } : null,
+      usage: {
+        input_tokens: verdict.tokenUsage.inputTokens,
+        output_tokens: verdict.tokenUsage.outputTokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    });
+    return { messages: { parse: parseFn }, _parseFn: parseFn };
+  }
+
+  const judgeTokenUsage: TokenUsage = {
+    inputTokens: 100, outputTokens: 40, cacheCreationInputTokens: 0, cacheReadInputTokens: 0,
+  };
+
+  it('discards finding when judge suggestion points to type-incompatible registry attribute', async () => {
+    // Novel attr: "period.identifier" with string value → inferred 'string'
+    // Low Jaccard similarity to registry attrs → reaches the judge tier
+    // Judge hallucinates: suggests "week.count" (int) despite receiving only string candidates
+    // Post-validate: novel is string, matched is int → discard verdict
+    const mixedSchema = {
+      groups: [{
+        id: 'registry.test',
+        type: 'attribute_group',
+        attributes: [
+          { name: 'year.label', type: 'string' },
+          { name: 'week.count', type: 'int' },
+        ],
+      }],
+    };
+
+    const code = [
+      'const { trace } = require("@opentelemetry/api");',
+      'const tracer = trace.getTracer("svc");',
+      'function doWork() {',
+      '  return tracer.startActiveSpan("doWork", (span) => {',
+      '    try {',
+      '      span.setAttribute("period.identifier", "2026-W09");',
+      '      return 1;',
+      '    } finally { span.end(); }',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const client = makeMockClient({
+      verdict: {
+        answer: false,
+        // Judge hallucinates a suggestion pointing to the int attr (not in pre-filtered candidates)
+        suggestion: 'Use "week.count" instead of "period.identifier".',
+        confidence: 0.9,
+      },
+      tokenUsage: judgeTokenUsage,
+    });
+
+    const { results } = await checkNoRedundantSchemaEntries(
+      code, filePath, mixedSchema, { client: client as any },
+    );
+
+    // Post-validate discards: novel type 'string' vs matched type 'int' → incompatible
+    expect(results).toHaveLength(1);
+    expect(results[0].passed).toBe(true);
+  });
+
+  it('allows finding when judge suggestion points to type-compatible registry attribute', async () => {
+    // Novel attr: "period.identifier" with string value → compatible with string registry attr
+    const mixedSchema = {
+      groups: [{
+        id: 'registry.test',
+        type: 'attribute_group',
+        attributes: [
+          { name: 'year.label', type: 'string' },
+          { name: 'week.count', type: 'int' },
+        ],
+      }],
+    };
+
+    const code = [
+      'const { trace } = require("@opentelemetry/api");',
+      'const tracer = trace.getTracer("svc");',
+      'function doWork() {',
+      '  return tracer.startActiveSpan("doWork", (span) => {',
+      '    try {',
+      '      span.setAttribute("period.identifier", "2026-W09");',
+      '      return 1;',
+      '    } finally { span.end(); }',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const client = makeMockClient({
+      verdict: {
+        answer: false,
+        suggestion: 'Use "year.label" instead of "period.identifier".',
+        confidence: 0.9,
+      },
+      tokenUsage: judgeTokenUsage,
+    });
+
+    const { results } = await checkNoRedundantSchemaEntries(
+      code, filePath, mixedSchema, { client: client as any },
+    );
+
+    // Post-validate allows: novel type 'string' vs matched type 'string' → compatible
+    expect(results).toHaveLength(1);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].message).toContain('period.identifier');
   });
 });


### PR DESCRIPTION
## Summary

- **Pre-filter candidates by value type** — before calling the judge, infer the novel attribute's value type from the `setAttribute` value expression (`.length` → int, string literals → string, `true`/`false` → boolean) and filter candidates to only type-compatible registry attributes. Skips the judge entirely when no compatible candidates exist.
- **Post-verdict type validation** — after a duplicate verdict, extract the matched registry attr from the suggestion and discard if types are incompatible (safety net for hallucination edge cases).
- **Prompt constraint** — adds to the judge question: "Attributes with different value types are NOT semantic duplicates even if they describe the same concept."

## Root cause

The judge hallucinates semantic equivalence between attributes that share a concept word but have incompatible value types. Run-13 showed 67% false positive rate (4 of 6 findings wrong), all following this pattern:
- `week_label` (string "2026-W09") flagged as dup of `week_count` (int)
- `month_label` (string "2026-02") flagged as dup of `month_count` (int)
- `date_count` (int) flagged as dup of `time_window_start` (string ISO date)
- `force` (boolean) flagged as dup of `gen_ai.request.max_tokens` (int)

## Test plan

- [ ] Pre-filter: boolean attribute with no boolean registry candidates → judge not called
- [ ] Pre-filter: string attribute with only int registry candidates → judge not called
- [ ] Pre-filter: `.length` attribute with only string registry candidates → judge not called
- [ ] Pre-filter: int attribute vs double registry candidates → judge called (numeric compat)
- [ ] Pre-filter: string judge candidates list excludes int/double attrs
- [ ] Post-verdict: finding discarded when suggestion points to incompatible type
- [ ] Post-verdict: finding emitted when suggestion points to compatible type
- [ ] Judge question contains "different value types" constraint
- [ ] All 2020 existing tests still pass
- [ ] Typecheck clean

Closes #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced type-aware candidate pre-filtering for semantic duplicate detection—only attributes with compatible inferred value types are evaluated as potential matches.

* **Bug Fixes**
  * Added post-verdict validation to reject duplicate detection results that suggest type-incompatible attributes, improving detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->