### PR TITLE
feat(fix-loop): escalate NDS-003 retry guidance on repeat line violations

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -206,14 +206,70 @@ function buildValidationConfig(
  * Combines a preamble with the structured validation feedback.
  *
  * @param validationFeedback - Formatted validation errors from formatFeedbackForAgent
+ * @param existingSpanNames - Span names already used by other files in this run
+ * @param repeatLineEscalation - Optional escalation block for NDS-003 repeat offenders
  * @returns Complete feedback message for the LLM
  */
-function buildFixPrompt(validationFeedback: string, existingSpanNames?: string[]): string {
+function buildFixPrompt(
+  validationFeedback: string,
+  existingSpanNames?: string[],
+  repeatLineEscalation?: string,
+): string {
   let prompt = `The instrumented file has validation errors. Fix ONLY the failing rules listed below. Do not restructure code that is not related to a failing rule. Make minimal, targeted changes. Return the complete corrected file.\n\n${validationFeedback}`;
   if (existingSpanNames && existingSpanNames.length > 0) {
     prompt += `\n\nReminder: these span names are already in use by other files — do not reuse them: ${existingSpanNames.join(', ')}`;
   }
+  if (repeatLineEscalation) {
+    prompt += repeatLineEscalation;
+  }
   return prompt;
+}
+
+/**
+ * Detect NDS-003 failures that have occurred on the same source line in the last
+ * two consecutive attempts. These are structural repeat offenders — the agent
+ * modified the same line after receiving NDS-003 feedback, so the standard message
+ * is insufficient.
+ *
+ * @param violations - NDS-003 CheckResult arrays accumulated per attempt
+ * @returns Set of line numbers that appeared in both the last and second-to-last attempt
+ */
+export function detectRepeatNds003Lines(violations: import('../validation/types.ts').CheckResult[][]): Set<number> {
+  if (violations.length < 2) return new Set();
+  const last = violations[violations.length - 1];
+  const prev = violations[violations.length - 2];
+  const prevLines = new Set(
+    prev.map(v => v.lineNumber).filter((n): n is number => n !== null),
+  );
+  const repeated = new Set<number>();
+  for (const v of last) {
+    if (v.lineNumber !== null && prevLines.has(v.lineNumber)) {
+      repeated.add(v.lineNumber);
+    }
+  }
+  return repeated;
+}
+
+/**
+ * Build an escalation block for lines that have triggered NDS-003 across consecutive
+ * attempts. Includes the exact original line content and a strong preservation directive.
+ * Appended to the multi-turn fix prompt or fresh-regen hint when repeats are detected.
+ *
+ * @param repeatLines - Line numbers that have repeated NDS-003 violations
+ * @param originalCode - The unmodified source file content
+ * @returns Escalation text to append, or empty string when no repeats
+ */
+function buildRepeatLineEscalation(repeatLines: Set<number>, originalCode: string): string {
+  if (repeatLines.size === 0) return '';
+  const sourceLines = originalCode.split('\n');
+  const parts: string[] = [
+    '\n\nIMPORTANT — The following lines triggered NDS-003 in two consecutive attempts. You modified them after receiving NDS-003 feedback. Do NOT modify these lines:',
+  ];
+  for (const lineNum of [...repeatLines].sort((a, b) => a - b)) {
+    const content = sourceLines[lineNum - 1] ?? '';
+    parts.push(`  Line ${lineNum} must be reproduced exactly: ${content.trim()}`);
+  }
+  return parts.join('\n');
 }
 
 /**
@@ -472,17 +528,26 @@ async function executeRetryLoop(
     if (plannedStrategy === 'multi-turn-fix' && lastConversationContext && lastValidation) {
       // Multi-turn fix: grow the conversation with validation feedback.
       // Use low effort to constrain thinking — corrections should be targeted, not exploratory.
+      // When NDS-003 fires on the same line in the last two attempts, escalate with the
+      // exact original line content so the agent cannot repeat the same modification.
+      const repeatLines = detectRepeatNds003Lines(nds003ViolationsPerAttempt);
+      const escalation = buildRepeatLineEscalation(repeatLines, originalCode);
       callOptions = {
         conversationContext: lastConversationContext,
-        feedbackMessage: buildFixPrompt(formatFeedbackFn(lastValidation), existingSpanNames),
+        feedbackMessage: buildFixPrompt(formatFeedbackFn(lastValidation), existingSpanNames, escalation || undefined),
         maxOutputTokens: outputBudget,
         effortOverride: 'low',
         existingSpanNames,
       };
     } else if (plannedStrategy === 'fresh-regeneration' && lastValidation) {
-      // Fresh regeneration: new conversation with failure category hint
+      // Fresh regeneration: new conversation with failure category hint.
+      // Append repeat-line escalation when NDS-003 has fired on the same line
+      // across the last two attempts — the hint anchors the agent on what not to touch.
+      const repeatLines = detectRepeatNds003Lines(nds003ViolationsPerAttempt);
+      const escalation = buildRepeatLineEscalation(repeatLines, originalCode);
+      const baseHint = buildFailureHint(lastValidation) ?? '';
       callOptions = {
-        failureHint: buildFailureHint(lastValidation),
+        failureHint: (baseHint + escalation) || undefined,
         maxOutputTokens: outputBudget,
         existingSpanNames,
       };

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -3507,10 +3507,10 @@ describe('instrumentWithRetry — NDS-003 repeat-line escalation', () => {
     );
 
     expect(capturedFailureHint).toBeDefined();
-    // Must include the original line 27 content
-    expect(capturedFailureHint).toContain('const systemContent = `${guidelines}`');
-    // Must include a preservation directive
-    expect(capturedFailureHint).toContain('27');
+    expect(capturedFailureHint).toContain('IMPORTANT — The following lines triggered NDS-003');
+    expect(capturedFailureHint).toContain(
+      'Line 27 must be reproduced exactly: const systemContent = `${guidelines}`;',
+    );
   });
 
   it('includes original line content in multi-turn feedbackMessage when NDS-003 repeats on same line (partial overlap)', async () => {
@@ -3561,8 +3561,10 @@ describe('instrumentWithRetry — NDS-003 repeat-line escalation', () => {
     // Attempt 3 (multi-turn-fix): line 27 repeated from attempt 2 → escalation present
     const attempt3Message = capturedMessages[2];
     expect(attempt3Message).toBeDefined();
-    expect(attempt3Message).toContain('const systemContent = `${guidelines}`');
-    expect(attempt3Message).toContain('27');
+    expect(attempt3Message).toContain('IMPORTANT — The following lines triggered NDS-003');
+    expect(attempt3Message).toContain(
+      'Line 27 must be reproduced exactly: const systemContent = `${guidelines}`;',
+    );
   });
 
   it('does NOT escalate when NDS-003 fires on different lines across attempts', async () => {

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -1,12 +1,12 @@
 // ABOUTME: Tests for instrumentWithRetry — single-attempt, token budget, multi-turn fix, fresh regen, oscillation, function-level fallback.
-// ABOUTME: Milestones 2-6 + milestone 7 — verifies FileResult population, file revert, budget enforcement, retry, oscillation, and fallback flow.
+// ABOUTME: Milestones 2-6 + milestone 7 + NDS-003 repeat escalation (#495).
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, readFileSync, mkdtempSync, existsSync, unlinkSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createRequire } from 'node:module';
-import { instrumentWithRetry, isRetryableInstrumentError, isEarlyAbortError, normalizeSchemaExtension, detectMalformedExtensions, RETRYABLE_NULL_OUTPUT, RETRYABLE_ELISION, EARLY_ABORT_MAX_TOKENS } from '../../src/fix-loop/instrument-with-retry.ts';
+import { instrumentWithRetry, isRetryableInstrumentError, isEarlyAbortError, normalizeSchemaExtension, detectMalformedExtensions, detectRepeatNds003Lines, RETRYABLE_NULL_OUTPUT, RETRYABLE_ELISION, EARLY_ABORT_MAX_TOKENS } from '../../src/fix-loop/instrument-with-retry.ts';
 import type { FileResult } from '../../src/fix-loop/types.ts';
 import type { InstrumentationOutput, TokenUsage } from '../../src/agent/schema.ts';
 import type { ValidationResult, CheckResult, ValidateFileInput } from '../../src/validation/types.ts';
@@ -3374,5 +3374,226 @@ describe('budget escalation on stop_reason: max_tokens (#210)', () => {
     for (const opt of receivedOptions) {
       expect(opt?.maxOutputTokens).toBe(expectedBudget);
     }
+  });
+});
+
+// ─── NDS-003 repeat-line escalation (#495) ────────────────────────────────────
+
+describe('detectRepeatNds003Lines', () => {
+  function makeNds003(lineNumber: number, filePath = 'file.js'): CheckResult {
+    return {
+      ruleId: 'NDS-003',
+      passed: false,
+      filePath,
+      lineNumber,
+      message: `NDS-003: original line ${lineNumber} missing/modified`,
+      tier: 2,
+      blocking: true,
+    };
+  }
+
+  it('returns empty set when fewer than 2 attempts have violations', () => {
+    expect(detectRepeatNds003Lines([])).toEqual(new Set());
+    expect(detectRepeatNds003Lines([[makeNds003(27)]])).toEqual(new Set());
+  });
+
+  it('returns empty set when NDS-003 fires on different lines across attempts', () => {
+    const violations = [
+      [makeNds003(27)],
+      [makeNds003(35)],
+    ];
+    expect(detectRepeatNds003Lines(violations)).toEqual(new Set());
+  });
+
+  it('returns the repeated line number when NDS-003 fires on the same line in last two attempts', () => {
+    const violations = [
+      [makeNds003(27)],
+      [makeNds003(27)],
+    ];
+    expect(detectRepeatNds003Lines(violations)).toEqual(new Set([27]));
+  });
+
+  it('returns multiple repeated lines when several repeat', () => {
+    const violations = [
+      [makeNds003(10), makeNds003(27)],
+      [makeNds003(10), makeNds003(27)],
+    ];
+    expect(detectRepeatNds003Lines(violations)).toEqual(new Set([10, 27]));
+  });
+
+  it('only compares the last two attempts, ignoring earlier ones', () => {
+    // Line 27 repeated in attempts 1+2 but not in attempts 2+3
+    const violations = [
+      [makeNds003(27)],
+      [makeNds003(27)],
+      [makeNds003(99)], // attempt 3: different line
+    ];
+    expect(detectRepeatNds003Lines(violations)).toEqual(new Set());
+  });
+
+  it('returns empty set when last two attempts have no NDS-003 violations', () => {
+    const violations: CheckResult[][] = [[], []];
+    expect(detectRepeatNds003Lines(violations)).toEqual(new Set());
+  });
+});
+
+describe('instrumentWithRetry — NDS-003 repeat-line escalation', () => {
+  let testDir: string;
+  let testFilePath: string;
+  // originalContent has 30 lines so line 27 is within bounds
+  const originalContent = Array.from({ length: 30 }, (_, i) =>
+    i === 26
+      ? 'const systemContent = `${guidelines}`;'
+      : `const line${i + 1} = ${i + 1};`,
+  ).join('\n') + '\n';
+
+  const mockContext: ConversationContext = {
+    userMessage: 'instrument this file',
+    assistantResponseBlocks: [{ type: 'text', text: '{"instrumentedCode": "..."}' }],
+  };
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'spiny-orb-nds003-escalation-'));
+    testFilePath = join(testDir, 'target.js');
+    writeFileSync(testFilePath, originalContent, 'utf-8');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function makeNds003Validation(filePath: string, lineNumber: number): ValidationResult {
+    const failure: CheckResult = {
+      ruleId: 'NDS-003',
+      passed: false,
+      filePath,
+      lineNumber,
+      message: `NDS-003: original line ${lineNumber} missing/modified: const systemContent`,
+      tier: 2,
+      blocking: true,
+    };
+    return {
+      passed: false,
+      tier1Results: [],
+      tier2Results: [failure],
+      blockingFailures: [failure],
+      advisoryFindings: [],
+    };
+  }
+
+  it('includes original line content in fresh-regen failureHint when NDS-003 repeats on same line', async () => {
+    // Attempts 1 and 2 both fail NDS-003 on line 27; attempt 3 is fresh-regen
+    let attempt = 0;
+    let capturedFailureHint: string | undefined;
+
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async (_fp, _oc, _rs, _cfg, opts) => {
+        attempt++;
+        if (attempt === 3) capturedFailureHint = opts?.failureHint;
+        return {
+          success: true,
+          output: makeInstrumentationOutput({ instrumentedCode: originalContent }),
+          conversationContext: mockContext,
+        } as InstrumentFileResult;
+      },
+      validateFile: async () => {
+        if (attempt <= 2) return makeNds003Validation(testFilePath, 27);
+        return makePassingValidation(testFilePath);
+      },
+    };
+
+    await instrumentWithRetry(
+      testFilePath, originalContent, {}, makeConfig({ maxFixAttempts: 2 }), { deps },
+    );
+
+    expect(capturedFailureHint).toBeDefined();
+    // Must include the original line 27 content
+    expect(capturedFailureHint).toContain('const systemContent = `${guidelines}`');
+    // Must include a preservation directive
+    expect(capturedFailureHint).toContain('27');
+  });
+
+  it('includes original line content in multi-turn feedbackMessage when NDS-003 repeats on same line (partial overlap)', async () => {
+    // Oscillation fires only on identical error key sets. With PARTIAL overlap
+    // (line 27 repeats but other lines differ), oscillation does NOT fire and
+    // attempt 3 proceeds as multi-turn-fix with the escalated feedbackMessage.
+    let attempt = 0;
+    const capturedMessages: Array<string | undefined> = [];
+
+    function makeNds003Multi(lines: number[]): ValidationResult {
+      const failures = lines.map(ln => ({
+        ruleId: 'NDS-003',
+        passed: false,
+        filePath: testFilePath,
+        lineNumber: ln,
+        message: `NDS-003: original line ${ln} missing/modified`,
+        tier: 2 as const,
+        blocking: true,
+      }));
+      return { passed: false, tier1Results: [], tier2Results: failures, blockingFailures: failures, advisoryFindings: [] };
+    }
+
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async (_fp, _oc, _rs, _cfg, opts) => {
+        attempt++;
+        capturedMessages.push(opts?.feedbackMessage);
+        return {
+          success: true,
+          output: makeInstrumentationOutput({ instrumentedCode: originalContent }),
+          conversationContext: mockContext,
+        } as InstrumentFileResult;
+      },
+      validateFile: async () => {
+        // Lines 27+35 on attempt 1, lines 27+10 on attempt 2 → different key sets, no oscillation
+        // but line 27 repeats → escalation should appear in attempt 3 feedbackMessage
+        if (attempt === 1) return makeNds003Multi([27, 35]);
+        if (attempt === 2) return makeNds003Multi([27, 10]);
+        return makePassingValidation(testFilePath);
+      },
+    };
+
+    // maxFixAttempts=3 → 4 total attempts: initial, multi-turn, multi-turn, fresh-regen
+    // Attempt 3 is multi-turn (not yet fresh-regen), so it gets feedbackMessage
+    await instrumentWithRetry(
+      testFilePath, originalContent, {}, makeConfig({ maxFixAttempts: 3 }), { deps },
+    );
+
+    // Attempt 3 (multi-turn-fix): line 27 repeated from attempt 2 → escalation present
+    const attempt3Message = capturedMessages[2];
+    expect(attempt3Message).toBeDefined();
+    expect(attempt3Message).toContain('const systemContent = `${guidelines}`');
+    expect(attempt3Message).toContain('27');
+  });
+
+  it('does NOT escalate when NDS-003 fires on different lines across attempts', async () => {
+    let attempt = 0;
+    let capturedFailureHint: string | undefined;
+
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async (_fp, _oc, _rs, _cfg, opts) => {
+        attempt++;
+        if (attempt === 3) capturedFailureHint = opts?.failureHint;
+        return {
+          success: true,
+          output: makeInstrumentationOutput({ instrumentedCode: originalContent }),
+          conversationContext: mockContext,
+        } as InstrumentFileResult;
+      },
+      validateFile: async () => {
+        // Different lines on each attempt — no repeat
+        if (attempt === 1) return makeNds003Validation(testFilePath, 27);
+        if (attempt === 2) return makeNds003Validation(testFilePath, 10);
+        return makePassingValidation(testFilePath);
+      },
+    };
+
+    await instrumentWithRetry(
+      testFilePath, originalContent, {}, makeConfig({ maxFixAttempts: 2 }), { deps },
+    );
+
+    // Hint should exist (there was an NDS-003 failure) but should NOT contain
+    // the escalation block (only present when lines repeat across attempts)
+    expect(capturedFailureHint).toBeDefined();
+    expect(capturedFailureHint).not.toContain('must be reproduced exactly');
   });
 });

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -3507,7 +3507,9 @@ describe('instrumentWithRetry — NDS-003 repeat-line escalation', () => {
     );
 
     expect(capturedFailureHint).toBeDefined();
-    expect(capturedFailureHint).toContain('IMPORTANT — The following lines triggered NDS-003');
+    expect(capturedFailureHint).toContain(
+      'IMPORTANT — The following lines triggered NDS-003 in two consecutive attempts. You modified them after receiving NDS-003 feedback. Do NOT modify these lines:',
+    );
     expect(capturedFailureHint).toContain(
       'Line 27 must be reproduced exactly: const systemContent = `${guidelines}`;',
     );
@@ -3561,7 +3563,9 @@ describe('instrumentWithRetry — NDS-003 repeat-line escalation', () => {
     // Attempt 3 (multi-turn-fix): line 27 repeated from attempt 2 → escalation present
     const attempt3Message = capturedMessages[2];
     expect(attempt3Message).toBeDefined();
-    expect(attempt3Message).toContain('IMPORTANT — The following lines triggered NDS-003');
+    expect(attempt3Message).toContain(
+      'IMPORTANT — The following lines triggered NDS-003 in two consecutive attempts. You modified them after receiving NDS-003 feedback. Do NOT modify these lines:',
+    );
     expect(attempt3Message).toContain(
       'Line 27 must be reproduced exactly: const systemContent = `${guidelines}`;',
     );


### PR DESCRIPTION
## Summary

When NDS-003 fires on the same source line across two consecutive attempts, the standard feedback message is insufficient — the agent has already been told not to modify that line and did it again anyway.

- Adds `detectRepeatNds003Lines()` (exported, testable) that compares the last two NDS-003 violation batches and returns line numbers that appear in both
- Adds `buildRepeatLineEscalation()` that formats the exact original line content with an explicit "must be reproduced exactly" directive
- Wires into both the multi-turn `feedbackMessage` and fresh-regen `failureHint` paths when repeats are detected
- No new state tracking needed — piggybacks on the existing `nds003ViolationsPerAttempt` array

**Target**: `journal-graph.js` pattern where `const systemContent = \`${guidelines}\`` is modified in every first attempt across runs 12, 13, and 14.

Closes #495

## Test plan

- [ ] `detectRepeatNds003Lines` unit tests: empty set for <2 attempts, no repeats, single repeat, multiple repeats, only last 2 compared
- [ ] Fresh-regen escalation: NDS-003 on same line in attempts 1+2 → `failureHint` contains original line content and line number
- [ ] Multi-turn escalation: NDS-003 on partially overlapping lines (no oscillation) → attempt 3 `feedbackMessage` contains original line content
- [ ] No escalation: NDS-003 on different lines → hint does not contain escalation block
- [ ] Full suite: 2116/2116 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of repeated validation errors across consecutive attempts. When the same issue recurs, escalated feedback now includes the exact original source line content and an explicit preservation directive, applied to both retry and fresh-regeneration flows (including multi-turn attempts).

* **Tests**
  * Added unit and integration tests covering repeated-error detection, escalation content, and behavior across multiple attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->