### PR TITLE
fix(coordinator-test): only emit diagnostics on unexpected results

### DIFF
--- a/test/coordinator/acceptance-gate.test.ts
+++ b/test/coordinator/acceptance-gate.test.ts
@@ -199,11 +199,18 @@ function createTestSubscriber(): { callbacks: CoordinatorCallbacks; events: Even
   return { callbacks, events };
 }
 
-/** Log full RunResult diagnostics so CI failures are actionable without a re-run. */
+/** Log full RunResult diagnostics only when the run has unexpected results.
+ * Silent on clean runs so CI output stays quiet on pass. */
 function logRunResult(label: string, result: import('../../src/coordinator/types.ts').RunResult): void {
-  console.log(`\n[coordinator diagnostics] ${label}`);
+  const hasProblems =
+    result.filesFailed > 0 ||
+    result.filesPartial > 0 ||
+    result.fileResults.filter(r => r.status === 'success').every(r => r.spansAdded === 0);
+  if (!hasProblems) return;
+
+  console.error(`\n[coordinator diagnostics — UNEXPECTED] ${label}`);
   for (const r of result.fileResults) {
-    console.log(JSON.stringify({
+    console.error(JSON.stringify({
       path: r.path.split('/').slice(-2).join('/'),
       status: r.status,
       spansAdded: r.spansAdded,
@@ -214,7 +221,7 @@ function logRunResult(label: string, result: import('../../src/coordinator/types
       errorProgression: r.errorProgression,
     }));
   }
-  console.log(`[coordinator diagnostics] totals: succeeded=${result.filesSucceeded} failed=${result.filesFailed} skipped=${result.filesSkipped} partial=${result.filesPartial}`);
+  console.error(`[coordinator diagnostics] totals: succeeded=${result.filesSucceeded} failed=${result.filesFailed} skipped=${result.filesSkipped} partial=${result.filesPartial}`);
 }
 
 describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 4 Coordinator', () => {


### PR DESCRIPTION
## Summary

- The `logRunResult` helper added in #566 used `console.log` unconditionally, printing per-file JSON on every passing run. Silent on clean runs; loud when something is wrong.
- Changed to only emit (via `console.error`) when `filesFailed > 0`, `filesPartial > 0`, or all succeeded files have `spansAdded === 0`.

## Test plan

- [ ] Unit tests pass (`npm test`)
- [ ] No console output on a clean coordinator run; full diagnostics on unexpected results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved acceptance gate test diagnostics to provide clearer error visibility when issues are detected and cleaner output for successful test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->