### PR TITLE
fix(advisory-pass): respect maxTokensPerFile budget before firing advisory pass

### DIFF
--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -691,7 +691,8 @@ async function executeRetryLoop(
       if (
         spansAdded > 0 &&
         validation.advisoryFindings.length > 0 &&
-        cumulativeTokens.outputTokens <= MAX_OUTPUT_TOKENS_PER_FILE
+        cumulativeTokens.outputTokens <= MAX_OUTPUT_TOKENS_PER_FILE &&
+        totalTokens(cumulativeTokens) <= config.maxTokensPerFile
       ) {
         const passingCode = output.instrumentedCode;
         const advisoryFeedback = formatFeedbackFn({

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -691,8 +691,8 @@ async function executeRetryLoop(
       if (
         spansAdded > 0 &&
         validation.advisoryFindings.length > 0 &&
-        cumulativeTokens.outputTokens <= MAX_OUTPUT_TOKENS_PER_FILE &&
-        totalTokens(cumulativeTokens) <= config.maxTokensPerFile
+        cumulativeTokens.outputTokens < MAX_OUTPUT_TOKENS_PER_FILE &&
+        totalTokens(cumulativeTokens) < config.maxTokensPerFile
       ) {
         const passingCode = output.instrumentedCode;
         const advisoryFeedback = formatFeedbackFn({

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -2160,6 +2160,26 @@ describe('instrumentWithRetry — advisory-only pass (M3)', () => {
     expect(instrumentCallCount).toBe(1);
   });
 
+  it('does not fire advisory pass when total token budget is exactly at the limit', async () => {
+    let instrumentCallCount = 0;
+    // totalTokens = 30K + 50K = 80K exactly equals maxTokensPerFile — strict < means skip
+    const exactBudgetTokens: TokenUsage = { inputTokens: 30_000, outputTokens: 50_000, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async () => {
+        instrumentCallCount++;
+        return { success: true, output: makeInstrumentationOutput({ instrumentedCode: passingInstrumentedContent, tokenUsage: exactBudgetTokens }) } as InstrumentFileResult;
+      },
+      validateFile: async (input) => {
+        if (input.originalCode === originalContent) return makeValidationWithAdvisory(testFilePath);
+        return makePassingValidation(testFilePath);
+      },
+    };
+
+    await instrumentWithRetry(testFilePath, originalContent, {}, makeConfig({ maxTokensPerFile: 80_000 }), { deps });
+
+    expect(instrumentCallCount).toBe(1);
+  });
+
   it('file status remains success regardless of blocking revalidation outcome after advisory pass', async () => {
     let instrumentCallCount = 0;
     const deps: InstrumentWithRetryDeps = {

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -2139,6 +2139,27 @@ describe('instrumentWithRetry — advisory-only pass (M3)', () => {
     expect(instrumentCallCount).toBe(1);
   });
 
+  it('does not fire advisory pass when total token budget (maxTokensPerFile) is exhausted', async () => {
+    let instrumentCallCount = 0;
+    // outputTokens under MAX_OUTPUT_TOKENS_PER_FILE (100K) but totalTokens exceeds config.maxTokensPerFile
+    const heavyInputTokens: TokenUsage = { inputTokens: 90_000, outputTokens: 50_000, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
+    // totalTokens = 140K, config.maxTokensPerFile = 80K — advisory pass must be skipped
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async () => {
+        instrumentCallCount++;
+        return { success: true, output: makeInstrumentationOutput({ instrumentedCode: passingInstrumentedContent, tokenUsage: heavyInputTokens }) } as InstrumentFileResult;
+      },
+      validateFile: async (input) => {
+        if (input.originalCode === originalContent) return makeValidationWithAdvisory(testFilePath);
+        return makePassingValidation(testFilePath);
+      },
+    };
+
+    await instrumentWithRetry(testFilePath, originalContent, {}, makeConfig({ maxTokensPerFile: 80_000 }), { deps });
+
+    expect(instrumentCallCount).toBe(1);
+  });
+
   it('file status remains success regardless of blocking revalidation outcome after advisory pass', async () => {
     let instrumentCallCount = 0;
     const deps: InstrumentWithRetryDeps = {


### PR DESCRIPTION
## Summary

The advisory-only pass added in #550 checked `cumulativeTokens.outputTokens` against the hard-coded `MAX_OUTPUT_TOKENS_PER_FILE` ceiling (100K), but did not check the user's configured `maxTokensPerFile` (total input+output tokens). This meant the advisory pass could fire and push per-file total cost past the user's budget limit.

Added `totalTokens(cumulativeTokens) <= config.maxTokensPerFile` as a gate condition alongside the existing output-token check.

## Test plan

- [x] New test: `does not fire advisory pass when total token budget (maxTokensPerFile) is exhausted` — 131 unit tests pass
- [x] Covers the case where outputTokens is under MAX_OUTPUT_TOKENS_PER_FILE but totalTokens exceeds the config limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter enforcement of per-file token budgets to skip extra advisory-only validation when total token limits would be exceeded.

* **Tests**
  * Added tests confirming advisory-only passes are skipped when the overall per-file token budget is exhausted or exactly met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->