### PR TITLE
docs(494): journal-graph.js retry investigation findings

### DIFF
--- a/docs/reviews/494-journal-graph-retry-investigation.md
+++ b/docs/reviews/494-journal-graph-retry-investigation.md
@@ -1,0 +1,62 @@
+# Investigation: journal-graph.js 3-Attempt Retry Pattern
+
+**Issue**: [#494](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/494)  
+**Date**: 2026-04-16  
+**Runs examined**: 12, 13, 14
+
+---
+
+## Finding: Structural NDS-003 failure on template literal (line 27)
+
+The 3-attempt pattern is structural. The same failure class (NDS-003 Code Preserved) occurs on every first attempt across all three runs, driven by the agent modifying an existing template literal assignment in `summaryNode`.
+
+### Validation journeys
+
+**Run-12** (instrumentation.md):
+1. Attempt 1: 7 × NDS-003
+2. Attempt 2: 1 × NDS-001 (syntax error introduced while fixing NDS-003)
+3. Attempt 3: 5 × NDS-003
+4. Function-level fallback: 12/12 instrumented → SUCCESS
+
+**Run-13** (spiny-orb-output.log):
+- PARTIAL result, 3 spans, 3 attempts
+- `summaryNode` skipped all 3 attempts with the same error:
+  > `NDS-003: original line 27 missing/modified: const systemContent = \`${guidelines}\``
+
+**Run-14** (actionable-fix-output.md, from eval team):
+- SUCCESS, 4 spans, 3 attempts
+- `summaryNode` instrumented — but catch-block error recording missing (separate issue #493)
+
+### Root cause
+
+The agent consistently modifies `const systemContent = \`${guidelines}\`` (line 27 of `summaryNode`) when instrumenting the function. The variable holds a large template literal built from `guidelines`. The model appears to interact with this variable — possibly trying to capture it as a span attribute or restructure the function body around it — and modifies it rather than leaving it intact.
+
+The NDS-003 fix loop tells the agent which line was modified and asks it not to modify it, but the same violation recurs on the next attempt. The loop's guidance is not strong enough to prevent re-modification of this specific line across whole-file retries.
+
+Run-12 escapes via function-level fallback (where the agent works on one function at a time with more targeted context). Run-13 doesn't — `summaryNode` still fails at function level. Run-14 eventually succeeds after 3 attempts but with the catch-block gap.
+
+### Conclusion: structural, not LLM variation
+
+The failure is on the same line (or same category of line — large template literals in LangGraph node functions) across all three runs. This is a structural property of the file, not random LLM variation.
+
+---
+
+## Proposed fix
+
+**Target**: `src/fix-loop/instrument-with-retry.ts` and/or `src/agent/prompt.ts`
+
+When NDS-003 fires on the same line across two or more consecutive attempts, the retry guidance should include the exact original content of the failing line with an explicit preservation directive:
+
+> "You modified line N in a previous attempt. You MUST reproduce this line character-for-character:  
+> `const systemContent = \`${guidelines}\``  
+> Do not restructure or reference this variable in instrumentation code."
+
+This is a targeted escalation of the NDS-003 fix message for repeat failures. The current message names the line but does not repeat its exact content with an explicit "reproduce exactly" instruction.
+
+A secondary option: detect LangGraph-style files (functions that return state objects, `StateGraph` imports) and include a pre-instrumentation hint that template literal setup variables must not be touched.
+
+---
+
+## Follow-on implementation issue needed
+
+Create an issue for: escalate NDS-003 retry guidance when the same line fails across consecutive attempts — include the exact original line content in the fix prompt and add "reproduce exactly" language.

--- a/docs/reviews/494-journal-graph-retry-investigation.md
+++ b/docs/reviews/494-journal-graph-retry-investigation.md
@@ -57,6 +57,6 @@ A secondary option: detect LangGraph-style files (functions that return state ob
 
 ---
 
-## Follow-on implementation issue needed
+## Follow-on implementation issue
 
-Create an issue for: escalate NDS-003 retry guidance when the same line fails across consecutive attempts — include the exact original line content in the fix prompt and add "reproduce exactly" language.
+**[#495](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/495)** — Escalate NDS-003 retry guidance when the same line fails across consecutive attempts: include the exact original line content in the fix prompt and add "reproduce exactly" language.

--- a/docs/reviews/494-journal-graph-retry-investigation.md
+++ b/docs/reviews/494-journal-graph-retry-investigation.md
@@ -21,7 +21,10 @@ The 3-attempt pattern is structural. The same failure class (NDS-003 Code Preser
 **Run-13** (spiny-orb-output.log):
 - PARTIAL result, 3 spans, 3 attempts
 - `summaryNode` skipped all 3 attempts with the same error:
-  > `NDS-003: original line 27 missing/modified: const systemContent = \`${guidelines}\``
+  > NDS-003: original line 27 missing/modified:
+  > ```javascript
+  > const systemContent = `${guidelines}`
+  > ```
 
 **Run-14** (actionable-fix-output.md, from eval team):
 - SUCCESS, 4 spans, 3 attempts
@@ -29,7 +32,11 @@ The 3-attempt pattern is structural. The same failure class (NDS-003 Code Preser
 
 ### Root cause
 
-The agent consistently modifies `const systemContent = \`${guidelines}\`` (line 27 of `summaryNode`) when instrumenting the function. The variable holds a large template literal built from `guidelines`. The model appears to interact with this variable — possibly trying to capture it as a span attribute or restructure the function body around it — and modifies it rather than leaving it intact.
+The agent consistently modifies this line (line 27 of `summaryNode`) when instrumenting the function:
+
+```javascript
+const systemContent = `${guidelines}`
+``` The variable holds a large template literal built from `guidelines`. The model appears to interact with this variable — possibly trying to capture it as a span attribute or restructure the function body around it — and modifies it rather than leaving it intact.
 
 The NDS-003 fix loop tells the agent which line was modified and asks it not to modify it, but the same violation recurs on the next attempt. The loop's guidance is not strong enough to prevent re-modification of this specific line across whole-file retries.
 
@@ -47,9 +54,12 @@ The failure is on the same line (or same category of line — large template lit
 
 When NDS-003 fires on the same line across two or more consecutive attempts, the retry guidance should include the exact original content of the failing line with an explicit preservation directive:
 
-> "You modified line N in a previous attempt. You MUST reproduce this line character-for-character:  
-> `const systemContent = \`${guidelines}\``  
+> "You modified line N in a previous attempt. You MUST reproduce this line character-for-character.
 > Do not restructure or reference this variable in instrumentation code."
+>
+> ```javascript
+> const systemContent = `${guidelines}`
+> ```
 
 This is a targeted escalation of the NDS-003 fix message for repeat failures. The current message names the line but does not repeat its exact content with an explicit "reproduce exactly" instruction.
 

--- a/test/git/git-wrapper.test.ts
+++ b/test/git/git-wrapper.test.ts
@@ -224,6 +224,8 @@ describe('git-wrapper', () => {
 
   // Tests that hit real github.com need longer timeouts for slow/unstable connections
   const NETWORK_TEST_TIMEOUT = 30_000;
+  // Local git push tests can be slow under full-suite parallel load (I/O contention from other repos)
+  const LOCAL_PUSH_TIMEOUT = 15_000;
 
   describe('pushBranch with GITHUB_TOKEN', () => {
     let bareDir: string;
@@ -244,7 +246,7 @@ describe('git-wrapper', () => {
       await rm(bareDir, { recursive: true, force: true });
     });
 
-    it('logs path=bare-push when no GITHUB_TOKEN is set', async () => {
+    it('logs path=bare-push when no GITHUB_TOKEN is set', { timeout: LOCAL_PUSH_TIMEOUT }, async () => {
       const originalToken = process.env.GITHUB_TOKEN;
       const stderrChunks: string[] = [];
       const originalWrite = process.stderr.write.bind(process.stderr);


### PR DESCRIPTION
## Summary

Investigation of why `journal-graph.js` has required 3 retry attempts in eval runs 12, 13, and 14.

**Finding**: Structural NDS-003 failure on the same template literal line (`const systemContent = \`${guidelines}\``) across all three runs. The fix loop repeats the same guidance without escalation — the agent receives the same NDS-003 message, modifies the same line again, and cycles through 3 whole-file attempts before escaping to function-level fallback.

This is a structural failure, not LLM variation. Same line, same rule, three consecutive runs.

**Findings document**: `docs/reviews/494-journal-graph-retry-investigation.md`

**Follow-on implementation issue**: #495 (Escalate NDS-003 retry guidance when the same line fails across consecutive attempts)

Also includes a minor unrelated fix: `LOCAL_PUSH_TIMEOUT` added to `test/git/git-wrapper.test.ts` — the bare-push test had no explicit timeout and was timing out under full-suite parallel I/O load.

Closes #494

## Test plan

- [ ] Findings document is accurate and complete
- [ ] Follow-on issue #495 has enough detail to implement without re-investigating
- [ ] `LOCAL_PUSH_TIMEOUT` correctly guards the bare-push test against load-induced flakiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an investigation describing a reproducible 3-attempt retry failure pattern, its consistent first-attempt syndrome, and recommended escalation guidance for repeated same-line failures, plus a referenced follow-up issue for implementation.

* **Tests**
  * Tuned a local push test to use a shorter, dedicated timeout to improve reliability under slower local I/O.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->