### PR TITLE
fix(439): commit partial instrumentation results to git

### DIFF
--- a/src/deliverables/git-workflow.ts
+++ b/src/deliverables/git-workflow.ts
@@ -113,8 +113,10 @@ export async function runGitWorkflow(
       // Fire caller's callback first
       callerCallbacks?.onFileComplete?.(result, index, total);
 
-      // Per-file commit for successful files (skip in dry-run)
-      if (!dryRun && result.status === 'success') {
+      // Per-file commit for successful and partial files (skip in dry-run).
+      // Partial files have at least one successfully instrumented function — that work
+      // should land in git even if other functions in the same file could not be instrumented.
+      if (!dryRun && (result.status === 'success' || result.status === 'partial')) {
         commitChain = commitChain
           .then(async () => {
             // Lazy branch creation: create branch on first successful file

--- a/src/git/per-file-commit.ts
+++ b/src/git/per-file-commit.ts
@@ -28,8 +28,10 @@ export interface CommitFileResultOptions {
 /**
  * Commit a single file's instrumentation result to the repository.
  *
- * For successful files: stages the instrumented source file and (if applicable)
- * the schema extensions file, then commits with a descriptive message.
+ * For successful and partial files: stages the instrumented source file and (if
+ * applicable) the schema extensions file, then commits with a descriptive message.
+ * Partial files have at least one successfully instrumented function and their
+ * work should land in git even if some functions could not be instrumented.
  *
  * For failed or skipped files: returns undefined without creating a commit.
  *
@@ -43,7 +45,7 @@ export async function commitFileResult(
   projectDir: string,
   options?: CommitFileResultOptions,
 ): Promise<string | undefined> {
-  if (result.status !== 'success') {
+  if (result.status !== 'success' && result.status !== 'partial') {
     return undefined;
   }
 

--- a/test/deliverables/git-workflow.test.ts
+++ b/test/deliverables/git-workflow.test.ts
@@ -206,6 +206,34 @@ describe('runGitWorkflow', () => {
       expect(callArgs.companionFiles[0].content).toContain('Instrumentation Report');
     });
 
+    it('commits partial files — successfully instrumented functions should land in git', async () => {
+      const partialFile = makeFileResult({
+        path: '/project/src/graph.js',
+        status: 'partial',
+        spansAdded: 3,
+        functionsInstrumented: 11,
+        functionsSkipped: 1,
+      });
+      const deps = makeDeps({
+        coordinate: vi.fn().mockImplementation(async (_dir, _config, callbacks) => {
+          callbacks?.onFileComplete?.(partialFile, 0, 1);
+          return makeRunResult({ fileResults: [partialFile], filesPartial: 1, filesSucceeded: 0 });
+        }),
+      });
+
+      await runGitWorkflow(makeOptions(), deps);
+
+      expect(deps.commitFileResult).toHaveBeenCalledWith(
+        partialFile,
+        '/project',
+        expect.objectContaining({ registryDir: '/project/semconv' }),
+      );
+      // Companion file should be created for partial results too
+      const callArgs = (deps.commitFileResult as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      expect(callArgs.companionFiles).toHaveLength(1);
+      expect(callArgs.companionFiles[0].path).toBe('/project/src/graph.instrumentation.md');
+    });
+
     it('does not commit failed files', async () => {
       const failedFile = makeFileResult({ status: 'failed', reason: 'Syntax error' });
       const deps = makeDeps({

--- a/test/git/per-file-commit.test.ts
+++ b/test/git/per-file-commit.test.ts
@@ -105,6 +105,28 @@ describe('commitFileResult', () => {
     expect(committedFiles).toContain('telemetry/registry/agent-extensions.yaml');
   });
 
+  it('commits a partial file — successfully instrumented functions should land in git', async () => {
+    const srcDir = join(repoDir, 'src');
+    await mkdir(srcDir, { recursive: true });
+    const filePath = join(repoDir, 'src', 'graph.js');
+    await writeFile(filePath, 'import { trace } from "@opentelemetry/api";\n// partial instrumentation\n');
+
+    const result = makeFileResult({
+      path: filePath,
+      status: 'partial',
+      spansAdded: 3,
+      functionsInstrumented: 11,
+      functionsSkipped: 1,
+    });
+    const commitHash = await commitFileResult(result, repoDir);
+
+    expect(commitHash).toMatch(/^[a-f0-9]+$/);
+
+    const git = simpleGit(repoDir);
+    const log = await git.log({ maxCount: 1 });
+    expect(log.latest?.message).toBe('instrument src/graph.js');
+  });
+
   it('returns undefined and does not commit for failed files', async () => {
     const filePath = join(repoDir, 'src', 'broken.js');
     const result = makeFileResult({ path: filePath, status: 'failed' });


### PR DESCRIPTION
## Summary

Partial files (functions partially instrumented due to validation failures like NDS-003) were written to disk by the fix loop but never committed to git. The PR summary would report "partial (11/12 functions, 3 spans)" while `git diff` showed no change — the work was silently discarded.

The fix loop already writes the assembled partial code to disk and has a comment saying "Commit the partial code regardless." The git workflow was simply never wired to follow through. This one-line change makes validation-failure partials consistent with infrastructure-failure partials.

## Test plan

- [ ] New test: `commits partial files — successfully instrumented functions should land in git` — verifies `commitFileResult` is called for `status='partial'` files with the correct companion `.instrumentation.md`
- [ ] Existing test: `does not commit failed files` — unchanged, failed files still not committed
- [ ] Full suite: `npx vitest run` — 2074 tests, all pass

Closes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow now creates git commits for files with partial instrumentation success (not just fully successful files), ensuring partially instrumented work is recorded and companion files are registered.

* **Tests**
  * Added unit tests covering partial-instrumentation scenarios to verify commits, commit messages, and companion-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->