### PR TITLE
fix(430): improve PR summary readability for human reviewers

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -240,9 +240,9 @@ When you cannot instrument a function because doing so would require modifying n
 **When NOT to report**: Do not report refactors for patterns you can work around. Only report transforms you genuinely need but cannot make without changing business logic.
 
 Each entry in \`suggestedRefactors\` has:
-- \`description\`: What the user should change (human-readable)
+- \`description\`: What the user should change, in plain English. Name the function and describe the structural change needed. Do not cite rule IDs without explaining them. Good: \`"Extract the template literal in summaryNode (line 445) to a const variable so span.setAttribute can reference the already-assigned value after the assignment"\`. Bad: \`"NDS-003 refactor needed in summaryNode"\`.
 - \`diff\`: Unified diff showing the before/after (the user applies this)
-- \`reason\`: Why the agent needs this change to instrument correctly
+- \`reason\`: One sentence explaining what the current code structure prevents — describe the structural problem, not the rule that caught it. Good: \`"The template literal assigns directly inline — adding span context before it would modify the original line, which validation rejects as a non-instrumentation change"\`. Bad: \`"NDS-003 violation"\`.
 - \`unblocksRules\`: Which validation rules block instrumentation (e.g., \`["NDS-003"]\`)
 - \`startLine\`: First line of the code that needs refactoring (1-based)
 - \`endLine\`: Last line of the code that needs refactoring (1-based)
@@ -272,7 +272,23 @@ You are returning structured JSON via the output schema. Fill in each field:
 - \`attributesCreated\`: Count of new span attributes added that were not in the existing schema. 0 if none.
 - \`spanCategories\`: Breakdown of spans added: \`{ externalCalls, schemaDefined, serviceEntryPoints, totalFunctionsInFile }\`. Set to null only if the file could not be processed at all.
 - \`suggestedRefactors\`: Array of refactors the user should apply before re-running the agent. Empty array if no blocked transforms were identified. See the Suggested Refactors section above for field details.
-- \`notes\`: Array of 3-5 judgment call explanations focusing on non-obvious decisions. Include: why functions were skipped, why specific attributes were chosen, ratio backstop warnings, variable shadowing decisions, already-instrumented detections. Standard patterns (span wrapping, error recording, import additions) do not need notes — only explain what is surprising or requires judgment. Return an empty array if there are no non-obvious decisions to document.`;
+- \`notes\`: Array of 3-5 judgment call explanations focusing on non-obvious decisions. Include: why functions were skipped, why specific attributes were chosen, ratio backstop warnings, variable shadowing decisions, already-instrumented detections. Standard patterns (span wrapping, error recording, import additions) do not need notes — only explain what is surprising or requires judgment. Return an empty array if there are no non-obvious decisions to document.
+
+  **Write for an external reader.** Every note must be self-contained: name the function, describe what it does or what happened, and only then cite any rule — always with a plain-English explanation alongside it. A reviewer reading this PR has never seen the codebase and doesn\'t know the rule registry.
+
+  For each decision, follow this structure: *what the function does → what happened → why (with rule in parentheses if applicable)*. Never cite a rule ID alone.
+
+  Good:
+  - \`"formatTimestamp is a pure synchronous helper with no I/O — it doesn\'t need a span (RST-001: no spans on synchronous utilities)"\`
+  - \`"processEntry makes an LLM API call and is exported — it gets its own span even though it\'s called from within an already-instrumented parent (COV-004: all exported async operations must have spans)"\`
+  - \`"summaryNode cannot be instrumented without modifying the template literal on line 445, which validation rejects as a non-instrumentation change (NDS-003: original code must be preserved exactly). Recommend extracting the template literal to a const before re-running"\`
+  - \`"Used \'commit.sha\' for the span attribute rather than a generic \'id\' — \'commit.sha\' matches the domain terminology and the Weaver schema\'s registered key for this field"\`
+
+  Bad:
+  - \`"skipped per RST-001"\`
+  - \`"NDS-003: original line 27 missing/modified"\`
+  - \`"COV-004 exemption not applicable"\`
+  - \`"SCH-002 violation avoided"\``;
 }
 
 /**

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -559,8 +559,11 @@ export async function dispatchFiles(
                   const failingSources = testResult.output
                     ? parseFailingSourceFiles(testResult.output, windowPaths)
                     : [];
+                  const baseNames = failingSources.map(p => basename(p));
+                  const hasDuplicates = new Set(baseNames).size !== baseNames.length;
+                  const displayNames = hasDuplicates ? failingSources : baseNames;
                   const failureSummary = failingSources.length > 0
-                    ? `changes to ${failingSources.map(p => basename(p)).join(', ')} broke tests`
+                    ? `changes to ${displayNames.join(', ')} broke tests`
                     : 'tests failed';
                   extWarnings.push(
                     `Checkpoint test run failed at file ${i + 1}/${total} ` +

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Includes already-instrumented detection, schema re-resolution per file, and sequential dispatch to instrumentWithRetry.
 
 import { readFile, writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { resolve, basename } from 'node:path';
 import { execFile } from 'node:child_process';
 import type { LanguageProvider } from '../languages/types.ts';
 import { JavaScriptProvider } from '../languages/javascript/index.ts';
@@ -555,9 +555,16 @@ export async function dispatchFiles(
                 testFailedAtCheckpoint = true;
                 lastTestOutput = testResult.output;
                 if (extWarnings) {
+                  const windowPaths = checkpointWindowFiles.map(f => f.path);
+                  const failingSources = testResult.output
+                    ? parseFailingSourceFiles(testResult.output, windowPaths)
+                    : [];
+                  const failureSummary = failingSources.length > 0
+                    ? `changes to ${failingSources.map(p => basename(p)).join(', ')} broke tests`
+                    : 'tests failed';
                   extWarnings.push(
                     `Checkpoint test run failed at file ${i + 1}/${total} ` +
-                    `(${filePath}): ${testResult.error ?? 'tests failed'}`,
+                    `(${filePath}): ${failureSummary}`,
                   );
                 }
               }

--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -364,7 +364,7 @@ function renderReviewSensitivity(runResult: RunResult, config: AgentConfig, disp
       const [, { fileDisplay, annotations }] = fileEntries[i];
       lines.push(`**${fileDisplay}**`);
       for (const ann of annotations) {
-        lines.push(`- ${formatRuleId(ann.ruleId)}: ${ann.message}`);
+        lines.push(`- ${formatRuleId(ann.ruleId)}: ${expandRuleCodesInText(ann.message)}`);
       }
       if (i < fileEntries.length - 1) {
         lines.push('');

--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -197,8 +197,12 @@ function renderSchemaChanges(runResult: RunResult): string {
   lines.push('');
 
   if (runResult.schemaDiff) {
-    lines.push('### New Attribute Keys');
-    lines.push('');
+    // Only add a heading when the diff doesn't already contain its own ### headings.
+    // Real Weaver output uses plain-text labels; test fixtures may contain markdown headers.
+    if (!/^###\s/m.test(runResult.schemaDiff)) {
+      lines.push('### New Attribute Keys');
+      lines.push('');
+    }
     lines.push(runResult.schemaDiff);
   } else {
     lines.push('No schema changes detected.');
@@ -417,10 +421,10 @@ function computeSensitivityWarnings(runResult: RunResult, config: AgentConfig, d
 }
 
 function renderAgentNotes(runResult: RunResult, display: DisplayFn): string {
-  // Exclude zero-span success files — their notes are repetitive ("No instrumentable functions")
-  // and already summarized in the per-file table's "No changes needed" line.
+  // Only show the pointer when at least one committed file has notes — failed files
+  // may not have a companion .instrumentation.md if they were never written to disk.
   const filesWithNotes = runResult.fileResults.filter(
-    f => f.notes && f.notes.length > 0 && !(f.status === 'success' && f.spansAdded === 0),
+    f => f.notes && f.notes.length > 0 && (f.status === 'success' || f.status === 'partial') && f.spansAdded > 0,
   );
 
   if (filesWithNotes.length === 0) return '';

--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -364,7 +364,10 @@ function renderReviewSensitivity(runResult: RunResult, config: AgentConfig, disp
       const [, { fileDisplay, annotations }] = fileEntries[i];
       lines.push(`**${fileDisplay}**`);
       for (const ann of annotations) {
-        lines.push(`- ${formatRuleId(ann.ruleId)}: ${expandRuleCodesInText(ann.message)}`);
+        // Strip leading "RULE-NNN: " prefix from message — already rendered via formatRuleId above.
+        // Then expand any other rule codes in the body to include their human-readable labels.
+        const messageBody = ann.message.replace(/^[A-Z]{2,4}-\d{3}[a-z]?:\s*/, '');
+        lines.push(`- ${formatRuleId(ann.ruleId)}: ${expandRuleCodesInText(messageBody)}`);
       }
       if (i < fileEntries.length - 1) {
         lines.push('');

--- a/src/deliverables/pr-summary.ts
+++ b/src/deliverables/pr-summary.ts
@@ -84,7 +84,7 @@ function renderSummaryHeader(runResult: RunResult, config: AgentConfig): string 
   lines.push(`- **Files processed**: ${runResult.filesProcessed}`);
   lines.push(`- **Committed**: ${committed}`);
   if (correctSkips > 0) {
-    lines.push(`- **Correct skips**: ${correctSkips}`);
+    lines.push(`- **No changes needed**: ${correctSkips}`);
   }
   if (runResult.filesFailed > 0) {
     lines.push(`- **Failed**: ${runResult.filesFailed}`);
@@ -152,7 +152,7 @@ function renderPerFileStatus(runResult: RunResult, config: AgentConfig, display:
   if (zeroSpanFiles.length > 0) {
     const names = zeroSpanFiles.map(f => display(f.path)).join(', ');
     lines.push('');
-    lines.push(`**Correct skips** (${zeroSpanFiles.length} files, 0 spans): ${names}`);
+    lines.push(`**No changes needed** (${zeroSpanFiles.length} files, 0 spans): ${names}`);
   }
 
   return lines.join('\n');
@@ -197,6 +197,8 @@ function renderSchemaChanges(runResult: RunResult): string {
   lines.push('');
 
   if (runResult.schemaDiff) {
+    lines.push('### New Attribute Keys');
+    lines.push('');
     lines.push(runResult.schemaDiff);
   } else {
     lines.push('No schema changes detected.');
@@ -208,7 +210,7 @@ function renderSchemaChanges(runResult: RunResult): string {
   const spanExtensions = collectSpanExtensionIds(runResult);
   if (spanExtensions.length > 0) {
     lines.push('');
-    lines.push(`### Span Extensions (${spanExtensions.length})`);
+    lines.push(`### New Span IDs (${spanExtensions.length})`);
     lines.push('');
     for (const spanId of spanExtensions) {
       lines.push(`- \`${spanId}\``);
@@ -342,32 +344,26 @@ function renderReviewSensitivity(runResult: RunResult, config: AgentConfig, disp
     lines.push('### Advisory Findings');
     lines.push('');
 
-    // Group by ruleId + message to collapse repeated findings.
-    // Use canonical filePath for deduplication, display path for rendering.
-    const groups = new Map<string, { ruleId: string; message: string; filePathSet: Set<string>; fileDisplayMap: Map<string, string> }>();
+    // Group by file so reviewers can navigate finding by finding within each file.
+    const fileGroups = new Map<string, { fileDisplay: string; annotations: CheckResult[] }>();
     for (const { filePath, fileDisplay, annotation } of allAdvisory) {
-      const key = `${annotation.ruleId}|${annotation.message}`;
-      const existing = groups.get(key);
+      const existing = fileGroups.get(filePath);
       if (existing) {
-        existing.filePathSet.add(filePath);
-        existing.fileDisplayMap.set(filePath, fileDisplay);
+        existing.annotations.push(annotation);
       } else {
-        groups.set(key, {
-          ruleId: annotation.ruleId,
-          message: annotation.message,
-          filePathSet: new Set([filePath]),
-          fileDisplayMap: new Map([[filePath, fileDisplay]]),
-        });
+        fileGroups.set(filePath, { fileDisplay, annotations: [annotation] });
       }
     }
 
-    for (const { ruleId, message, filePathSet, fileDisplayMap } of groups.values()) {
-      const displayNames = [...filePathSet].map(p => fileDisplayMap.get(p) ?? p);
-      if (displayNames.length === 1) {
-        lines.push(`- **${formatRuleId(ruleId)}** (${displayNames[0]}): ${message}`);
-      } else {
-        lines.push(`- **${formatRuleId(ruleId)}** (${displayNames.length} files): ${message}`);
-        lines.push(`  Files: ${displayNames.join(', ')}`);
+    const fileEntries = [...fileGroups.entries()];
+    for (let i = 0; i < fileEntries.length; i++) {
+      const [, { fileDisplay, annotations }] = fileEntries[i];
+      lines.push(`**${fileDisplay}**`);
+      for (const ann of annotations) {
+        lines.push(`- ${formatRuleId(ann.ruleId)}: ${ann.message}`);
+      }
+      if (i < fileEntries.length - 1) {
+        lines.push('');
       }
     }
   }
@@ -422,30 +418,19 @@ function computeSensitivityWarnings(runResult: RunResult, config: AgentConfig, d
 
 function renderAgentNotes(runResult: RunResult, display: DisplayFn): string {
   // Exclude zero-span success files — their notes are repetitive ("No instrumentable functions")
-  // and already summarized in the per-file table's "Correct skips" line.
+  // and already summarized in the per-file table's "No changes needed" line.
   const filesWithNotes = runResult.fileResults.filter(
     f => f.notes && f.notes.length > 0 && !(f.status === 'success' && f.spansAdded === 0),
   );
 
   if (filesWithNotes.length === 0) return '';
 
-  const lines: string[] = ['## Agent Notes'];
-  lines.push('');
-
-  const MAX_NOTES_PER_FILE = 3;
-  for (const file of filesWithNotes) {
-    lines.push(`**${display(file.path)}**:`);
-    const shown = file.notes!.slice(0, MAX_NOTES_PER_FILE);
-    for (const note of shown) {
-      lines.push(`- ${expandRuleCodesInText(note)}`);
-    }
-    if (file.notes!.length > MAX_NOTES_PER_FILE) {
-      lines.push(`- *... ${file.notes!.length - MAX_NOTES_PER_FILE} more notes in reasoning report*`);
-    }
-    lines.push('');
-  }
-
-  return lines.join('\n').trimEnd();
+  return [
+    '## Agent Notes',
+    '',
+    "Each instrumented file has a companion `.instrumentation.md` file in the same directory " +
+    '(e.g., `src/api.js` → `src/api.instrumentation.md`) containing the agent\'s full decision notes.',
+  ].join('\n');
 }
 
 function renderRecommendedRefactors(runResult: RunResult, display: DisplayFn): string {
@@ -515,12 +500,18 @@ function renderCompanionPackages(runResult: RunResult, config: AgentConfig): str
     lines.push(`- \`${pkg}\``);
   }
 
+  lines.push('');
+  lines.push(
+    '> **Important**: Initialize these packages **inside your application code**, not via `--import`. ' +
+    'Loading them through `--import` can install a competing ESM hook registry alongside the one ' +
+    'already registered by your OTel SDK, causing spans to be created but silently dropped — ' +
+    'the exporter reports success but data never reaches the backend.',
+  );
+
   if (config.targetType === 'short-lived') {
     lines.push('');
     lines.push(
-      '> **Short-lived process warning**: Do not load these packages via `--import`. ' +
-      'Initialize them in-app instead to avoid ESM hook conflicts that cause silent span loss. ' +
-      'See the Short-Lived Process Setup Guidance section below for details.',
+      '> See the Short-Lived Process Setup Guidance section below for additional setup details.',
     );
   }
 
@@ -574,20 +565,6 @@ function renderShortLivedSetupGuidance(config: AgentConfig): string {
   lines.push('    .finally(() => originalExit.call(process, process.exitCode));');
   lines.push('};');
   lines.push('```');
-  lines.push('');
-  lines.push('### Auto-Instrumentation Warning');
-  lines.push('');
-  lines.push(
-    '**Do not load third-party auto-instrumentation packages via `--import`.** ' +
-    'They may bring a different version of `@opentelemetry/instrumentation` which installs ' +
-    'a separate `import-in-the-middle` with its own ESM hook registry. This causes silent span loss — ' +
-    'the exporter reports success but spans never reach the backend.',
-  );
-  lines.push('');
-  lines.push(
-    'Instead, initialize auto-instrumentation **inside your application code** (not in the `--import` bootstrap). ' +
-    'This avoids the competing ESM hook registries.',
-  );
 
   return lines.join('\n');
 }

--- a/test/coordinator/dispatch-checkpoint-rollback.test.ts
+++ b/test/coordinator/dispatch-checkpoint-rollback.test.ts
@@ -402,7 +402,9 @@ describe('dispatchFiles — checkpoint test failure rollback', () => {
       // Should have a warning about the test failure AND a warning about rollback
       const rollbackWarning = warnings.find(w => w.toLowerCase().includes('rolled back'));
       expect(rollbackWarning).toBeDefined();
-      expect(warnings.some(w => w.includes('ReferenceError: tracer is not defined'))).toBe(true);
+      // Checkpoint warning should mention test failure without dumping raw error output
+      const checkpointWarning = warnings.find(w => w.includes('Checkpoint test run failed'));
+      expect(checkpointWarning).toBeDefined();
     });
   });
 });

--- a/test/coordinator/dispatch-checkpoint-rollback.test.ts
+++ b/test/coordinator/dispatch-checkpoint-rollback.test.ts
@@ -405,6 +405,7 @@ describe('dispatchFiles — checkpoint test failure rollback', () => {
       // Checkpoint warning should mention test failure without dumping raw error output
       const checkpointWarning = warnings.find(w => w.includes('Checkpoint test run failed'));
       expect(checkpointWarning).toBeDefined();
+      expect(checkpointWarning).not.toContain('ReferenceError: tracer is not defined');
     });
   });
 });

--- a/test/deliverables/git-workflow-integration.test.ts
+++ b/test/deliverables/git-workflow-integration.test.ts
@@ -272,6 +272,6 @@ describe('git workflow integration', () => {
     expect(capturedPrBody).toContain('## Schema Changes');
     expect(capturedPrBody).toContain('## Token Usage');
     expect(capturedPrBody).toContain('## Agent Notes');
-    expect(capturedPrBody).toContain('Added HTTP span');
+    expect(capturedPrBody).toContain('.instrumentation.md');
   }, 30000);
 });

--- a/test/deliverables/pr-summary.test.ts
+++ b/test/deliverables/pr-summary.test.ts
@@ -341,7 +341,7 @@ describe('renderPrSummary', () => {
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      expect(md).toContain('Span Extensions');
+      expect(md).toContain('New Span IDs');
       expect(md).toContain('span.myapp.fetch_data');
       expect(md).toContain('span.myapp.process_order');
     });
@@ -357,7 +357,7 @@ describe('renderPrSummary', () => {
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      expect(md).not.toContain('Span Extensions');
+      expect(md).not.toContain('New Span IDs');
     });
 
     it('deduplicates span extensions across multiple files', () => {
@@ -378,8 +378,8 @@ describe('renderPrSummary', () => {
 
       // fetch_data appears in both files but should render once
       const matches = md.match(/span\.myapp\.fetch_data/g);
-      // One in per-file table extensions column + one in Span Extensions list
-      const spanSection = md.split('### Span Extensions')[1]?.split('##')[0] ?? '';
+      // One in per-file table extensions column + one in New Span IDs list
+      const spanSection = md.split('### New Span IDs')[1]?.split('##')[0] ?? '';
       expect(spanSection.match(/span\.myapp\.fetch_data/g)).toHaveLength(1);
       expect(spanSection).toContain('span.myapp.save');
     });
@@ -396,7 +396,7 @@ describe('renderPrSummary', () => {
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      expect(md).toContain('Span Extensions');
+      expect(md).toContain('New Span IDs');
       expect(md).toContain('span.myapp.partial_span');
     });
 
@@ -411,7 +411,7 @@ describe('renderPrSummary', () => {
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      expect(md).toContain('Span Extensions');
+      expect(md).toContain('New Span IDs');
       expect(md).toContain('myapp.custom_operation');
     });
 
@@ -430,11 +430,11 @@ describe('renderPrSummary', () => {
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      expect(md).toContain('Span Extensions');
+      expect(md).toContain('New Span IDs');
       expect(md).toContain('span.myapp.cli.main');
       expect(md).toContain('span.myapp.context.gather');
-      // Non-span bare string should not appear in the Span Extensions section
-      const spanSection = md.split('### Span Extensions')[1]?.split('##')[0] ?? '';
+      // Non-span bare string should not appear in the New Span IDs section
+      const spanSection = md.split('### New Span IDs')[1]?.split('##')[0] ?? '';
       expect(spanSection).not.toContain('myapp.request.method');
     });
   });
@@ -673,7 +673,7 @@ describe('renderPrSummary', () => {
     });
   });
 
-    it('groups repeated advisories by rule ID with file count', () => {
+    it('groups advisories by file — each file gets its own section with a blank line between files', () => {
       const makeAdvisory = (file: string) => ({
         ruleId: 'CDQ-006',
         passed: false,
@@ -692,72 +692,33 @@ describe('renderPrSummary', () => {
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      // Should group identical advisories into exactly 1 entry, not 3 separate lines
+      // Each file gets its own header and finding — 3 separate CDQ-006 bullets
       const advisorySection = md.split('### Advisory Findings')[1]?.split('##')[0] ?? '';
       const cdq006Bullets = advisorySection.split('\n').filter(l => l.startsWith('- ') && l.includes('CDQ-006'));
-      expect(cdq006Bullets).toHaveLength(1); // exactly 1 grouped entry
-      expect(advisorySection).toContain('3 files'); // mentions file count
-      // All three files appear in the grouped output
-      expect(advisorySection).toContain('a.js');
-      expect(advisorySection).toContain('b.js');
-      expect(advisorySection).toContain('c.js');
+      expect(cdq006Bullets).toHaveLength(3);
+      // All three files appear as bold headers
+      expect(advisorySection).toContain('**a.js**');
+      expect(advisorySection).toContain('**b.js**');
+      expect(advisorySection).toContain('**c.js**');
+      // Blank lines separate the file sections
+      expect(advisorySection).toContain('\n\n');
     });
 
   describe('agent notes section', () => {
-    it('includes notes from each file', () => {
+    it('shows companion file pointer when any file has notes', () => {
       const result = _makeRunResult({
         fileResults: [
           _makeFileResult({
             path: '/project/src/api-client.js',
             notes: ['Added context propagation for outgoing HTTP calls'],
           }),
-          _makeFileResult({
-            path: '/project/src/db-handler.js',
-            notes: ['File has 600 lines — may benefit from splitting'],
-          }),
         ],
       });
       const md = renderPrSummary(result, _makeConfig());
 
-      expect(md).toContain('context propagation');
-      expect(md).toContain('600 lines');
-    });
-
-    it('truncates notes to first 3 per file in PR summary', () => {
-      const notes = Array.from({ length: 10 }, (_, i) => `Note ${i + 1} about instrumentation decisions`);
-      const result = _makeRunResult({
-        fileResults: [
-          _makeFileResult({
-            path: '/project/src/api-client.js',
-            notes,
-          }),
-        ],
-      });
-      const md = renderPrSummary(result, _makeConfig());
-
-      const notesSection = md.split('## Agent Notes')[1]?.split('##')[0] ?? '';
-      // Should show exactly 3 notes, not all 10
-      const noteLines = notesSection.split('\n').filter(l => l.startsWith('- Note'));
-      expect(noteLines).toHaveLength(3);
-      // First 3 notes present, 4th absent
-      expect(notesSection).toContain('Note 1');
-      expect(notesSection).toContain('Note 3');
-      expect(notesSection).not.toContain('Note 4 about');
-      // Should indicate 7 more notes exist
-      expect(notesSection).toContain('7 more');
-    });
-
-    it('expands rule codes in notes to include labels', () => {
-      const result = _makeRunResult({
-        fileResults: [
-          _makeFileResult({ notes: ['skipped per RST-001, RST-003'] }),
-        ],
-      });
-      const md = renderPrSummary(result, _makeConfig());
-
-      const notesSection = md.split('## Agent Notes')[1]?.split('##')[0] ?? '';
-      expect(notesSection).toContain('RST-001 (No Utility Spans)');
-      expect(notesSection).toContain('RST-003 (No Thin Wrapper Spans)');
+      expect(md).toContain('## Agent Notes');
+      expect(md).toContain('.instrumentation.md');
+      expect(md).toContain('same directory');
     });
 
     it('skips notes section when no files have notes', () => {
@@ -1284,25 +1245,25 @@ describe('renderPrSummary', () => {
       expect(md).not.toContain('Recommended Companion Packages');
     });
 
-    it('includes --import warning for short-lived targets with companion packages', () => {
-      const result = _makeRunResult({
-        companionPackages: ['@traceloop/instrumentation-langchain'],
-      });
-      const md = renderPrSummary(result, _makeConfig({ targetType: 'short-lived' }));
-
-      expect(md).toContain('Recommended Companion Packages');
-      expect(md).toContain('--import');
-      expect(md).toContain('in-app');
-    });
-
-    it('does not include --import warning for long-lived targets with companion packages', () => {
+    it('includes in-app initialization warning for all targets with companion packages', () => {
       const result = _makeRunResult({
         companionPackages: ['@traceloop/instrumentation-langchain'],
       });
       const md = renderPrSummary(result, _makeConfig({ targetType: 'long-lived' }));
+
+      expect(md).toContain('Recommended Companion Packages');
+      expect(md).toContain('--import');
+      expect(md).toContain('inside your application code');
+    });
+
+    it('includes short-lived section link for short-lived targets with companion packages', () => {
+      const result = _makeRunResult({
+        companionPackages: ['@traceloop/instrumentation-langchain'],
+      });
+      const md = renderPrSummary(result, _makeConfig({ targetType: 'short-lived' }));
       const companionSection = md.split('## Recommended Companion Packages')[1]?.split('##')[0] ?? '';
 
-      expect(companionSection).not.toContain('--import');
+      expect(companionSection).toContain('Short-Lived Process Setup Guidance');
     });
   });
 
@@ -1377,12 +1338,9 @@ describe('renderPrSummary', () => {
       const result = _makeRunResult({ fileResults: files, filesSucceeded: 3 });
       const md = renderPrSummary(result, _makeConfig());
 
-      // Instrumented file notes should appear
-      expect(md).toContain('Instrumented 3 functions');
-      // Zero-span file notes should NOT appear individually in Agent Notes section
-      const notesSection = md.split('## Agent Notes')[1]?.split('##')[0] ?? '';
-      expect(notesSection).not.toContain('skip1.js');
-      expect(notesSection).not.toContain('skip2.js');
+      // Instrumented file (api.js) has notes — Agent Notes section should appear with companion pointer
+      expect(md).toContain('## Agent Notes');
+      expect(md).toContain('.instrumentation.md');
     });
 
     it('distinguishes committed vs correct-skip in summary header', () => {
@@ -1395,7 +1353,7 @@ describe('renderPrSummary', () => {
 
       expect(md).toContain('Committed');
       expect(md).toContain('1');
-      expect(md).toContain('Correct skips');
+      expect(md).toContain('No changes needed');
     });
   });
 
@@ -1435,12 +1393,14 @@ describe('renderPrSummary', () => {
       expect(md).toContain('process.exit');
     });
 
-    it('warns about auto-instrumentation --import conflict for short-lived targets', () => {
+    it('does not include auto-instrumentation warning — that lives in companion packages section', () => {
       const result = _makeRunResult();
       const md = renderPrSummary(result, _makeConfig({ targetType: 'short-lived' }));
 
-      expect(md).toContain('auto-instrumentation');
-      expect(md).toContain('--import');
+      expect(md).not.toContain('Auto-Instrumentation Warning');
+      // Essential setup content still present
+      expect(md).toContain('SimpleSpanProcessor');
+      expect(md).toContain('process.exit');
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Agent prompt**: adds external reader guidelines to `notes` and `suggestedRefactors` fields — name the function, explain what happened, always accompany rule IDs with plain-English descriptions. Four concrete good/bad examples using real project patterns (RST-001, NDS-003, COV-004, schema attribution).
- **PR summary rendering**: seven targeted improvements across sections — see commit message for full list.
- **Checkpoint warnings**: replaces raw test stderr dump with human-readable failure summary using the existing `parseFailingSourceFiles` parser.

## Test plan

- [ ] `test/deliverables/pr-summary.test.ts` — 70 tests covering all changed sections
- [ ] `test/coordinator/dispatch-checkpoint-rollback.test.ts` — updated checkpoint warning assertion
- [ ] `test/deliverables/git-workflow-integration.test.ts` — updated agent notes assertion
- [ ] Full suite: `npx vitest run` — 2071 tests, all pass

Closes #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failure warnings now summarize which changed files likely broke tests instead of exposing raw error traces.

* **Refactor**
  * PR summary sections relabeled (e.g., "No changes needed", "New Span IDs"); schema diff heading insertion improved.
  * Advisory findings grouped and listed per-file with cleaner formatting.
  * Agent notes condensed to a single pointer to a companion .instrumentation.md and adjusted eligibility.
  * Companion package guidance simplified with an admonition to initialize in application code; removed auto-instrumentation warning.

* **Tests**
  * Tests updated to expect sanitized warnings, new section labels, and the .instrumentation.md pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->