### PR TITLE
feat(cdq010): add CDQ-010 rule and prompt guidance for string method type safety

### DIFF
--- a/src/languages/javascript/index.ts
+++ b/src/languages/javascript/index.ts
@@ -41,6 +41,7 @@ import { cdq001Rule } from './rules/cdq001.ts';
 import { cdq006Rule } from './rules/cdq006.ts';
 import { cdq007Rule } from './rules/cdq007.ts';
 import { cdq009Rule } from './rules/cdq009.ts';
+import { cdq010Rule } from './rules/cdq010.ts';
 import { api001Rule, api003Rule, api004Rule } from './rules/api001.ts';
 import { api002Rule } from './rules/api002.ts';
 import { sch001Rule } from './rules/sch001.ts';
@@ -51,7 +52,7 @@ import { cdq008Rule } from '../../validation/tier2/cdq008.ts';
 
 /**
  * All ValidationRule instances this provider registers.
- * Covers 28 per-file Tier 2 rules (including API-003/API-004 from api001.ts)
+ * Covers 29 per-file Tier 2 rules (including API-003/API-004 from api001.ts)
  * plus CDQ-008 (shared cross-file rule registered here for parity tracking).
  *
  * NDS-001 (syntax) and LINT are not ValidationRule objects — they are
@@ -62,7 +63,7 @@ const JS_RULES = [
   cov001Rule, cov002Rule, cov003Rule, cov004Rule, cov005Rule, cov006Rule,
   rst001Rule, rst002Rule, rst003Rule, rst004Rule, rst005Rule,
   nds003Rule, nds004Rule, nds005Rule, nds006Rule,
-  cdq001Rule, cdq006Rule, cdq007Rule, cdq008Rule, cdq009Rule,
+  cdq001Rule, cdq006Rule, cdq007Rule, cdq008Rule, cdq009Rule, cdq010Rule,
   api001Rule, api002Rule, api003Rule, api004Rule,
   sch001Rule, sch002Rule, sch003Rule, sch004Rule,
 ] as const;

--- a/src/languages/javascript/prompt.ts
+++ b/src/languages/javascript/prompt.ts
@@ -254,7 +254,15 @@ export function getSystemPromptSections(): LanguagePromptSections {
   span.setAttribute('result.count', result.length);
   return result;
   \`\`\`
-  This is the ONLY non-instrumentation code change the validator permits. Use it only for capturing values needed by \`setAttribute\` or \`addEvent\`.`,
+  This is the ONLY non-instrumentation code change the validator permits. Use it only for capturing values needed by \`setAttribute\` or \`addEvent\`.
+- **Do not call string methods directly on property-access expressions.** When extracting a value for a span attribute, never assume an object field holds a string. Calling \`.split()\`, \`.slice()\`, \`.replace()\`, or similar string methods directly on \`obj.field\` will crash at runtime if the field is a \`Date\`, number, or other non-string type. When extracting a date string from a timestamp field, use \`new Date(value).toISOString().split('T')[0]\` — this handles both \`Date\` objects and ISO string inputs safely. For other fields, use \`String(value)\` to coerce explicitly.
+  \`\`\`javascript
+  // WRONG — crashes if commit.timestamp is a Date object
+  span.setAttribute('date', commit.timestamp.split('T')[0]);
+
+  // CORRECT — handles both Date objects and ISO strings
+  span.setAttribute('date', new Date(commit.timestamp).toISOString().split('T')[0]);
+  \`\`\``,
 
     tracerAcquisition: `Add \`const tracer = trace.getTracer('service-name');\` at module scope if not already present, replacing \`'service-name'\` with a stable identifier for this service. Use exactly this tracer name in every file — do not vary it. If a tracer variable is already declared, reuse it.`,
 

--- a/src/languages/javascript/rules/cdq010.ts
+++ b/src/languages/javascript/rules/cdq010.ts
@@ -1,0 +1,178 @@
+// ABOUTME: CDQ-010 Tier 2 advisory check — untyped string method on property access.
+// ABOUTME: Flags string methods called directly on obj.field without String() coercion.
+
+import { Project, Node } from 'ts-morph';
+import type { CheckResult } from '../../../validation/types.ts';
+import type { ValidationRule, RuleInput } from '../../types.ts';
+
+/**
+ * String methods that are only defined on String values.
+ * Calling these on a property access without type coercion crashes when the
+ * property holds a non-string value (e.g., a Date object, number, or null).
+ */
+const STRING_ONLY_METHODS = new Set([
+  'split', 'slice', 'replace', 'replaceAll',
+  'substring', 'substr',
+  'trim', 'trimStart', 'trimEnd',
+  'toLowerCase', 'toUpperCase', 'toLocaleLowerCase', 'toLocaleUpperCase',
+  'indexOf', 'lastIndexOf', 'includes', 'startsWith', 'endsWith',
+  'padStart', 'padEnd', 'repeat',
+]);
+
+/**
+ * Check a single node for the unsafe string-method-on-property-access pattern.
+ * Pushes a finding if the node is a CallExpression matching the pattern.
+ */
+function checkNodeForUnsafeStringMethod(
+  node: import('ts-morph').Node,
+  line: number,
+  findings: Array<{ line: number; message: string }>,
+): void {
+  if (!Node.isCallExpression(node)) return;
+
+  const callExpr = node.getExpression();
+  if (!Node.isPropertyAccessExpression(callExpr)) return;
+
+  const methodName = callExpr.getName();
+  if (!STRING_ONLY_METHODS.has(methodName)) return;
+
+  // The receiver of the string method — must be a PropertyAccessExpression
+  // (not a simple identifier, string literal, or call expression)
+  const receiver = callExpr.getExpression();
+  if (!Node.isPropertyAccessExpression(receiver)) return;
+
+  const receiverStr = receiver.getText();
+  findings.push({
+    line,
+    message:
+      `"${receiverStr}.${methodName}()" at line ${line} calls a string method directly on a ` +
+      `property access. If "${receiverStr}" is not a string at runtime (e.g., a Date or number), ` +
+      `this will throw "TypeError: ${receiverStr}.${methodName} is not a function". ` +
+      `Use \`new Date(${receiverStr}).toISOString()\` or \`String(${receiverStr})\` to coerce to string first.`,
+  });
+}
+
+/**
+ * CDQ-010: Flag string methods called directly on a property-access expression
+ * inside span.setAttribute calls without type coercion.
+ *
+ * When instrumented code calls a string method (e.g., `.split()`, `.slice()`)
+ * on a property-access expression (e.g., `commit.timestamp`), the agent is
+ * assuming the field holds a string. If it holds a Date, number, or other
+ * type at runtime, the call throws `TypeError: x.method is not a function`.
+ *
+ * Safe alternatives:
+ * - `new Date(commit.timestamp).toISOString().split('T')[0]` — handles Date and string
+ * - `String(commit.timestamp).split('T')[0]` — explicit coercion
+ * - `commit.timestamp.toString().split('T')[0]` — explicit coercion
+ *
+ * Not flagged:
+ * - `someVar.split(...)` where `someVar` is a simple identifier (not a property access)
+ * - `String(obj.field).split(...)` where `String()` is applied first
+ * - `obj.method().split(...)` where a call expression returns the value
+ * - `"literal".split(...)` string literal
+ *
+ * @param code - The instrumented JavaScript code to check
+ * @param filePath - Path to the file being validated (for CheckResult)
+ * @returns CheckResult[] — one per finding, or a single passing result
+ */
+export function checkUntypedStringMethod(code: string, filePath: string): CheckResult[] {
+  const project = new Project({
+    compilerOptions: { allowJs: true },
+    useInMemoryFileSystem: true,
+  });
+  const ext = filePath.endsWith('.tsx') ? 'tsx'
+    : filePath.endsWith('.ts') ? 'ts'
+    : filePath.endsWith('.jsx') ? 'jsx'
+    : 'js';
+  const sourceFile = project.createSourceFile(`check.${ext}`, code);
+
+  const findings: Array<{ line: number; message: string }> = [];
+
+  sourceFile.forEachDescendant((node) => {
+    // Only look at span.setAttribute() call sites
+    if (!Node.isCallExpression(node)) return;
+
+    const expr = node.getExpression();
+    if (!Node.isPropertyAccessExpression(expr)) return;
+    if (expr.getName() !== 'setAttribute') return;
+
+    const receiverText = expr.getExpression().getText();
+    if (!isSpanReceiver(receiverText)) return;
+
+    const args = node.getArguments();
+    if (args.length < 2) return;
+
+    const valueArg = args[1];
+
+    // Check valueArg itself and all its descendants for the unsafe pattern.
+    // forEachDescendant skips the node itself, so we check valueArg directly first.
+    const line = node.getStartLineNumber();
+    checkNodeForUnsafeStringMethod(valueArg, line, findings);
+    valueArg.forEachDescendant((descendant) => {
+      checkNodeForUnsafeStringMethod(descendant, line, findings);
+    });
+  });
+
+  if (findings.length === 0) {
+    return [{
+      ruleId: 'CDQ-010',
+      passed: true,
+      filePath,
+      lineNumber: null,
+      message: 'No untyped string method calls on property access expressions detected.',
+      tier: 2,
+      blocking: false,
+    }];
+  }
+
+  // Deduplicate findings by line number (same setAttribute call may match multiple descendants)
+  const seen = new Set<string>();
+  const deduped = findings.filter((f) => {
+    const key = `${f.line}:${f.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return deduped.map((f) => ({
+    ruleId: 'CDQ-010' as const,
+    passed: false as const,
+    filePath,
+    lineNumber: f.line,
+    message: `CDQ-010: ${f.message}`,
+    tier: 2 as const,
+    blocking: false as const,
+  }));
+}
+
+/**
+ * Known non-span APIs with a .setAttribute() method.
+ */
+const NON_SPAN_RECEIVERS = new Set([
+  'element', 'node', 'document', 'map', 'urlSearchParams',
+  'params', 'headers', 'formData', 'attributes',
+]);
+
+/**
+ * Check if a receiver expression is likely a span variable.
+ */
+function isSpanReceiver(receiverText: string): boolean {
+  const parts = receiverText.split('.');
+  const name = parts[parts.length - 1].toLowerCase();
+  if (NON_SPAN_RECEIVERS.has(name)) return false;
+  return /span/i.test(name);
+}
+
+/** CDQ-010 ValidationRule — untyped string method on property access advisory check. */
+export const cdq010Rule: ValidationRule = {
+  ruleId: 'CDQ-010',
+  dimension: 'Code Quality',
+  blocking: false,
+  applicableTo(language: string): boolean {
+    return language === 'javascript' || language === 'typescript';
+  },
+  check(input: RuleInput): CheckResult[] {
+    return checkUntypedStringMethod(input.instrumentedCode, input.filePath);
+  },
+};

--- a/src/validation/rule-names.ts
+++ b/src/validation/rule-names.ts
@@ -25,6 +25,8 @@ const RULE_NAMES: Record<string, string> = {
   'CDQ-005': 'Async Context Maintained',
   'CDQ-006': 'isRecording Guard',
   'CDQ-008': 'Tracer Naming',
+  'CDQ-009': 'Null-Safe Guard',
+  'CDQ-010': 'String Method Type Safety',
 
   // Tier 2 — Restraint
   'RST-001': 'No Utility Spans',

--- a/test/languages/javascript/rules/cdq010.test.ts
+++ b/test/languages/javascript/rules/cdq010.test.ts
@@ -320,6 +320,39 @@ describe('checkUntypedStringMethod (CDQ-010)', () => {
       expect(results).toHaveLength(1);
       expect(results[0].passed).toBe(true);
     });
+
+    it('does not flag setAttribute on non-span receivers (DOM element)', () => {
+      const code = [
+        'function setAttr(element, obj) {',
+        '  element.setAttribute("data-id", obj.id.slice(0, 8));',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+  });
+
+  describe('TypeScript file support', () => {
+    it('flags the same pattern in a .ts file', () => {
+      const tsFilePath = '/tmp/test-file.ts';
+      const code = [
+        'import { trace, SpanStatusCode } from "@opentelemetry/api";',
+        'const tracer = trace.getTracer("svc");',
+        'export async function process(commit: { timestamp: Date }) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", commit.timestamp.split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, tsFilePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].ruleId).toBe('CDQ-010');
+    });
   });
 
   describe('result shape', () => {

--- a/test/languages/javascript/rules/cdq010.test.ts
+++ b/test/languages/javascript/rules/cdq010.test.ts
@@ -1,0 +1,364 @@
+// ABOUTME: Tests for CDQ-010 advisory check — untyped string method on property access.
+// ABOUTME: Verifies string methods called on obj.field without type coercion are flagged.
+
+import { describe, it, expect } from 'vitest';
+import { checkUntypedStringMethod } from '../../../../src/languages/javascript/rules/cdq010.ts';
+
+describe('checkUntypedStringMethod (CDQ-010)', () => {
+  const filePath = '/tmp/test-file.js';
+
+  describe('flags string methods called on property access expressions', () => {
+    it('flags .split() called on obj.field in setAttribute value', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function saveEntry(commit) {',
+        '  return tracer.startActiveSpan("save", (span) => {',
+        '    span.setAttribute("date", commit.timestamp.split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].ruleId).toBe('CDQ-010');
+      expect(results[0].tier).toBe(2);
+      expect(results[0].blocking).toBe(false);
+      expect(results[0].message).toContain('split');
+      expect(results[0].message).toContain('commit.timestamp');
+    });
+
+    it('flags .slice() called on obj.field in setAttribute value', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(record) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("short_id", record.id.slice(0, 8));',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('slice');
+      expect(results[0].message).toContain('record.id');
+    });
+
+    it('flags .replace() called on obj.field in setAttribute value', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(item) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("normalized", item.name.replace(/-/g, "_"));',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('replace');
+      expect(results[0].message).toContain('item.name');
+    });
+
+    it('flags .substring() called on obj.field in setAttribute value', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(event) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("prefix", event.type.substring(0, 4));',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('substring');
+    });
+
+    it('flags .trim() called on obj.field in setAttribute value', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(req) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("query", req.body.trim());',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('trim');
+    });
+
+    it('flags .toLowerCase() called on obj.field in setAttribute value', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(user) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("email_lower", user.email.toLowerCase());',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('toLowerCase');
+    });
+
+    it('flags .toUpperCase() called on obj.field in setAttribute value', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(order) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("status", order.status.toUpperCase());',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('toUpperCase');
+    });
+
+    it('flags .split() on a deeper property access (obj.nested.field)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(context) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", context.commit.timestamp.split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].message).toContain('split');
+    });
+
+    it('reports the line number of the setAttribute call', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(commit) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", commit.timestamp.split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results[0].lineNumber).toBeTypeOf('number');
+      expect(results[0].lineNumber).toBeGreaterThan(0);
+    });
+
+    it('reports multiple findings when multiple setAttribute calls have the issue', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(commit) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", commit.timestamp.split("T")[0]);',
+        '    span.setAttribute("short", commit.sha.slice(0, 7));',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(2);
+      expect(results.every(r => r.passed === false)).toBe(true);
+    });
+  });
+
+  describe('passes for safe patterns', () => {
+    it('passes when String() coercion wraps the property access', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(commit) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", String(commit.timestamp).split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when new Date().toISOString() is used before the string method', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(commit) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", new Date(commit.timestamp).toISOString().split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when .toString() is called on the property before the string method', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(commit) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", commit.timestamp.toString().split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when string method is called on a simple identifier (not a property access)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(timestampStr) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", timestampStr.split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when string method is called on a string literal', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process() {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("prefix", "hello-world".split("-")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when no setAttribute calls exist', () => {
+      const code = 'function greet(name) { console.log(name); }';
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when setAttribute value is a plain property access without string methods', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(commit) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("sha", commit.sha);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+
+    it('passes when string method is called on a call expression result (not property access)', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function process(collector) {',
+        '  return tracer.startActiveSpan("process", (span) => {',
+        '    span.setAttribute("date", collector.getTimestamp().split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results).toHaveLength(1);
+      expect(results[0].passed).toBe(true);
+    });
+  });
+
+  describe('result shape', () => {
+    it('returns ruleId CDQ-010, tier 2, blocking false on finding', () => {
+      const code = [
+        'const { trace } = require("@opentelemetry/api");',
+        'const tracer = trace.getTracer("svc");',
+        'function f(commit) {',
+        '  return tracer.startActiveSpan("f", (span) => {',
+        '    span.setAttribute("date", commit.timestamp.split("T")[0]);',
+        '    span.end();',
+        '  });',
+        '}',
+      ].join('\n');
+
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results[0].ruleId).toBe('CDQ-010');
+      expect(results[0].tier).toBe(2);
+      expect(results[0].blocking).toBe(false);
+      expect(results[0].filePath).toBe(filePath);
+      expect(results[0].lineNumber).toBeTypeOf('number');
+    });
+
+    it('passes result has ruleId CDQ-010, tier 2, passed true', () => {
+      const code = 'function f() {}';
+      const results = checkUntypedStringMethod(code, filePath);
+      expect(results[0].ruleId).toBe('CDQ-010');
+      expect(results[0].passed).toBe(true);
+      expect(results[0].tier).toBe(2);
+      expect(results[0].blocking).toBe(false);
+    });
+  });
+});
+
+describe('CDQ-010 prompt guidance', () => {
+  it('instrumentation prompt includes guidance against calling string methods directly on property access', async () => {
+    const { getSystemPromptSections } = await import('../../../../src/languages/javascript/prompt.ts');
+    const sections = getSystemPromptSections();
+    // The constraints section should mention Date or toISOString as the safe pattern
+    expect(sections.constraints).toContain('toISOString');
+  });
+});

--- a/test/validation/parity.test.ts
+++ b/test/validation/parity.test.ts
@@ -98,7 +98,17 @@ describe('feature parity matrix', () => {
     expect(cdq009!.applicableTo('go')).toBe(false);
   });
 
-  it('all 28 expected rules are registered', () => {
+  it('CDQ-010 applies to JS/TS, not Python/Go (string method type safety check)', () => {
+    const rules = getAllRules();
+    const cdq010 = rules.find(r => r.ruleId === 'CDQ-010');
+    expect(cdq010).toBeDefined();
+    expect(cdq010!.applicableTo('javascript')).toBe(true);
+    expect(cdq010!.applicableTo('typescript')).toBe(true);
+    expect(cdq010!.applicableTo('python')).toBe(false);
+    expect(cdq010!.applicableTo('go')).toBe(false);
+  });
+
+  it('all 29 expected rules are registered', () => {
     const rules = getAllRules();
     const ruleIds = new Set(rules.map(r => r.ruleId));
 
@@ -106,7 +116,7 @@ describe('feature parity matrix', () => {
       'COV-001', 'COV-002', 'COV-003', 'COV-004', 'COV-005', 'COV-006',
       'RST-001', 'RST-002', 'RST-003', 'RST-004', 'RST-005',
       'NDS-003', 'NDS-004', 'NDS-005', 'NDS-006',
-      'CDQ-001', 'CDQ-006', 'CDQ-007', 'CDQ-008', 'CDQ-009',
+      'CDQ-001', 'CDQ-006', 'CDQ-007', 'CDQ-008', 'CDQ-009', 'CDQ-010',
       'API-001', 'API-002', 'API-003', 'API-004',
       'SCH-001', 'SCH-002', 'SCH-003', 'SCH-004',
     ];


### PR DESCRIPTION
## Summary

- Adds CDQ-010 advisory validation rule that detects string methods (`.split()`, `.slice()`, `.replace()`, etc.) called directly on property-access expressions (e.g., `commit.timestamp.split('T')`) inside `span.setAttribute` calls. Without type coercion, these crash at runtime when the field holds a `Date`, number, or other non-string type.
- Adds prompt guidance in the `constraints` section directing the agent to use `new Date(value).toISOString().split('T')[0]` for timestamp fields and `String(value)` for other unknown-type fields.
- Updates the parity test (28 → 29 registered rules).

## Test plan

- [ ] `cdq010.test.ts` — 21 tests covering all 7 flagged string methods, deeper property access, multiple findings, and all safe patterns (String() coercion, `.toString()`, `new Date().toISOString()`, simple identifiers, call expression receivers)
- [ ] `parity.test.ts` — updated to assert CDQ-010 is registered and applies to JS/TS only, and total rule count is 29
- [ ] Full suite: `npx vitest run` — 2069 tests, all pass

Closes #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CDQ-010 "String Method Type Safety" validation rule for JavaScript/TypeScript to detect unsafe string-method usage on property-access expressions.
  * Updated the JavaScript rule registry to include CDQ-010.

* **Behavior / Prompts**
  * Extended JS instrumentation guidance to require safe coercion (e.g., explicit String(...) or toISOString for timestamps) before calling string methods.

* **Tests**
  * Added comprehensive tests and updated parity checks to cover CDQ-010.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->