### PR TITLE
refactor(tests): extract makeTestRepo helper to centralize commit.gpgsign=false

### DIFF
--- a/test/deliverables/acceptance-gate.test.ts
+++ b/test/deliverables/acceptance-gate.test.ts
@@ -10,6 +10,7 @@ import { execFileSync } from 'node:child_process';
 import { simpleGit } from 'simple-git';
 import { pushBranch, createBranch, validateCredentials } from '../../src/git/git-wrapper.ts';
 import { createPr } from '../../src/deliverables/git-workflow.ts';
+import { makeTestRepo } from '../helpers/git.ts';
 
 const GITHUB_TOKEN_AVAILABLE = !!process.env.GITHUB_TOKEN;
 const REPO_ROOT = join(import.meta.dirname, '..', '..');
@@ -21,11 +22,9 @@ const REPO_ROOT = join(import.meta.dirname, '..', '..');
 async function cloneTestRepo(): Promise<string> {
   const dir = join(tmpdir(), `spiny-orb-e2e-pr-${randomUUID()}`);
   await mkdir(dir, { recursive: true });
-  const git = simpleGit(dir);
-  await git.clone(REPO_ROOT, dir, ['--depth', '1', '--single-branch']);
-  await git.addConfig('user.email', 'test@example.com');
-  await git.addConfig('user.name', 'E2E Test');
-  await git.addConfig('commit.gpgsign', 'false');
+  await simpleGit(dir).clone(REPO_ROOT, dir, ['--depth', '1', '--single-branch']);
+  // Apply standard test config (makeTestRepo reinits safely on a cloned repo)
+  const git = await makeTestRepo(dir);
 
   // Point the remote to the real GitHub repo for push
   const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: REPO_ROOT })

--- a/test/deliverables/git-workflow-integration.test.ts
+++ b/test/deliverables/git-workflow-integration.test.ts
@@ -16,16 +16,12 @@ import { renderPrSummary } from '../../src/deliverables/pr-summary.ts';
 import type { RunResult, CoordinatorCallbacks } from '../../src/coordinator/types.ts';
 import type { FileResult } from '../../src/fix-loop/types.ts';
 import type { AgentConfig } from '../../src/config/schema.ts';
+import { makeTestRepo } from '../helpers/git.ts';
 
 /** Create an isolated git repo with initial commit. */
 async function initTestRepo(): Promise<string> {
   const dir = join(tmpdir(), `spiny-orb-e2e-git-${randomUUID()}`);
-  await mkdir(dir, { recursive: true });
-  const git = simpleGit(dir);
-  await git.init();
-  await git.addConfig('user.email', 'test@example.com');
-  await git.addConfig('user.name', 'Test');
-  await git.addConfig('commit.gpgsign', 'false');
+  const git = await makeTestRepo(dir);
   // Create initial files
   await writeFile(join(dir, 'README.md'), '# Test\n');
   await writeFile(join(dir, 'package.json'), JSON.stringify({ name: 'test', version: '1.0.0' }, null, 2));

--- a/test/git/aggregate-commit.test.ts
+++ b/test/git/aggregate-commit.test.ts
@@ -9,16 +9,12 @@ import { randomUUID } from 'node:crypto';
 import { simpleGit } from 'simple-git';
 import { commitAggregateChanges } from '../../src/git/aggregate-commit.ts';
 import type { AggregateCommitInput } from '../../src/git/aggregate-commit.ts';
+import { makeTestRepo } from '../helpers/git.ts';
 
 /** Create an isolated git repo with an initial commit. */
 async function initTestRepo(): Promise<string> {
   const dir = join(tmpdir(), `spiny-orb-aggregate-test-${randomUUID()}`);
-  await mkdir(dir, { recursive: true });
-  const git = simpleGit(dir);
-  await git.init();
-  await git.addConfig('user.email', 'test@example.com');
-  await git.addConfig('user.name', 'Test');
-  await git.addConfig('commit.gpgsign', 'false');
+  const git = await makeTestRepo(dir);
   const readmePath = join(dir, 'README.md');
   await writeFile(readmePath, '# Test Repo\n');
   const pkgPath = join(dir, 'package.json');

--- a/test/git/git-wrapper.test.ts
+++ b/test/git/git-wrapper.test.ts
@@ -18,6 +18,7 @@ import {
   resolveAuthenticatedUrl,
   validateCredentials,
 } from '../../src/git/git-wrapper.ts';
+import { makeTestRepo } from '../helpers/git.ts';
 
 /**
  * Create an isolated git repo in a temp directory for testing.
@@ -25,12 +26,7 @@ import {
  */
 async function initTestRepo(): Promise<string> {
   const dir = join(tmpdir(), `spiny-orb-git-test-${randomUUID()}`);
-  await mkdir(dir, { recursive: true });
-  const git = simpleGit(dir);
-  await git.init();
-  await git.addConfig('user.email', 'test@example.com');
-  await git.addConfig('user.name', 'Test');
-  await git.addConfig('commit.gpgsign', 'false');
+  const git = await makeTestRepo(dir);
   // Create initial commit so we have a branch to work from
   const readmePath = join(dir, 'README.md');
   await writeFile(readmePath, '# Test Repo\n');

--- a/test/git/per-file-commit.test.ts
+++ b/test/git/per-file-commit.test.ts
@@ -9,16 +9,12 @@ import { randomUUID } from 'node:crypto';
 import { simpleGit } from 'simple-git';
 import { commitFileResult } from '../../src/git/per-file-commit.ts';
 import type { FileResult } from '../../src/fix-loop/types.ts';
+import { makeTestRepo } from '../helpers/git.ts';
 
 /** Create an isolated git repo with an initial commit. */
 async function initTestRepo(): Promise<string> {
   const dir = join(tmpdir(), `spiny-orb-perfile-test-${randomUUID()}`);
-  await mkdir(dir, { recursive: true });
-  const git = simpleGit(dir);
-  await git.init();
-  await git.addConfig('user.email', 'test@example.com');
-  await git.addConfig('user.name', 'Test');
-  await git.addConfig('commit.gpgsign', 'false');
+  const git = await makeTestRepo(dir);
   const readmePath = join(dir, 'README.md');
   await writeFile(readmePath, '# Test Repo\n');
   await git.add('README.md');

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -22,7 +22,7 @@ describe('makeTestRepo', () => {
     testDir = join(tmpdir(), `spiny-orb-makeTestRepo-${randomUUID()}`);
     const git = await makeTestRepo(testDir);
     const status = await git.status();
-    expect(status).toBeDefined(); // repo is valid and responsive
+    expect(status.isClean()).toBe(true);
   });
 
   it('sets commit.gpgsign to false', async () => {

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Tests for makeTestRepo — the shared test helper for creating configured temp git repos.
+// ABOUTME: Verifies commit.gpgsign, user.email, and user.name are always applied.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { makeTestRepo } from './git.ts';
+
+describe('makeTestRepo', () => {
+  let testDir: string | undefined;
+
+  afterEach(async () => {
+    if (testDir) {
+      await rm(testDir, { recursive: true, force: true });
+      testDir = undefined;
+    }
+  });
+
+  it('creates and initializes a git repo at the given directory', async () => {
+    testDir = join(tmpdir(), `spiny-orb-makeTestRepo-${randomUUID()}`);
+    const git = await makeTestRepo(testDir);
+    const status = await git.status();
+    expect(status).toBeDefined(); // repo is valid and responsive
+  });
+
+  it('sets commit.gpgsign to false', async () => {
+    testDir = join(tmpdir(), `spiny-orb-makeTestRepo-${randomUUID()}`);
+    const git = await makeTestRepo(testDir);
+    const result = await git.raw(['config', '--local', 'commit.gpgsign']);
+    expect(result.trim()).toBe('false');
+  });
+
+  it('sets user.email to test@example.com', async () => {
+    testDir = join(tmpdir(), `spiny-orb-makeTestRepo-${randomUUID()}`);
+    const git = await makeTestRepo(testDir);
+    const result = await git.raw(['config', '--local', 'user.email']);
+    expect(result.trim()).toBe('test@example.com');
+  });
+
+  it('sets user.name to E2E Test', async () => {
+    testDir = join(tmpdir(), `spiny-orb-makeTestRepo-${randomUUID()}`);
+    const git = await makeTestRepo(testDir);
+    const result = await git.raw(['config', '--local', 'user.name']);
+    expect(result.trim()).toBe('E2E Test');
+  });
+});

--- a/test/helpers/git.ts
+++ b/test/helpers/git.ts
@@ -1,0 +1,27 @@
+// ABOUTME: Shared test helper for creating isolated, correctly-configured git repos.
+// ABOUTME: Centralizes commit.gpgsign=false to prevent dd-gitsign failures in subprocess environments.
+
+import { mkdir } from 'node:fs/promises';
+import { simpleGit } from 'simple-git';
+import type { SimpleGit } from 'simple-git';
+
+/**
+ * Create an isolated git repo in the given directory with standard test config applied.
+ *
+ * Always sets commit.gpgsign=false so dd-gitsign (Datadog's commit signing tool)
+ * does not fail when tests run in subprocess environments like `vals exec` where
+ * no SSH agent is available. Also sets user.email and user.name so commits succeed
+ * without global git config.
+ *
+ * @param dir - Directory to initialize as a git repo (created if it does not exist)
+ * @returns Configured SimpleGit instance pointing at dir
+ */
+export async function makeTestRepo(dir: string): Promise<SimpleGit> {
+  await mkdir(dir, { recursive: true });
+  const git = simpleGit(dir);
+  await git.init();
+  await git.addConfig('user.email', 'test@example.com');
+  await git.addConfig('user.name', 'E2E Test');
+  await git.addConfig('commit.gpgsign', 'false');
+  return git;
+}


### PR DESCRIPTION
## Summary

- `commit.gpgsign=false` was patched individually in five test helpers across `test/git/` and `test/deliverables/`. Any new test that creates a temp git repo had to manually add all three config lines or risk a `dd-gitsign` failure in `vals exec` environments (where no SSH agent is available).
- Extracts `makeTestRepo(dir)` in `test/helpers/git.ts` that wraps `simpleGit` initialization with the standard test config (`user.email`, `user.name`, `commit.gpgsign=false`).
- Updates all five callers. The acceptance-gate clone path calls `makeTestRepo` after `git.clone`; `git init` on a cloned repo is safe and preserves history and remotes.

Closes #464

## Test plan

- [ ] New helper tests in `test/helpers/git.test.ts` verify `commit.gpgsign=false`, `user.email`, and `user.name` are set
- [ ] All five refactored test files still pass (git-wrapper, aggregate-commit, per-file-commit, git-workflow-integration, acceptance-gate)
- [ ] Full suite: 2106/2106 tests pass across 112 files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Git repository initialization across tests into a reusable helper to reduce duplication in test setup.

* **Tests**
  * Added tests for the new repository setup helper to validate repository initialization and local Git configuration, ensuring clean repos for test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->