### PR TITLE
fix(acceptance-gate): fix index.js NDS-005 failure — token budget + prompt guidance

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- (2026-04-21) Fixed acceptance gate failures on `index.js` (commit-story-v2 fixture, 533 lines): the agent was removing an inner try/catch block at line 489 when wrapping `main()` in a span, triggering NDS-005. Two changes combined: (1) doubled TOKENS_PER_LINE from 50 to 100, giving index.js a 61K output budget instead of 34K — enough headroom for adaptive thinking plus JSON output without truncation; also raised MAX_OUTPUT_TOKENS_PER_FILE from 50K to 100K so complex files can retry without hitting the per-file abort threshold. (2) Added concrete NDS-005 guidance to the agent prompt covering the inner-nested case: when wrapping a function that contains inner try/catch blocks, those blocks must be preserved exactly as nested blocks inside the outer span try — not removed or merged with the span's own catch.
+
 ### Added
 
 - (2026-04-21) Bumped the `action.yml` default Weaver version from `0.21.2` to `0.22.1` to match what CI has been running. Users who rely on the GitHub Action without pinning `weaver-version` explicitly were previously getting a stale Weaver binary that differed from what CI validated against.

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -187,7 +187,37 @@ Your output is scored against these rules. Violating gate rules causes immediate
 ### Non-Destructiveness
 
 - **NDS-004**: Do NOT change exported function signatures — parameters, return types, or export declarations.
-- **NDS-005**: Do NOT restructure existing try/catch/finally blocks, reorder catch clauses, or change throw behavior.
+- **NDS-005**: Do NOT restructure existing try/catch/finally blocks, reorder catch clauses, or change throw behavior. When adding a span wrapper, all original try/catch blocks must survive intact — either as the outer structure (with \`span.end()\` added to their finally) or as nested blocks inside the outer span try. Never remove or merge an inner try/catch to simplify the span wrapper structure.
+
+  **Pattern A — original try/catch becomes the outer wrapper** (add \`span.end()\` to its finally):
+  \`\`\`js
+  tracer.startActiveSpan('op', async (span) => {
+    try {
+      // original try body — unchanged
+    } catch (err) {
+      // original catch body — unchanged
+    } finally {
+      span.end(); // only addition
+    }
+  });
+  \`\`\`
+
+  **Pattern B — wrapping a function that has inner try/catch blocks** (keep them nested inside):
+  \`\`\`js
+  tracer.startActiveSpan('op', async (span) => {
+    try {
+      // ... other original code ...
+      try {           // inner try/catch preserved exactly as-is
+        const result = await someOp();
+      } catch (err) {
+        // original catch body — unchanged, even if it's a graceful-degradation catch
+      }
+      // ... more original code ...
+    } finally {
+      span.end();
+    }
+  });
+  \`\`\`
 - **NDS-007**: Do NOT add \`recordException()\` or \`setStatus(ERROR)\` to catch blocks that handle expected conditions gracefully — catch blocks that return a default value, return empty, or swallow the error without propagating it. These are graceful-degradation catches, not failures. Adding error recording to them creates false alerts. When in doubt: if the original catch does not propagate the error (no \`throw\`, no \`next(err)\`, no \`reject(err)\`, no \`return Promise.reject(err)\`), do not add error recording to it.
 
 ### Coverage

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -93,8 +93,10 @@ const ZERO_TOKENS: TokenUsage = {
   cacheReadInputTokens: 0,
 };
 
-/** Per-file output token limit to prevent one partial from consuming disproportionate cost. */
-const MAX_OUTPUT_TOKENS_PER_FILE = 50_000;
+/** Per-file output token limit to prevent one partial from consuming disproportionate cost.
+ *  Raised from 50K to 100K: complex files (500+ lines) need multiple retry attempts at
+ *  ~30-60K output tokens each; the old limit caused premature abort after just one retry. */
+const MAX_OUTPUT_TOKENS_PER_FILE = 100_000;
 
 /**
  * Count the number of startActiveSpan calls in instrumented code.

--- a/src/fix-loop/token-budget.ts
+++ b/src/fix-loop/token-budget.ts
@@ -65,10 +65,14 @@ export function estimateMinTokens(sourceCodeLength: number): number {
 
 /**
  * Calibration constants for deterministic output token sizing.
- * Derived from run-5 session data: output tokens range from 7K (small files)
- * to 26K (large files at 21K limit), roughly linear with file size.
+ * Derived from run-5 session data and acceptance gate failures:
+ * - TOKENS_PER_LINE raised from 50 to 100 after CI showed adaptive thinking on
+ *   complex files (533-line index.js) consuming 30K+ tokens, starving JSON output.
+ *   With 50 tokens/line, index.js budget was 34,650; ~30K thinking left only ~4K
+ *   for JSON, producing truncated responses. 100 tokens/line gives 61,300, which
+ *   provides adequate headroom for heavy-thinking runs on large files.
  */
-export const TOKENS_PER_LINE = 50;
+export const TOKENS_PER_LINE = 100;
 export const THINKING_OVERHEAD = 8_000;
 export const MIN_OUTPUT_BUDGET = 16_384;
 export const MAX_OUTPUT_BUDGET = 65_536;

--- a/test/agent/prompt.test.ts
+++ b/test/agent/prompt.test.ts
@@ -546,6 +546,19 @@ describe('buildSystemPrompt', () => {
     });
   });
 
+  describe('NDS-005: preserve try/catch when wrapping in spans', () => {
+    it('includes concrete patterns for both outer-wrap and inner-nested try/catch cases', () => {
+      const prompt = buildSystemPrompt(schema);
+
+      // Must cover the inner-nested case (function wrapping where try/catch is inside)
+      expect(prompt).toContain('inner try/catch preserved exactly');
+      // Must cover the outer-wrap case (add span.end() to existing finally)
+      expect(prompt).toContain('span.end(); // only addition');
+      // Must prohibit removing inner try/catch to simplify span wrapper
+      expect(prompt).toContain('Never remove or merge an inner try/catch');
+    });
+  });
+
   // Claude 4.x prompt hygiene checks
   describe('Claude 4.x prompt hygiene', () => {
     it('does NOT contain anti-laziness directives', () => {

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -3147,10 +3147,10 @@ describe('instrumentWithRetry — output token budget', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('aborts retries when cumulative output tokens exceed 50K', async () => {
+  it('aborts retries when cumulative output tokens exceed 100K', async () => {
     const expensiveTokens: TokenUsage = {
       inputTokens: 5000,
-      outputTokens: 55_000,
+      outputTokens: 105_000,
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
     };
@@ -3168,9 +3168,12 @@ describe('instrumentWithRetry — output token budget', () => {
       validateFile: async () => makeFailingValidation(testFilePath),
     };
 
+    // maxTokensPerFile must exceed totalTokens (5K input + 105K output = 110K) so the
+    // per-run budgetExceeded check does not fire on attempt 1 — we want the per-file
+    // output token guard (MAX_OUTPUT_TOKENS_PER_FILE = 100K) to fire before attempt 2.
     const result = await instrumentWithRetry(
       testFilePath, originalContent, {},
-      makeConfig({ maxFixAttempts: 2 }),
+      makeConfig({ maxFixAttempts: 2, maxTokensPerFile: 200_000 }),
       { deps },
     );
 

--- a/test/fix-loop/token-budget.test.ts
+++ b/test/fix-loop/token-budget.test.ts
@@ -125,66 +125,66 @@ describe('estimateOutputBudget — deterministic output token sizing (#210)', ()
   });
 
   it('returns MIN_OUTPUT_BUDGET for small files below the floor', () => {
-    // 100 lines × 50 tokens/line + 8000 overhead = 13000 < 16384
-    expect(estimateOutputBudget(100)).toBe(MIN_OUTPUT_BUDGET);
+    // 50 lines × 100 tokens/line + 8000 overhead = 13000 < 16384
+    expect(estimateOutputBudget(50)).toBe(MIN_OUTPUT_BUDGET);
   });
 
   it('returns MIN_OUTPUT_BUDGET at the exact floor boundary', () => {
-    // (MIN_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (16384 - 8000) / 50 = 167.68
-    // At 167 lines: 167 × 50 + 8000 = 16350 < 16384 → MIN
-    expect(estimateOutputBudget(167)).toBe(MIN_OUTPUT_BUDGET);
+    // (MIN_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (16384 - 8000) / 100 = 83.84
+    // At 83 lines: 83 × 100 + 8000 = 16300 < 16384 → MIN
+    expect(estimateOutputBudget(83)).toBe(MIN_OUTPUT_BUDGET);
   });
 
   it('exceeds MIN_OUTPUT_BUDGET just above the floor boundary', () => {
-    // At 168 lines: 168 × 50 + 8000 = 16400 > 16384
-    expect(estimateOutputBudget(168)).toBe(168 * TOKENS_PER_LINE + THINKING_OVERHEAD);
-    expect(estimateOutputBudget(168)).toBeGreaterThan(MIN_OUTPUT_BUDGET);
+    // At 84 lines: 84 × 100 + 8000 = 16400 > 16384
+    expect(estimateOutputBudget(84)).toBe(84 * TOKENS_PER_LINE + THINKING_OVERHEAD);
+    expect(estimateOutputBudget(84)).toBeGreaterThan(MIN_OUTPUT_BUDGET);
   });
 
   it('scales linearly for medium files', () => {
-    // 400 lines: 400 × 50 + 8000 = 28000
-    expect(estimateOutputBudget(400)).toBe(28000);
-    // 600 lines: 600 × 50 + 8000 = 38000
-    expect(estimateOutputBudget(600)).toBe(38000);
+    // 400 lines: 400 × 100 + 8000 = 48000
+    expect(estimateOutputBudget(400)).toBe(48000);
+    // 500 lines: 500 × 100 + 8000 = 58000
+    expect(estimateOutputBudget(500)).toBe(58000);
   });
 
   it('caps at MAX_OUTPUT_BUDGET for very large files', () => {
-    // 2000 lines: 2000 × 50 + 8000 = 108000 > 65536
+    // 2000 lines: 2000 × 100 + 8000 = 208000 > 65536
     expect(estimateOutputBudget(2000)).toBe(MAX_OUTPUT_BUDGET);
   });
 
   it('caps at MAX_OUTPUT_BUDGET at the exact ceiling boundary', () => {
-    // (MAX_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (65536 - 8000) / 50 = 1150.72
-    // At 1151 lines: 1151 × 50 + 8000 = 65550 > 65536 → capped
-    expect(estimateOutputBudget(1151)).toBe(MAX_OUTPUT_BUDGET);
-    // At 1150 lines: 1150 × 50 + 8000 = 65500 < 65536 → not capped
-    expect(estimateOutputBudget(1150)).toBe(65500);
-    expect(estimateOutputBudget(1150)).toBeLessThan(MAX_OUTPUT_BUDGET);
+    // (MAX_OUTPUT_BUDGET - THINKING_OVERHEAD) / TOKENS_PER_LINE = (65536 - 8000) / 100 = 575.36
+    // At 576 lines: 576 × 100 + 8000 = 65600 > 65536 → capped
+    expect(estimateOutputBudget(576)).toBe(MAX_OUTPUT_BUDGET);
+    // At 575 lines: 575 × 100 + 8000 = 65500 < 65536 → not capped
+    expect(estimateOutputBudget(575)).toBe(65500);
+    expect(estimateOutputBudget(575)).toBeLessThan(MAX_OUTPUT_BUDGET);
   });
 
   it('matches calibration data from run-5 session', () => {
-    // Calibration: output tokens range from 7K (small) to 26K (large at 21K limit).
-    // The budget should provide headroom above observed output sizes.
+    // Calibration: with 100 tokens/line, complex files get larger budgets to
+    // accommodate adaptive thinking + JSON output without truncation.
 
     // journal-manager.js: 422 lines, observed output 8,402 tokens
     const jmBudget = estimateOutputBudget(422);
     expect(jmBudget).toBeGreaterThan(8402); // headroom above observed output
-    expect(jmBudget).toBe(422 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 29100
+    expect(jmBudget).toBe(422 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 50200
 
-    // index.js: 533 lines, observed output at 16K truncated
+    // index.js: 533 lines, observed output truncated at old 16K limit
     const idxBudget = estimateOutputBudget(533);
-    expect(idxBudget).toBeGreaterThan(16384); // must exceed the old 16K limit
-    expect(idxBudget).toBe(533 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 34650
+    expect(idxBudget).toBeGreaterThan(16384); // must exceed old truncation point
+    expect(idxBudget).toBe(533 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 61300
 
-    // journal-graph.js: 631 lines, observed output 14,471 tokens at 32K
+    // journal-graph.js: 631 lines — now capped at MAX_OUTPUT_BUDGET (65536)
     const jgBudget = estimateOutputBudget(631);
-    expect(jgBudget).toBeGreaterThan(14471);
-    expect(jgBudget).toBe(631 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 39550
+    expect(jgBudget).toBeGreaterThan(14471); // headroom above observed 14,471 tokens
+    expect(jgBudget).toBe(MAX_OUTPUT_BUDGET); // 631 × 100 + 8000 = 71100 → capped
 
-    // summary-graph.js: ~700 lines, observed output 29,835 at 32K
+    // summary-graph.js: ~700 lines — also capped at MAX_OUTPUT_BUDGET
     const sgBudget = estimateOutputBudget(700);
-    expect(sgBudget).toBeGreaterThan(29835);
-    expect(sgBudget).toBe(700 * TOKENS_PER_LINE + THINKING_OVERHEAD); // 43000
+    expect(sgBudget).toBeGreaterThan(29835); // headroom above observed 29,835 tokens
+    expect(sgBudget).toBe(MAX_OUTPUT_BUDGET); // 700 × 100 + 8000 = 78000 → capped
   });
 
   it('is monotonically increasing with file size', () => {
@@ -197,7 +197,7 @@ describe('estimateOutputBudget — deterministic output token sizing (#210)', ()
   });
 
   it('exports the calibration constants', () => {
-    expect(TOKENS_PER_LINE).toBe(50);
+    expect(TOKENS_PER_LINE).toBe(100);
     expect(THINKING_OVERHEAD).toBe(8000);
     expect(MIN_OUTPUT_BUDGET).toBe(16384);
     expect(MAX_OUTPUT_BUDGET).toBe(65536);


### PR DESCRIPTION
## Summary

- **Token budget**: `TOKENS_PER_LINE` 50→100 and `MAX_OUTPUT_TOKENS_PER_FILE` 50K→100K. The 533-line `index.js` fixture was getting a 34K output budget; adaptive thinking consumed ~30K, leaving only ~4K for JSON output, causing truncation and cascading NDS-003/NDS-005 violations. At 100 tokens/line, `index.js` gets a 61K budget — enough headroom for both thinking and full output.
- **NDS-005 prompt guidance**: added concrete Pattern A/B examples covering both try/catch instrumentation cases: (A) existing try/catch becomes the outer span wrapper — add `span.end()` to its finally; (B) wrapping a function that contains inner try/catch blocks — keep them nested inside the outer span try, never remove or merge them. The agent was removing the graceful-degradation try/catch at line 489 when wrapping `main()`.

Supersedes PRs #535 (token budget alone, still failed on NDS-005) and #542 (prompt guidance alone, missing token budget fix + introduced coordinator regression). Combining both fixes addresses the root cause.

## Test plan

- [ ] All 2122 unit tests pass (verified locally)
- [ ] Acceptance gate run triggered via `run-acceptance` label — verify `index.js` test passes in `run-5-coverage` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased per-file output token limits to improve processing reliability for larger files

* **Improvements**
  * Enhanced handling of nested code structures to preserve original code patterns during automatic instrumentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->