### PR TITLE
Smart rollback: clean up schema extensions from reverted files

### DIFF
--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -627,7 +627,34 @@ export async function dispatchFiles(
               } catch { /* re-run infrastructure failure → treat as still failing */ }
 
               if (reRunPassed) {
-                // Targeted rollback succeeded — remaining window files are clean
+                // Targeted rollback succeeded — remaining window files are clean.
+                // Clean up schema extensions from the reverted files: restore to the
+                // pre-window checkpoint snapshot, then re-apply extensions from non-reverted files.
+                if (registryDir && checkpointExtensionsSnapshot !== undefined) {
+                  try {
+                    await restoreFn(registryDir, checkpointExtensionsSnapshot);
+                    accumulatedExtensions.length = checkpointAccumulatorLength;
+                    seenExtensions.clear();
+                    for (const ext of accumulatedExtensions) seenExtensions.add(ext);
+
+                    // Re-add extensions from non-reverted window files
+                    for (const tracked of checkpointWindowFiles) {
+                      if (!failingFiles.includes(tracked.path)) {
+                        for (const ext of (results[tracked.resultIndex].schemaExtensions ?? [])) {
+                          if (!seenExtensions.has(ext)) {
+                            accumulatedExtensions.push(ext);
+                            seenExtensions.add(ext);
+                          }
+                        }
+                      }
+                    }
+
+                    if (accumulatedExtensions.length > checkpointAccumulatorLength) {
+                      await writeExtFn(registryDir, accumulatedExtensions);
+                    }
+                  } catch { /* best-effort extension cleanup */ }
+                }
+
                 didSmartRollback = true;
                 try {
                   callbacks?.onCheckpointRollback?.(failingFiles);

--- a/test/coordinator/dispatch-checkpoint-rollback.test.ts
+++ b/test/coordinator/dispatch-checkpoint-rollback.test.ts
@@ -680,4 +680,51 @@ describe('dispatchFiles — smart checkpoint rollback (targeted revert)', () => 
     expect(results[0].status).toBe('failed');
     expect(results[1].status).toBe('failed');
   });
+
+  it('cleans up schema extensions from the reverted file after successful smart rollback', async () => {
+    const { cp } = await import('node:fs/promises');
+    const FIXTURES_DIR = resolve(import.meta.dirname, '../fixtures/weaver-registry');
+    const registryDir = join(tmpDir, 'registry');
+    await cp(resolve(FIXTURES_DIR, 'valid'), registryDir, { recursive: true });
+    const baselineDir = resolve(FIXTURES_DIR, 'valid');
+
+    const files = await Promise.all([
+      createFile('a.js', 'function a() {}'),
+      createFile('b.js', 'function b() {}'),
+    ]);
+
+    const extA = '- id: test_app.payment.amount\n  type: double\n  stability: development\n  brief: Payment amount\n  examples: [29.99]';
+    const extB = '- id: test_app.shipping.cost\n  type: double\n  stability: development\n  brief: Shipping cost\n  examples: [5.99]';
+
+    const instrumentWithRetry = vi.fn().mockImplementation(async (filePath: string) => {
+      await writeFile(filePath, '// INSTRUMENTED', 'utf-8');
+      const index = files.indexOf(filePath);
+      if (index === 0) return makeSuccessResult(filePath, { schemaExtensions: [extA] });
+      return makeSuccessResult(filePath, { schemaExtensions: [extB] });
+    });
+
+    const config = makeConfig({ schemaCheckpointInterval: 2, testCommand: 'npm test' });
+
+    let callCount = 0;
+    await dispatchFiles(files, tmpDir, config, undefined, {
+      deps: { resolveSchema: vi.fn().mockResolvedValue({ resolved: true }), instrumentWithRetry },
+      checkpoint: { registryDir, baselineSnapshotDir: baselineDir },
+      registryDir,
+      runTestCommand: async () => {
+        callCount++;
+        if (callCount === 1) {
+          // First run fails: stack trace points to b.js (the file that added extB)
+          return { passed: false, error: 'ReferenceError', output: `at Object.<anonymous> (${files[1]}:10:5)` };
+        }
+        // Re-run after targeted rollback of b.js passes
+        return { passed: true };
+      },
+      baselineTestPassed: true,
+    });
+
+    // Extensions file should contain a.js's extension but NOT b.js's (reverted)
+    const extContent = await readFile(join(registryDir, 'agent-extensions.yaml'), 'utf-8');
+    expect(extContent).toContain('payment.amount');
+    expect(extContent).not.toContain('shipping.cost');
+  });
 });


### PR DESCRIPTION
## Summary

- After a successful smart rollback (targeted file revert + passing re-run), restores the extensions file to the pre-window checkpoint snapshot and re-applies extensions only from non-reverted window files
- Prevents orphaned `agent-extensions.yaml` entries for OTel attributes that no longer exist in reverted code
- Mirrors the extension cleanup already performed by the full-window rollback fallback path

## Test plan

- [ ] New test: `agent-extensions.yaml` contains kept file's extensions and not reverted file's after successful smart rollback
- [ ] All 2035 existing tests still pass
- [ ] Typecheck and build clean

Closes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced smart targeted rollback to properly clean up schema extensions when recovery succeeds, ensuring only relevant extensions are retained in the persisted configuration.

* **Tests**
  * Added test coverage for schema extension cleanup during smart rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->