### PR TITLE
CDQ-009: flag !== undefined guards before property access on setAttribute values

### DIFF
--- a/src/languages/javascript/index.ts
+++ b/src/languages/javascript/index.ts
@@ -40,6 +40,7 @@ import { nds006Rule } from './rules/nds006.ts';
 import { cdq001Rule } from './rules/cdq001.ts';
 import { cdq006Rule } from './rules/cdq006.ts';
 import { cdq007Rule } from './rules/cdq007.ts';
+import { cdq009Rule } from './rules/cdq009.ts';
 import { api001Rule, api003Rule, api004Rule } from './rules/api001.ts';
 import { api002Rule } from './rules/api002.ts';
 import { sch001Rule } from './rules/sch001.ts';
@@ -50,7 +51,7 @@ import { cdq008Rule } from '../../validation/tier2/cdq008.ts';
 
 /**
  * All ValidationRule instances this provider registers.
- * Covers 27 per-file Tier 2 rules (including API-003/API-004 from api001.ts)
+ * Covers 28 per-file Tier 2 rules (including API-003/API-004 from api001.ts)
  * plus CDQ-008 (shared cross-file rule registered here for parity tracking).
  *
  * NDS-001 (syntax) and LINT are not ValidationRule objects — they are
@@ -61,7 +62,7 @@ const JS_RULES = [
   cov001Rule, cov002Rule, cov003Rule, cov004Rule, cov005Rule, cov006Rule,
   rst001Rule, rst002Rule, rst003Rule, rst004Rule, rst005Rule,
   nds003Rule, nds004Rule, nds005Rule, nds006Rule,
-  cdq001Rule, cdq006Rule, cdq007Rule, cdq008Rule,
+  cdq001Rule, cdq006Rule, cdq007Rule, cdq008Rule, cdq009Rule,
   api001Rule, api002Rule, api003Rule, api004Rule,
   sch001Rule, sch002Rule, sch003Rule, sch004Rule,
 ] as const;

--- a/src/languages/javascript/prompt.ts
+++ b/src/languages/javascript/prompt.ts
@@ -240,11 +240,12 @@ export function getSystemPromptSections(): LanguagePromptSections {
   // WRONG — entries?.length may be undefined
   span.setAttribute('result.count', entries?.length);
 
-  // CORRECT — guard optional values
-  if (entries !== undefined) {
+  // CORRECT — guard optional values with != null (covers both null and undefined)
+  if (entries != null) {
     span.setAttribute('result.count', entries.length);
   }
   \`\`\`
+- When guarding a variable before accessing its properties, always use \`!= null\` (loose inequality), not \`!== undefined\` (strict). \`!== undefined\` passes when the value is \`null\`, causing a TypeError on property access at runtime.
 - **Return-value capture is allowed.** When you need to call \`setAttribute\` on a return value, you may extract the expression to a \`const\`:
   \`\`\`javascript
   // Original: return computeResult();

--- a/src/languages/javascript/rules/cdq009.ts
+++ b/src/languages/javascript/rules/cdq009.ts
@@ -1,0 +1,191 @@
+// ABOUTME: CDQ-009 Tier 2 advisory check — not-null-safe undefined guard.
+// ABOUTME: Flags !==undefined guards before property access on span attribute values.
+
+import { Project, Node, SyntaxKind } from 'ts-morph';
+import type { CheckResult } from '../../../validation/types.ts';
+import type { ValidationRule, RuleInput } from '../../types.ts';
+
+/**
+ * CDQ-009: Flag `!== undefined` guards before property access on setAttribute values.
+ *
+ * When instrumented code guards a variable with `if (x !== undefined)` and then
+ * accesses a property of `x` (e.g., `x.length`) inside the guard, the guard is not
+ * null-safe: it passes when `x` is `null`, causing a TypeError at runtime.
+ *
+ * The correct guard is `if (x != null)` (loose inequality), which excludes both
+ * `null` and `undefined`.
+ *
+ * Only flagged when the variable's property is used as a span.setAttribute value —
+ * this is the pattern the instrumentation agent produces.
+ *
+ * @param code - The instrumented JavaScript code to check
+ * @param filePath - Path to the file being validated (for CheckResult)
+ * @returns CheckResult[] — one per finding, or a single passing result
+ */
+export function checkNotNullSafeGuard(code: string, filePath: string): CheckResult[] {
+  const project = new Project({
+    compilerOptions: { allowJs: true },
+    useInMemoryFileSystem: true,
+  });
+  const ext = filePath.endsWith('.tsx') ? 'tsx'
+    : filePath.endsWith('.ts') ? 'ts'
+    : filePath.endsWith('.jsx') ? 'jsx'
+    : 'js';
+  const sourceFile = project.createSourceFile(`check.${ext}`, code);
+
+  const findings: Array<{ line: number; message: string }> = [];
+
+  sourceFile.forEachDescendant((node) => {
+    if (!Node.isCallExpression(node)) return;
+
+    const expr = node.getExpression();
+    if (!Node.isPropertyAccessExpression(expr)) return;
+    if (expr.getName() !== 'setAttribute') return;
+
+    const receiverText = expr.getExpression().getText();
+    if (!isSpanReceiver(receiverText)) return;
+
+    const args = node.getArguments();
+    if (args.length < 2) return;
+
+    const valueArg = args[1];
+
+    // Only flag when the value is a property access: x.prop
+    if (!Node.isPropertyAccessExpression(valueArg)) return;
+    if (valueArg.getQuestionDotTokenNode() !== undefined) return; // optional chaining is fine
+
+    const objectNode = valueArg.getExpression();
+    if (!Node.isIdentifier(objectNode)) return;
+    const varName = objectNode.getText();
+
+    // Check if this setAttribute is inside an if-guard that uses !== undefined
+    const guardKind = findEnclosingGuardKind(node, varName);
+    if (guardKind === 'strict-undefined') {
+      findings.push({
+        line: node.getStartLineNumber(),
+        message:
+          `"${varName}" at line ${node.getStartLineNumber()} is guarded with \`!== undefined\` ` +
+          `before accessing \`${valueArg.getText()}\`. ` +
+          `This guard does not protect against null — use \`!= null\` instead to cover both null and undefined.`,
+      });
+    }
+  });
+
+  if (findings.length === 0) {
+    return [{
+      ruleId: 'CDQ-009',
+      passed: true,
+      filePath,
+      lineNumber: null,
+      message: 'No not-null-safe undefined guards detected.',
+      tier: 2,
+      blocking: false,
+    }];
+  }
+
+  return findings.map((f) => ({
+    ruleId: 'CDQ-009' as const,
+    passed: false as const,
+    filePath,
+    lineNumber: f.line,
+    message: `CDQ-009: ${f.message}`,
+    tier: 2 as const,
+    blocking: false as const,
+  }));
+}
+
+/**
+ * Walk up from a setAttribute call and determine if it is inside an if-statement
+ * that guards `varName` with `!== undefined` (not null-safe).
+ * Returns 'strict-undefined' if a !==undefined guard is found, 'other' for any
+ * other guard kind (truthy, != null, etc.), or null if no enclosing guard.
+ */
+function findEnclosingGuardKind(
+  node: import('ts-morph').Node,
+  varName: string,
+): 'strict-undefined' | null {
+  let current: import('ts-morph').Node | undefined = node.getParent();
+
+  while (current && !isFunctionBoundary(current)) {
+    if (Node.isIfStatement(current)) {
+      const condition = current.getExpression();
+      const thenStmt = current.getThenStatement();
+      if (isInsideNode(node, thenStmt) && isStrictUndefinedGuard(condition, varName)) {
+        return 'strict-undefined';
+      }
+    }
+    current = current.getParent();
+  }
+
+  return null;
+}
+
+/**
+ * Check if a condition is `varName !== undefined` or `undefined !== varName` (strict only).
+ */
+function isStrictUndefinedGuard(
+  condition: import('ts-morph').Expression,
+  varName: string,
+): boolean {
+  if (!Node.isBinaryExpression(condition)) return false;
+
+  const operator = condition.getOperatorToken().getKind();
+  if (operator !== SyntaxKind.ExclamationEqualsEqualsToken) return false;
+
+  const left = condition.getLeft();
+  const right = condition.getRight();
+
+  const leftIsVar = Node.isIdentifier(left) && left.getText() === varName;
+  const rightIsVar = Node.isIdentifier(right) && right.getText() === varName;
+  const leftIsUndefined = left.getText() === 'undefined';
+  const rightIsUndefined = right.getText() === 'undefined';
+
+  return (leftIsVar && rightIsUndefined) || (rightIsVar && leftIsUndefined);
+}
+
+/**
+ * Check if a receiver expression is likely a span variable.
+ */
+const NON_SPAN_RECEIVERS = new Set([
+  'element', 'node', 'document', 'map', 'urlSearchParams',
+  'params', 'headers', 'formData', 'attributes',
+]);
+
+function isSpanReceiver(receiverText: string): boolean {
+  const parts = receiverText.split('.');
+  const name = parts[parts.length - 1].toLowerCase();
+  if (NON_SPAN_RECEIVERS.has(name)) return false;
+  return /span/i.test(name);
+}
+
+function isFunctionBoundary(node: import('ts-morph').Node): boolean {
+  return (
+    Node.isFunctionDeclaration(node) ||
+    Node.isFunctionExpression(node) ||
+    Node.isArrowFunction(node) ||
+    Node.isMethodDeclaration(node) ||
+    Node.isConstructorDeclaration(node)
+  );
+}
+
+function isInsideNode(node: import('ts-morph').Node, ancestor: import('ts-morph').Node): boolean {
+  let c: import('ts-morph').Node | undefined = node.getParent();
+  while (c) {
+    if (c === ancestor) return true;
+    c = c.getParent();
+  }
+  return false;
+}
+
+/** CDQ-009 ValidationRule — not-null-safe undefined guard advisory check. */
+export const cdq009Rule: ValidationRule = {
+  ruleId: 'CDQ-009',
+  dimension: 'Code Quality',
+  blocking: false,
+  applicableTo(language: string): boolean {
+    return language === 'javascript' || language === 'typescript';
+  },
+  check(input: RuleInput): CheckResult[] {
+    return checkNotNullSafeGuard(input.instrumentedCode, input.filePath);
+  },
+};

--- a/src/languages/javascript/rules/cdq009.ts
+++ b/src/languages/javascript/rules/cdq009.ts
@@ -97,8 +97,8 @@ export function checkNotNullSafeGuard(code: string, filePath: string): CheckResu
 /**
  * Walk up from a setAttribute call and determine if it is inside an if-statement
  * that guards `varName` with `!== undefined` (not null-safe).
- * Returns 'strict-undefined' if a !==undefined guard is found, 'other' for any
- * other guard kind (truthy, != null, etc.), or null if no enclosing guard.
+ * Returns 'strict-undefined' if a !==undefined guard is found, or null if no
+ * such enclosing guard exists (including truthy checks and != null guards).
  */
 function findEnclosingGuardKind(
   node: import('ts-morph').Node,

--- a/src/languages/javascript/rules/cdq009.ts
+++ b/src/languages/javascript/rules/cdq009.ts
@@ -122,6 +122,7 @@ function findEnclosingGuardKind(
 
 /**
  * Check if a condition is `varName !== undefined` or `undefined !== varName` (strict only).
+ * Also handles && compounds: `varName !== undefined && ...` is still a strict-undefined guard.
  */
 function isStrictUndefinedGuard(
   condition: import('ts-morph').Expression,
@@ -130,6 +131,15 @@ function isStrictUndefinedGuard(
   if (!Node.isBinaryExpression(condition)) return false;
 
   const operator = condition.getOperatorToken().getKind();
+
+  // Handle && compound: x !== undefined && x.length > 0 still uses a not-null-safe guard
+  if (operator === SyntaxKind.AmpersandAmpersandToken) {
+    return (
+      isStrictUndefinedGuard(condition.getLeft(), varName) ||
+      isStrictUndefinedGuard(condition.getRight(), varName)
+    );
+  }
+
   if (operator !== SyntaxKind.ExclamationEqualsEqualsToken) return false;
 
   const left = condition.getLeft();

--- a/test/languages/javascript/rules/cdq009.test.ts
+++ b/test/languages/javascript/rules/cdq009.test.ts
@@ -52,6 +52,26 @@ describe('checkNotNullSafeGuard (CDQ-009)', () => {
       expect(results[0].message).toContain('config');
     });
 
+    it('flags compound condition: varName !== undefined && other_condition', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(items) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    if (items !== undefined && items.length > 0) {',
+        '      span.setAttribute("items.count", items.length);',
+        '    }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('items');
+    });
+
     it('flags undefined !== varName (reversed operand order)', () => {
       const code = [
         'const { trace } = require("@opentelemetry/api");',

--- a/test/languages/javascript/rules/cdq009.test.ts
+++ b/test/languages/javascript/rules/cdq009.test.ts
@@ -1,0 +1,191 @@
+// ABOUTME: Tests for CDQ-009 advisory check — not-null-safe undefined guard.
+// ABOUTME: Verifies !==undefined guards before property access are flagged and != null suggested.
+
+import { describe, it, expect } from 'vitest';
+import { checkNotNullSafeGuard } from '../../../../src/languages/javascript/rules/cdq009.ts';
+
+describe('checkNotNullSafeGuard (CDQ-009)', () => {
+  const filePath = '/tmp/test-file.js';
+
+  describe('flags !==undefined guard before property access', () => {
+    it('flags variable guarded with !== undefined then .length accessed', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function summarize(weeklySummaries) {',
+        '  return tracer.startActiveSpan("summarize", (span) => {',
+        '    if (weeklySummaries !== undefined) {',
+        '      span.setAttribute("summaries.count", weeklySummaries.length);',
+        '    }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].ruleId).toBe('CDQ-009');
+      expect(results[0].tier).toBe(2);
+      expect(results[0].blocking).toBe(false);
+      expect(results[0].message).toContain('weeklySummaries');
+      expect(results[0].message).toContain('!= null');
+    });
+
+    it('flags !== undefined guard with arbitrary property access (not just .length)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(config) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    if (config !== undefined) {',
+        '      span.setAttribute("config.name", config.name);',
+        '    }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('config');
+    });
+
+    it('flags undefined !== varName (reversed operand order)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(items) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    if (undefined !== items) {',
+        '      span.setAttribute("items.count", items.length);',
+        '    }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+    });
+  });
+
+  describe('passes for safe guards', () => {
+    it('passes when guarded with != null (null-safe loose inequality)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function summarize(weeklySummaries) {',
+        '  return tracer.startActiveSpan("summarize", (span) => {',
+        '    if (weeklySummaries != null) {',
+        '      span.setAttribute("summaries.count", weeklySummaries.length);',
+        '    }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when guarded with truthy check if (x)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(data) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    if (data) {',
+        '      span.setAttribute("data.count", data.length);',
+        '    }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when no guard is needed (value is a plain identifier)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(count) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("item.count", count);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when guarded with !== undefined but value is a direct identifier (no property access)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(status) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    if (status !== undefined) {',
+        '      span.setAttribute("status", status);',
+        '    }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      // No property access on `status` — just passing it directly, so no crash risk
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when no setAttribute calls exist', () => {
+      const code = 'function greet(name) { console.log(name); }';
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+  });
+
+  describe('result shape', () => {
+    it('returns ruleId CDQ-009, tier 2, blocking false on finding', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function f(x) {',
+        '  return tracer.startActiveSpan("f", (span) => {',
+        '    if (x !== undefined) { span.setAttribute("k", x.prop); }',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkNotNullSafeGuard(code, filePath);
+      expect(results[0].ruleId).toBe('CDQ-009');
+      expect(results[0].tier).toBe(2);
+      expect(results[0].blocking).toBe(false);
+      expect(results[0].filePath).toBe(filePath);
+      expect(results[0].lineNumber).toBeTypeOf('number');
+    });
+  });
+});
+
+describe('CDQ-009 prompt guidance', () => {
+  it('instrumentation prompt uses != null in the CORRECT guard example (not !== undefined)', async () => {
+    const { getSystemPromptSections } = await import('../../../../src/languages/javascript/prompt.ts');
+    const sections = getSystemPromptSections();
+    // The CORRECT example in the code block should use != null, not !== undefined
+    expect(sections.constraints).toContain('if (entries != null)');
+    // The old incorrect pattern should not appear as a positive example
+    expect(sections.constraints).not.toContain('if (entries !== undefined)');
+  });
+});

--- a/test/validation/parity.test.ts
+++ b/test/validation/parity.test.ts
@@ -88,7 +88,7 @@ describe('feature parity matrix', () => {
     expect(cdq008!.applicableTo('go')).toBe(true);
   });
 
-  it('CDQ-009 applies to JS/TS only (not-null-safe guard check)', () => {
+  it('CDQ-009 applies to JS/TS, not Python/Go (not-null-safe guard check)', () => {
     const rules = getAllRules();
     const cdq009 = rules.find(r => r.ruleId === 'CDQ-009');
     expect(cdq009).toBeDefined();

--- a/test/validation/parity.test.ts
+++ b/test/validation/parity.test.ts
@@ -88,7 +88,17 @@ describe('feature parity matrix', () => {
     expect(cdq008!.applicableTo('go')).toBe(true);
   });
 
-  it('all 27 expected rules are registered', () => {
+  it('CDQ-009 applies to JS/TS only (not-null-safe guard check)', () => {
+    const rules = getAllRules();
+    const cdq009 = rules.find(r => r.ruleId === 'CDQ-009');
+    expect(cdq009).toBeDefined();
+    expect(cdq009!.applicableTo('javascript')).toBe(true);
+    expect(cdq009!.applicableTo('typescript')).toBe(true);
+    expect(cdq009!.applicableTo('python')).toBe(false);
+    expect(cdq009!.applicableTo('go')).toBe(false);
+  });
+
+  it('all 28 expected rules are registered', () => {
     const rules = getAllRules();
     const ruleIds = new Set(rules.map(r => r.ruleId));
 
@@ -96,7 +106,7 @@ describe('feature parity matrix', () => {
       'COV-001', 'COV-002', 'COV-003', 'COV-004', 'COV-005', 'COV-006',
       'RST-001', 'RST-002', 'RST-003', 'RST-004', 'RST-005',
       'NDS-003', 'NDS-004', 'NDS-005', 'NDS-006',
-      'CDQ-001', 'CDQ-006', 'CDQ-007', 'CDQ-008',
+      'CDQ-001', 'CDQ-006', 'CDQ-007', 'CDQ-008', 'CDQ-009',
       'API-001', 'API-002', 'API-003', 'API-004',
       'SCH-001', 'SCH-002', 'SCH-003', 'SCH-004',
     ];


### PR DESCRIPTION
## Summary

- **Prompt fix**: updates the CORRECT guard example in the attribute-setting section from `if (entries !== undefined)` to `if (entries != null)`, with an added explicit rule explaining why `!== undefined` is not null-safe
- **CDQ-009 validation rule** (advisory): AST check that detects `!== undefined` guards before property access (e.g., `.length`) on span attribute values; flags with variable name, property accessed, and `!= null` suggestion

## Root cause

Run-13 on commit-story-v2 caught two crashes where the agent wrote `if (x !== undefined)` guards before `x.length` — this guard passes when `x` is `null`, causing TypeError. The prompt showed `!== undefined` as the CORRECT pattern.

## Test plan

- [ ] CDQ-009 flags `!== undefined` + property access; passes `!= null`, truthy, and no-guard cases
- [ ] Prompt constraints contain `if (entries != null)` and not `if (entries !== undefined)`
- [ ] Parity test updated: 28 rules, CDQ-009 registered for JS/TS
- [ ] All 2045 existing tests pass
- [ ] Typecheck and build clean

Closes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CDQ-009 validation rule to flag non-null-safe guards using strict `!== undefined` before property access; findings are tier 2, non-blocking.

* **Documentation**
  * Guidance updated to prefer `!= null` (covers null and undefined) when guarding before accessing properties.

* **Tests**
  * Added tests for CDQ-009 behavior and result shape; updated registration checks to include CDQ-009 and reflect 28 rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->