### PR TITLE
docs(prd-483): archive PRD to done/, remove from ROADMAP

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,6 @@ Dependency-ordered backlog across three sources: the advisory rules audit ([PRD 
 
 ## Short-term (current focus)
 
-- Advisory rules audit — closing out ([PRD #483](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/483))
 - TypeScript language provider ([PRD #372](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/372)) — branch `feature/prd-372-typescript-provider` exists with 18 commits through Milestone C6; canary test passed 0/27 interface changes; remaining work is rebase + apply prompt guidance from D-7 + run TS eval + PR. Not blocked by the multi-language architecture cleanup below (TS shares the JS abstraction via the explicit `javascript || typescript` guard).
 - Multi-language rule architecture cleanup ([PRD #507](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/507)) — refactor `src/agent/instrument-file.ts`, `src/agent/prompt.ts`, and `src/fix-loop/index.ts` to route through the `LanguageProvider` interface; consolidate `src/validation/tier2/` SCH duplicates. Prerequisite for PRD #373, PRD #374, and the SCH rebuild PRD.
 - `action.yml` Weaver default `0.21.2` → `0.22.1` (trivial fix; action currently ships stale Weaver relative to CI at v0.22.1)

--- a/prds/done/483-advisory-rules-audit.md
+++ b/prds/done/483-advisory-rules-audit.md
@@ -1,6 +1,6 @@
 # PRD #483: Advisory Rules Audit
 
-**Status**: Active  
+**Status**: Complete (merged 2026-04-21)  
 **Priority**: High  
 **GitHub Issue**: [#483](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/483)  
 **Created**: 2026-04-15


### PR DESCRIPTION
## Description

Archive PRD #483 (advisory rules audit) to `prds/done/` now that PR #520 has merged. Remove the closing-out entry from ROADMAP — completed work lives in PROGRESS.md.

## Related Issues

Related to #483 (already closed)

## Type of Change

- [x] 📚 Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated advisory rules audit project status to complete
  * Removed audit from active roadmap items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->