### PR TITLE
fix(findExports): deduplicate export default function foo() {} entries

### DIFF
--- a/src/languages/javascript/index.ts
+++ b/src/languages/javascript/index.ts
@@ -192,15 +192,19 @@ export class JavaScriptProvider implements LanguageProvider {
     });
     const sourceFile = project.createSourceFile('file.js', source);
     const exports: ExportInfo[] = [];
+    const seen = new Set<string>();
 
     // Named function declarations: export function foo() {}
+    // export default function foo() {} — tracked under key 'default' to prevent
+    // getDefaultExportSymbol() from adding a second entry for the same declaration.
     for (const fn of sourceFile.getFunctions()) {
       if (fn.isExported()) {
-        exports.push({
-          name: fn.getName() ?? '<anonymous>',
-          lineNumber: fn.getStartLineNumber(),
-          isDefault: fn.isDefaultExport(),
-        });
+        const name = fn.getName() ?? '<anonymous>';
+        const isDefault = fn.isDefaultExport();
+        const seenKey = isDefault ? 'default' : name;
+        if (seen.has(seenKey)) continue;
+        seen.add(seenKey);
+        exports.push({ name, lineNumber: fn.getStartLineNumber(), isDefault });
       }
     }
 
@@ -208,11 +212,10 @@ export class JavaScriptProvider implements LanguageProvider {
     for (const varStatement of sourceFile.getVariableStatements()) {
       if (varStatement.isExported()) {
         for (const decl of varStatement.getDeclarations()) {
-          exports.push({
-            name: decl.getName(),
-            lineNumber: varStatement.getStartLineNumber(),
-            isDefault: false,
-          });
+          const name = decl.getName();
+          if (seen.has(name)) continue;
+          seen.add(name);
+          exports.push({ name, lineNumber: varStatement.getStartLineNumber(), isDefault: false });
         }
       }
     }
@@ -221,27 +224,26 @@ export class JavaScriptProvider implements LanguageProvider {
     for (const exportDecl of sourceFile.getExportDeclarations()) {
       if (!exportDecl.isNamespaceExport()) {
         for (const named of exportDecl.getNamedExports()) {
-          exports.push({
-            name: named.getNameNode().getText(),
-            lineNumber: exportDecl.getStartLineNumber(),
-            isDefault: false,
-          });
+          const name = named.getNameNode().getText();
+          if (seen.has(name)) continue;
+          seen.add(name);
+          exports.push({ name, lineNumber: exportDecl.getStartLineNumber(), isDefault: false });
         }
       }
     }
 
-    // Default exports: export default ...
-    const defaultExportSymbol = sourceFile.getDefaultExportSymbol();
-    if (defaultExportSymbol !== undefined) {
-      const declarations = defaultExportSymbol.getDeclarations();
-      if (declarations.length > 0) {
-        const decl = declarations[0];
-        if (decl !== undefined) {
-          exports.push({
-            name: 'default',
-            lineNumber: decl.getStartLineNumber(),
-            isDefault: true,
-          });
+    // Default exports: export default <expression>
+    // Skip when getFunctions() already registered the default (e.g. export default function foo() {})
+    if (!seen.has('default')) {
+      const defaultExportSymbol = sourceFile.getDefaultExportSymbol();
+      if (defaultExportSymbol !== undefined) {
+        const declarations = defaultExportSymbol.getDeclarations();
+        if (declarations.length > 0) {
+          const decl = declarations[0];
+          if (decl !== undefined) {
+            seen.add('default');
+            exports.push({ name: 'default', lineNumber: decl.getStartLineNumber(), isDefault: true });
+          }
         }
       }
     }

--- a/test/languages/javascript/provider.test.ts
+++ b/test/languages/javascript/provider.test.ts
@@ -210,10 +210,11 @@ export const bar = () => 2;`;
       expect(exports.some(e => e.name === 'bar' && !e.isDefault)).toBe(true);
     });
 
-    it('identifies default exports', () => {
+    it('identifies anonymous default export as single entry', () => {
       const source = `export default function() {}`;
       const exports = provider.findExports(source);
-      expect(exports.some(e => e.isDefault)).toBe(true);
+      expect(exports).toHaveLength(1);
+      expect(exports[0]).toMatchObject({ isDefault: true });
     });
 
     it('finds re-exported names', () => {

--- a/test/languages/javascript/provider.test.ts
+++ b/test/languages/javascript/provider.test.ts
@@ -230,6 +230,13 @@ export { foo, bar };`;
       const source = `function internal() {}`;
       expect(provider.findExports(source)).toHaveLength(0);
     });
+
+    it('does not produce duplicate entries for export default function foo() {}', () => {
+      const source = `export default function foo() {}`;
+      const exports = provider.findExports(source);
+      expect(exports).toHaveLength(1);
+      expect(exports[0]).toMatchObject({ name: 'foo', isDefault: true });
+    });
   });
 
   describe('classifyFunction', () => {


### PR DESCRIPTION
## Summary

- `export default function foo() {}` was previously collected by two separate AST paths in `findExports`, producing two entries: `{ name: 'foo', isDefault: true }` and `{ name: 'default', isDefault: true }`.
- Added a `seen` Set across all four collection paths. Default function declarations are tracked under the key `'default'`, so `getDefaultExportSymbol()` skips them when `getFunctions()` has already registered the declaration.
- Applied the same deduplication pattern already used in `extractExportedSignatures` in `nds004.ts`.

Closes #429

## Test plan

- [ ] New test: `does not produce duplicate entries for export default function foo() {}` — confirms single entry `{ name: 'foo', isDefault: true }`
- [ ] All 47 existing `findExports` tests pass
- [ ] Full suite: 2103/2103 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate exports being discovered in JavaScript files, preventing duplicate entries for default-exported functions.

* **Tests**
  * Added/updated tests to ensure default exports (including named default functions) are reported exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->