### PR TITLE
fix(prompt): add template literal preservation constraint

### DIFF
--- a/src/languages/javascript/prompt.ts
+++ b/src/languages/javascript/prompt.ts
@@ -246,6 +246,15 @@ export function getSystemPromptSections(): LanguagePromptSections {
   }
   \`\`\`
 - When guarding a variable before accessing its properties, always use \`!= null\` (loose inequality), not \`!== undefined\` (strict). \`!== undefined\` passes when the value is \`null\`, causing a TypeError on property access at runtime.
+- **Do not modify the content of existing template literals.** If you need to capture a template literal value as a span attribute, add \`span.setAttribute()\` **after** the template literal assignment using the already-assigned variable — never inline a span context expression within the template expression itself.
+  \`\`\`javascript
+  // WRONG — modifies the template literal content, triggers NDS-003
+  const systemContent = \`\${traceId}\n\${guidelines}\n\${sectionPrompt}\`;
+
+  // CORRECT — capture the template literal value first, then set the attribute after
+  const systemContent = \`\${guidelines}\n\${sectionPrompt}\`;
+  span.setAttribute('ai.system_prompt', systemContent);
+  \`\`\`
 - **Return-value capture is allowed.** When you need to call \`setAttribute\` on a return value, you may extract the expression to a \`const\`:
   \`\`\`javascript
   // Original: return computeResult();

--- a/test/languages/javascript/prompt.test.ts
+++ b/test/languages/javascript/prompt.test.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Tests for JavaScript-specific prompt sections.
+// ABOUTME: Verifies constraint guidance is present and correct.
+
+import { describe, it, expect } from 'vitest';
+import { getSystemPromptSections } from '../../../src/languages/javascript/prompt.ts';
+
+describe('JavaScript instrumentation prompt constraints', () => {
+  it('includes template literal preservation constraint', () => {
+    const sections = getSystemPromptSections();
+    // Must mention template literals and that they should not be modified
+    expect(sections.constraints).toContain('template literal');
+  });
+
+  it('directs agent to add setAttribute after the assignment, not inside the template expression', () => {
+    const sections = getSystemPromptSections();
+    // Must explain the correct pattern: setAttribute after the variable assignment
+    expect(sections.constraints).toContain('span.setAttribute');
+    expect(sections.constraints).toMatch(/after.*template literal|template literal.*after/i);
+  });
+});

--- a/test/languages/javascript/prompt.test.ts
+++ b/test/languages/javascript/prompt.test.ts
@@ -7,14 +7,13 @@ import { getSystemPromptSections } from '../../../src/languages/javascript/promp
 describe('JavaScript instrumentation prompt constraints', () => {
   it('includes template literal preservation constraint', () => {
     const sections = getSystemPromptSections();
-    // Must mention template literals and that they should not be modified
-    expect(sections.constraints).toContain('template literal');
+    expect(sections.constraints).toContain('Do not modify the content of existing template literals.');
   });
 
   it('directs agent to add setAttribute after the assignment, not inside the template expression', () => {
     const sections = getSystemPromptSections();
-    // Must explain the correct pattern: setAttribute after the variable assignment
     expect(sections.constraints).toContain('span.setAttribute');
     expect(sections.constraints).toMatch(/after.*template literal|template literal.*after/i);
+    expect(sections.constraints).toContain('never inline a span context expression within the template expression itself');
   });
 });


### PR DESCRIPTION
## Summary

- Adds a prompt constraint prohibiting the agent from modifying existing template literal content when adding span attributes.
- The correct pattern: capture the template literal into a variable first (which the original code already does), then call `span.setAttribute()` after — never inject expressions into the template itself.
- Adds a test (`test/languages/javascript/prompt.test.ts`) verifying the constraint is present.

## Motivation

`summaryNode` in `journal-graph.js` failed NDS-003 (Code Preserved) in three consecutive runs (11, 12, 13). Root cause: the function has no early-exit guard, so the agent had no natural anchor for span-start code. Instead it injected span context into the first line of the template literal (`const systemContent = \`...\``), modifying the original line and triggering NDS-003.

The new constraint gives the agent an explicit rule and a code example covering this case.

## Test plan

- [ ] `test/languages/javascript/prompt.test.ts` — 2 tests verifying the constraints section mentions template literals and the after-assignment pattern
- [ ] Full suite: `npx vitest run` — 2051 tests (base + 2 new), all pass

Closes #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified prompt guidance for JavaScript: preserve existing template literal content and capture values into a variable before calling span.setAttribute; disallow inlining span context expressions inside template expressions.

* **Tests**
  * Added tests to validate the new constraint wording and enforcement for JavaScript prompt generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->