### PR TITLE
fix(token-budget): double TOKENS_PER_LINE and raise MAX_OUTPUT_TOKENS_PER_FILE

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- (2026-04-21) Fixed acceptance gate failures on `index.js` (commit-story-v2) caused by adaptive thinking consuming too large a fraction of the per-call output token budget. `TOKENS_PER_LINE` doubled from 50 to 100 so complex 500+ line files get a 61K token budget instead of 35K, leaving sufficient headroom after thinking tokens for the JSON instrumented output. `MAX_OUTPUT_TOKENS_PER_FILE` raised from 50K to 100K to allow complex files the retry budget they need when validation failures require multiple attempts.
+
 ### Added
 
 - (2026-04-21) Bumped the `action.yml` default Weaver version from `0.21.2` to `0.22.1` to match what CI has been running. Users who rely on the GitHub Action without pinning `weaver-version` explicitly were previously getting a stale Weaver binary that differed from what CI validated against.

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -93,8 +93,10 @@ const ZERO_TOKENS: TokenUsage = {
   cacheReadInputTokens: 0,
 };
 
-/** Per-file output token limit to prevent one partial from consuming disproportionate cost. */
-const MAX_OUTPUT_TOKENS_PER_FILE = 50_000;
+/** Per-file output token limit to prevent one partial from consuming disproportionate cost.
+ *  Raised from 50K to 100K: complex files (500+ lines) need multiple retry attempts at ~30-60K
+ *  output tokens each; the old limit caused premature abort after just one retry. */
+const MAX_OUTPUT_TOKENS_PER_FILE = 100_000;
 
 /**
  * Count the number of startActiveSpan calls in instrumented code.

--- a/src/fix-loop/token-budget.ts
+++ b/src/fix-loop/token-budget.ts
@@ -65,10 +65,14 @@ export function estimateMinTokens(sourceCodeLength: number): number {
 
 /**
  * Calibration constants for deterministic output token sizing.
- * Derived from run-5 session data: output tokens range from 7K (small files)
- * to 26K (large files at 21K limit), roughly linear with file size.
+ * Derived from run-5 session data and acceptance gate failures:
+ * - TOKENS_PER_LINE raised from 50 to 100 after CI showed adaptive thinking on
+ *   complex files (533-line index.js) consuming 30K+ tokens, starving JSON output.
+ *   With 50 tokens/line, index.js budget was 34,650; ~30K thinking left only ~4K
+ *   for JSON, producing truncated responses. 100 tokens/line gives 61,300, which
+ *   provides adequate headroom for heavy-thinking runs on large files.
  */
-export const TOKENS_PER_LINE = 50;
+export const TOKENS_PER_LINE = 100;
 export const THINKING_OVERHEAD = 8_000;
 export const MIN_OUTPUT_BUDGET = 16_384;
 export const MAX_OUTPUT_BUDGET = 65_536;

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -3147,10 +3147,10 @@ describe('instrumentWithRetry — output token budget', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('aborts retries when cumulative output tokens exceed 50K', async () => {
+  it('aborts retries when cumulative output tokens exceed 100K', async () => {
     const expensiveTokens: TokenUsage = {
       inputTokens: 5000,
-      outputTokens: 55_000,
+      outputTokens: 105_000,
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
     };
@@ -3168,9 +3168,12 @@ describe('instrumentWithRetry — output token budget', () => {
       validateFile: async () => makeFailingValidation(testFilePath),
     };
 
+    // maxTokensPerFile must be large enough that totalTokens (inputTokens + outputTokens = 110K)
+    // doesn't trigger the per-run budgetExceeded check first — we want the per-file output
+    // token guard (MAX_OUTPUT_TOKENS_PER_FILE = 100K) to fire on attempt 2 instead.
     const result = await instrumentWithRetry(
       testFilePath, originalContent, {},
-      makeConfig({ maxFixAttempts: 2 }),
+      makeConfig({ maxFixAttempts: 2, maxTokensPerFile: 200_000 }),
       { deps },
     );
 

--- a/test/fix-loop/token-budget.test.ts
+++ b/test/fix-loop/token-budget.test.ts
@@ -125,66 +125,67 @@ describe('estimateOutputBudget — deterministic output token sizing (#210)', ()
   });
 
   it('returns MIN_OUTPUT_BUDGET for small files below the floor', () => {
-    // 100 lines × 50 tokens/line + 8000 overhead = 13000 < 16384
-    expect(estimateOutputBudget(100)).toBe(MIN_OUTPUT_BUDGET);
+    // 50 lines × 100 tokens/line + 8000 overhead = 13000 < 16384
+    expect(estimateOutputBudget(50)).toBe(MIN_OUTPUT_BUDGET);
   });
 
   it('returns MIN_OUTPUT_BUDGET at the exact floor boundary', () => {
-    // (MIN_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (16384 - 8000) / 50 = 167.68
-    // At 167 lines: 167 × 50 + 8000 = 16350 < 16384 → MIN
-    expect(estimateOutputBudget(167)).toBe(MIN_OUTPUT_BUDGET);
+    // (MIN_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (16384 - 8000) / 100 = 83.84
+    // At 83 lines: 83 × 100 + 8000 = 16300 < 16384 → MIN
+    expect(estimateOutputBudget(83)).toBe(MIN_OUTPUT_BUDGET);
   });
 
   it('exceeds MIN_OUTPUT_BUDGET just above the floor boundary', () => {
-    // At 168 lines: 168 × 50 + 8000 = 16400 > 16384
-    expect(estimateOutputBudget(168)).toBe(168 * TOKENS_PER_LINE + THINKING_OVERHEAD);
-    expect(estimateOutputBudget(168)).toBeGreaterThan(MIN_OUTPUT_BUDGET);
+    // At 84 lines: 84 × 100 + 8000 = 16400 > 16384
+    expect(estimateOutputBudget(84)).toBe(84 * TOKENS_PER_LINE + THINKING_OVERHEAD);
+    expect(estimateOutputBudget(84)).toBeGreaterThan(MIN_OUTPUT_BUDGET);
   });
 
   it('scales linearly for medium files', () => {
-    // 400 lines: 400 × 50 + 8000 = 28000
-    expect(estimateOutputBudget(400)).toBe(28000);
-    // 600 lines: 600 × 50 + 8000 = 38000
-    expect(estimateOutputBudget(600)).toBe(38000);
+    // 200 lines: 200 × 100 + 8000 = 28000
+    expect(estimateOutputBudget(200)).toBe(28000);
+    // 400 lines: 400 × 100 + 8000 = 48000
+    expect(estimateOutputBudget(400)).toBe(48000);
   });
 
   it('caps at MAX_OUTPUT_BUDGET for very large files', () => {
-    // 2000 lines: 2000 × 50 + 8000 = 108000 > 65536
+    // 2000 lines: 2000 × 100 + 8000 = 208000 > 65536
     expect(estimateOutputBudget(2000)).toBe(MAX_OUTPUT_BUDGET);
   });
 
   it('caps at MAX_OUTPUT_BUDGET at the exact ceiling boundary', () => {
-    // (MAX_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (65536 - 8000) / 50 = 1150.72
-    // At 1151 lines: 1151 × 50 + 8000 = 65550 > 65536 → capped
-    expect(estimateOutputBudget(1151)).toBe(MAX_OUTPUT_BUDGET);
-    // At 1150 lines: 1150 × 50 + 8000 = 65500 < 65536 → not capped
-    expect(estimateOutputBudget(1150)).toBe(65500);
-    expect(estimateOutputBudget(1150)).toBeLessThan(MAX_OUTPUT_BUDGET);
+    // (MAX_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (65536 - 8000) / 100 = 575.36
+    // At 576 lines: 576 × 100 + 8000 = 65600 > 65536 → capped
+    expect(estimateOutputBudget(576)).toBe(MAX_OUTPUT_BUDGET);
+    // At 575 lines: 575 × 100 + 8000 = 65500 < 65536 → not capped
+    expect(estimateOutputBudget(575)).toBe(65500);
+    expect(estimateOutputBudget(575)).toBeLessThan(MAX_OUTPUT_BUDGET);
   });
 
   it('matches calibration data from run-5 session', () => {
-    // Calibration: output tokens range from 7K (small) to 26K (large at 21K limit).
-    // The budget should provide headroom above observed output sizes.
+    // Budget should provide headroom above observed output token sizes.
+    // Files >= 576 lines hit MAX_OUTPUT_BUDGET (65536) with TOKENS_PER_LINE=100.
 
     // journal-manager.js: 422 lines, observed output 8,402 tokens
     const jmBudget = estimateOutputBudget(422);
-    expect(jmBudget).toBeGreaterThan(8402); // headroom above observed output
-    expect(jmBudget).toBe(422 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 29100
+    expect(jmBudget).toBeGreaterThan(8402);
+    expect(jmBudget).toBe(422 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 50200
 
-    // index.js: 533 lines, observed output at 16K truncated
+    // index.js: 533 lines — was truncating with old 34,650 budget (50 tokens/line).
+    // With 100 tokens/line: budget is 61,300 — sufficient headroom for heavy-thinking runs.
     const idxBudget = estimateOutputBudget(533);
-    expect(idxBudget).toBeGreaterThan(16384); // must exceed the old 16K limit
-    expect(idxBudget).toBe(533 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 34650
+    expect(idxBudget).toBeGreaterThan(34650); // must exceed old budget that caused truncation
+    expect(idxBudget).toBe(533 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 61300
 
-    // journal-graph.js: 631 lines, observed output 14,471 tokens at 32K
+    // journal-graph.js: 631 lines — hits ceiling with 100 tokens/line
     const jgBudget = estimateOutputBudget(631);
     expect(jgBudget).toBeGreaterThan(14471);
-    expect(jgBudget).toBe(631 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 39550
+    expect(jgBudget).toBe(MAX_OUTPUT_BUDGET); // 65536 (capped)
 
-    // summary-graph.js: ~700 lines, observed output 29,835 at 32K
+    // summary-graph.js: ~700 lines — also hits ceiling
     const sgBudget = estimateOutputBudget(700);
     expect(sgBudget).toBeGreaterThan(29835);
-    expect(sgBudget).toBe(700 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 43000
+    expect(sgBudget).toBe(MAX_OUTPUT_BUDGET); // 65536 (capped)
   });
 
   it('is monotonically increasing with file size', () => {
@@ -197,7 +198,7 @@ describe('estimateOutputBudget — deterministic output token sizing (#210)', ()
   });
 
   it('exports the calibration constants', () => {
-    expect(TOKENS_PER_LINE).toBe(50);
+    expect(TOKENS_PER_LINE).toBe(100);
     expect(THINKING_OVERHEAD).toBe(8000);
     expect(MIN_OUTPUT_BUDGET).toBe(16384);
     expect(MAX_OUTPUT_BUDGET).toBe(65536);


### PR DESCRIPTION
## Problem

`index.js` (commit-story-v2, 533 lines) has been consistently failing the acceptance gate across multiple CI runs with three distinct failure modes — all caused by the same root: adaptive thinking consuming too large a fraction of the per-call output token budget.

- **JSON truncation**: `estimateOutputBudget(533)` = 34,650 tokens. When thinking runs heavy (~30K tokens on complex files), only ~4K remain for JSON output. Response gets cut at char ~9980.
- **Output budget exceeded**: cumulative output tokens across retries crossed `MAX_OUTPUT_TOKENS_PER_FILE` (50K) — only one retry allowed for large files.
- **NDS-005 oscillation**: same file, different run — agent can't fix the violation with the limited retry budget.

The same `run-5-coverage` job was failing on `chore/archive-prd-483` (before this session) and on `chore/issues-510-511-512` and `feature/issue-516-prettier-diff-feedback` — all with different failure modes on the same file.

## Fix

- **`TOKENS_PER_LINE` 50 → 100**: 533-line file now gets 61,300 token budget instead of 34,650, leaving ~31K for JSON output after heavy thinking
- **`MAX_OUTPUT_TOKENS_PER_FILE` 50K → 100K**: allows 2-3 retries for complex files without aborting on budget

## Test changes

- `token-budget.test.ts`: updated floor/ceiling boundary values and calibration data for new `TOKENS_PER_LINE=100`
- `instrument-with-retry.test.ts`: updated the "aborts retries when output budget exceeded" test to use 105K output tokens (triggering the 100K guard) with a large `maxTokensPerFile` so the per-run budget check doesn't fire first

## Test plan

- [x] All 2121 unit tests pass
- [x] `npm run typecheck` passes
- [ ] Acceptance gate passes (specifically `test/commit-story-v2/acceptance-gate.test.ts index.js`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed acceptance gate failures on complex files by improving token budget allocation limits.

* **Chores**
  * Updated token budget calibration constants and corresponding test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->