### PR TITLE
test(sdk-init): cover getNodeAutoInstrumentations() pattern in coordinator acceptance gate fixture

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- (2026-04-25) Added a unit test that exercises `updateSdkInitFile` with a `getNodeAutoInstrumentations()` call expression already in the `instrumentations` array — the exact pattern used in the coordinator acceptance gate test fixture. The test confirms that the function correctly appends new instrumentation entries (array element + ESM import) without being blocked by the existing call expression. This closes issue #590's gap in unit-level coverage; the coordinator acceptance gate P4-3 passed in the companion live-API smoke test.
+- (2026-04-25) Added a unit test that exercises `updateSdkInitFile` when the `instrumentations` array already contains a `getNodeAutoInstrumentations()` call expression — the exact pattern used in the coordinator acceptance gate fixture project. The test confirms that the function correctly appends new instrumentation entries (both the array `new X()` element and the ESM import statement) without being blocked by the existing call expression or falling back to the separate fallback file.
 
 ### Added
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Fixed
-
-- (2026-04-25) Added a unit test that exercises `updateSdkInitFile` when the `instrumentations` array already contains a `getNodeAutoInstrumentations()` call expression — the exact pattern used in the coordinator acceptance gate fixture project. The test confirms that the function correctly appends new instrumentation entries (both the array `new X()` element and the ESM import statement) without being blocked by the existing call expression or falling back to the separate fallback file.
-
 ### Added
 
 - (2026-04-24) Shipped the TypeScript language provider (C0–C6): `TypeScriptProvider` implements all `LanguageProvider` methods using ts-morph; covers `.ts` and `.tsx` extensions; uses `tsc --noEmit` for syntax validation; adds 4 TypeScript-specific validation rules (entry point detection with NestJS decorators, `unknown`-typed catch error recording, type-annotated signature preservation, ESM/CJS module system matching); 23 remaining rules inherited from the JavaScript provider. Golden file tests with 4 fixture pairs including TSX. Canary test: 0/27 interface changes required — the `LanguageProvider` interface generalized cleanly. Real-world eval (taze, 33 files) deferred pending PRD #582 M2 infrastructure fix; tracked in issue #591.
@@ -43,6 +39,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (2026-04-21) Tightened `testCommand` config validation to reject empty strings, which previously passed schema validation silently. The field already existed and was wired to the test runners; this fix adds a Zod `.refine()` constraint so setting `testCommand: ""` or `testCommand: "   "` in `spiny-orb.yaml` produces a clear validation error rather than running an empty command at runtime. Updated the README field reference to document inline env var support (e.g., `GIT_CONFIG_GLOBAL=/tmp/test.gitconfig npm test` for repos whose global git config conflicts with the test suite).
 
 - (2026-04-21) Improved fix-loop LINT failure feedback: when the agent introduces a Prettier formatting violation, the check now computes a diff between the agent's output and the Prettier-reformatted version and includes it in the feedback message, so the agent can self-correct on the next attempt. When the target repo uses a non-default Prettier config (`.prettierrc*` or similar), the config file path is also included in the message so the agent knows which rule source to consult. Previously the message only said "Run Prettier on the output" with no specifics — causing the arrowParens violation to repeat across three attempts in the release-it eval run before oscillation detection gave up.
+
+### Fixed
+
+- (2026-04-25) Added a unit test that exercises `updateSdkInitFile` when the `instrumentations` array already contains a `getNodeAutoInstrumentations()` call expression — the exact pattern used in the coordinator acceptance gate fixture project. The test confirms that the function correctly appends new instrumentation entries (both the array `new X()` element and the ESM import statement) without being blocked by the existing call expression or falling back to the separate fallback file.
 
 ### Changed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- (2026-04-25) Added a unit test that exercises `updateSdkInitFile` with a `getNodeAutoInstrumentations()` call expression already in the `instrumentations` array — the exact pattern used in the coordinator acceptance gate test fixture. The test confirms that the function correctly appends new instrumentation entries (array element + ESM import) without being blocked by the existing call expression. This closes issue #590's gap in unit-level coverage; the coordinator acceptance gate P4-3 passed in the companion live-API smoke test.
+
 ### Added
 
 - (2026-04-24) Shipped the TypeScript language provider (C0–C6): `TypeScriptProvider` implements all `LanguageProvider` methods using ts-morph; covers `.ts` and `.tsx` extensions; uses `tsc --noEmit` for syntax validation; adds 4 TypeScript-specific validation rules (entry point detection with NestJS decorators, `unknown`-typed catch error recording, type-annotated signature preservation, ESM/CJS module system matching); 23 remaining rules inherited from the JavaScript provider. Golden file tests with 4 fixture pairs including TSX. Canary test: 0/27 interface changes required — the `LanguageProvider` interface generalized cleanly. Real-world eval (taze, 33 files) deferred pending PRD #582 M2 infrastructure fix; tracked in issue #591.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,19 @@
 
 Dependency-ordered backlog across three sources: the advisory rules audit ([PRD #483](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/483)), release-it evaluation run-1, and the 2026-04-16 codebase deep-dive. Individual PRDs and issues are the children of this roadmap — this document sequences them.
 
+## Language Provider Status Classifications
+
+When a real-world eval run completes for a language provider, mark it using these thresholds:
+
+- **Experimental** (≥ 90% pass rate, zero syntax errors, known limitations documented)
+- **Stable** (≥ 95% pass rate, zero syntax errors, known limitations documented)
+
+Pass rate = files committed / files discovered. Syntax errors = files where `tsc --noEmit` (TypeScript) or equivalent fails on the instrumented output. All language provider PRDs reference these thresholds in their C7/D7/E7 eval milestones.
+
+**Current status**: TypeScript — *pending eval run-3* (blocked on PRD #582 M2).
+
+---
+
 ## Short-term (current focus)
 
 - Multi-language rule architecture cleanup ([PRD #507](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/507)) — refactor `src/agent/instrument-file.ts`, `src/agent/prompt.ts`, and `src/fix-loop/index.ts` to route through the `LanguageProvider` interface; consolidate `src/validation/tier2/` SCH duplicates. Prerequisite for PRD #373, PRD #374, and the SCH rebuild PRD.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,14 +10,12 @@ Dependency-ordered backlog across three sources: the advisory rules audit ([PRD 
 
 ## Medium-term
 
-- Python language provider ([PRD #373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373)) — blocked by multi-language rule architecture PRD.
+- Python language provider ([PRD #373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373)) — blocked by PRD #507 (multi-language rule architecture). TypeScript canary prerequisite ✓ cleared (0/27 interface changes).
 - SCH-001/002 rebuild + SCH-004 deletion + SCH-005 audit ([PRD #508](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/508)) — blocked by multi-language rule architecture PRD.
 - Human-facing advisory output ([PRD #509](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/509)) — add human-facing descriptions for all rules that surface to humans; parallelizable, but rule-list milestones sequence after PRD #505 and PRD #508.
 - Canonical tracer name injection ([PRD #505](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/505)) — deletes CDQ-008, replaces with per-file blocking check driven by registry manifest name.
 - Weaver code generation for domain-specific constants ([PRD #379](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/379)).
 - Anthropic SDK version check + bump — pin `^0.78.0` is months stale.
-- Capture test failure output on checkpoint / end-of-run failure — fix-loop debuggability.
-- Fix-loop debuggability sweep — Weaver shutdown messages, live-check partial text, check-failure message clarity.
 - COV-005 receiver filter fragility — `extractSetAttributeName` misses non-standard span variable names; latent bug, accepted as-is in the audit.
 - Audit `src/agent/prompt.ts` for orphan rule references ([issue #519](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/519)) — one-shot sweep to reconcile the prompt against the rule catalog. Sequence-dependent: run after PRD #505, PRD #508, and PRD #509 merge so the rule catalog is stable. Prevention for future drift is covered by the rules-related work conventions in project CLAUDE.md.
 - Fix agent attribute invention strategy — registry-first, pattern inference, empty schema gate ([PRD #581](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/581)) — removes OTel semconv as a separate fallback, replaces with registry-first lookup and pattern inference from existing registry entries.

--- a/prds/373-python-provider.md
+++ b/prds/373-python-provider.md
@@ -1,9 +1,10 @@
 # PRD #373: Python language provider
 
-**Status**: Draft — refine after PRD #372 (TypeScript provider) and PRD #507 (multi-language rule architecture cleanup) are both complete
+**Status**: Draft — refine after PRD #507 (multi-language rule architecture cleanup) is complete
 **Priority**: Medium
 **GitHub Issue**: [#373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373)
-**Blocked by**: Two hard prerequisites — (1) [PRD #372](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/372) (TypeScript provider) must merge first; the TypeScript canary test must pass at ≤20% interface touch. (2) [PRD #507](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/507) (multi-language rule architecture cleanup) must merge first; the refactored `LanguageProvider` interface from #507 is the contract this PRD implements against. Starting Python before #507 merges means implementing against a leaky interface that bypasses the provider layer in hot-path modules (`src/agent/instrument-file.ts`, `src/agent/prompt.ts`, etc.) — Python would surface those leaks at runtime rather than at the clean seam #507 establishes.
+**Blocked by**: [PRD #507](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/507) (multi-language rule architecture cleanup) — the refactored `LanguageProvider` interface from #507 is the contract this PRD implements against. Starting Python before #507 merges means implementing against a leaky interface that bypasses the provider layer in hot-path modules. PRD #372 (TypeScript canary prerequisite) is merged ✓ — canary passed at 0/27 interface changes.
+**Design sync**: This PRD's OD decisions (parser choice, formatter, dependency file format, rule IDs) directly inform PRD #374 (Go). Complete Python M1 research spikes and record decisions in this PRD's Decision Log before Go's pre-implementation gate is finalized. PRD #374 explicitly cross-references several of these decisions (e.g., OD-9c rule ID choice).
 **Blocks**: PRD #374 (Go provider)
 **Created**: 2026-04-06
 **Updated**: 2026-04-20 — added PRD #507 blocker and Milestone D4 for Python API-002-equivalent package-hygiene rule, per PRD #483 audit's Downstream PRD candidates. See `docs/reviews/advisory-rules-audit-2026-04-15.md` Action Items → "Package-hygiene rules for Python and Go providers."

--- a/prds/374-go-provider.md
+++ b/prds/374-go-provider.md
@@ -3,7 +3,8 @@
 **Status**: Draft — refine after PRD #373 (Python provider) and PRD #507 (multi-language rule architecture cleanup) are both complete
 **Priority**: Medium
 **GitHub Issue**: [#374](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/374)
-**Blocked by**: Two hard prerequisites — (1) [PRD #373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373) (Python provider) must merge first; Python is the primary interface stress test and must succeed before Go (which is the hardest case). (2) [PRD #507](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/507) (multi-language rule architecture cleanup) must merge first; the refactored `LanguageProvider` interface from #507 is the contract this PRD implements against. PRD #373 is already blocked by PRD #507, so this transitive chain is honored automatically — #507 → #373 → #374.
+**Blocked by**: [PRD #373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373) (Python provider) and [PRD #507](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/507) (multi-language rule architecture cleanup). PRD #373 is already blocked by PRD #507, so the transitive chain is honored automatically — #507 → #373 → #374.
+**Design sync**: Several OD decisions in this PRD (OD-9b library/app classification, OD-9c rule ID choice) explicitly match whatever Python decided in PRD #373. Before finalizing Go's pre-implementation gate, read PRD #373's completed Decision Log and mirror the relevant decisions here. Do not resolve OD-9c independently — cross-reference PRD #373 OD-9c explicitly.
 **Created**: 2026-04-06
 **Updated**: 2026-04-20 — added PRD #507 blocker and Milestone E4 for Go API-002-equivalent package-hygiene rule, per PRD #483 audit's Downstream PRD candidates. See `docs/reviews/advisory-rules-audit-2026-04-15.md` Action Items → "Package-hygiene rules for Python and Go providers."
 

--- a/prds/379-weaver-code-generation.md
+++ b/prds/379-weaver-code-generation.md
@@ -1,9 +1,9 @@
 # PRD #379: Weaver code generation for domain-specific constants
 
-**Status**: Draft — refine after PRD #371 (JavaScript extraction) is complete  
+**Status**: Draft — refine after PRD #507 (multi-language architecture) is complete  
 **Priority**: Medium  
 **GitHub Issue**: [#379](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/379)  
-**Blocked by**: PRD #371 (JavaScript extraction) — the coordinator must dispatch through `LanguageProvider` before this can wire in cleanly  
+**Blocked by**: PRD #507 (multi-language rule architecture cleanup) — `LanguageProvider` must be wired into `dispatchFiles` (PRD #507 M3/M4) before this can wire in cleanly. PRD #371 (JavaScript extraction) is already merged ✓.  
 **Does NOT block**: PRDs #372–#374 — those providers ship without this enhancement and benefit retroactively  
 **Created**: 2026-04-06
 

--- a/prds/507-multi-language-rule-architecture.md
+++ b/prds/507-multi-language-rule-architecture.md
@@ -140,6 +140,8 @@ This milestone opens with a **design decision**: where does language-agnostic SC
 
 Decide between A and B — the SCH rebuild PRD (blocked by this milestone) cannot begin until this question is answered. Record the decision in this PRD's Decision Log, then execute it.
 
+**Escalation path**: If the A vs. B decision requires extended discussion or investigation (e.g., unclear how Python/Go AST extraction would integrate with a shared `tier2/` module), file a standalone design issue immediately and notify Whitney rather than letting M6 stall. Do not let an unresolved architectural question block the rest of PRD #507's milestones — M1–M5 are independent of M6 and can proceed in parallel.
+
 - [ ] Step 0: read `docs/reviews/advisory-rules-audit-2026-04-15.md` in full — especially the SCH section and the Action Items
 - [ ] Decision recorded in this PRD's Decision Log: Option A or Option B (or a third option if one emerges during implementation), with rationale
 - [ ] Decision executed: stale duplicate copies removed or unified; `tier2/sch004.ts` divergence resolved

--- a/test/coordinator/sdk-init.test.ts
+++ b/test/coordinator/sdk-init.test.ts
@@ -57,8 +57,8 @@ describe('updateSdkInitFile', () => {
       expect(result.fallbackWritten).toBe(false);
 
       const content = await readFile(sdkFile, 'utf-8');
-      expect(content).toContain('ExpressInstrumentation');
-      expect(content).toContain('@opentelemetry/instrumentation-express');
+      expect(content).toContain("import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express'");
+      expect(content).toContain('new ExpressInstrumentation()');
       // Original call expression must be preserved
       expect(content).toContain('getNodeAutoInstrumentations()');
     });

--- a/test/coordinator/sdk-init.test.ts
+++ b/test/coordinator/sdk-init.test.ts
@@ -33,6 +33,36 @@ function makeLibrary(pkg: string, importName: string): LibraryRequirement {
 
 describe('updateSdkInitFile', () => {
   describe('NodeSDK pattern detection with ES imports', () => {
+    it('appends new instrumentations when array contains a call expression like getNodeAutoInstrumentations()', async () => {
+      // Exact SDK_INIT_CONTENT used in the coordinator acceptance gate test
+      await writeFile(join(testDir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf-8');
+      const sdkFile = await createSdkInitFile(
+        `import { NodeSDK } from '@opentelemetry/sdk-node';\n` +
+        `import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';\n\n` +
+        `const sdk = new NodeSDK({\n` +
+        `  instrumentations: [\n` +
+        `    getNodeAutoInstrumentations(),\n` +
+        `  ],\n` +
+        `});\n\n` +
+        `sdk.start();\n`,
+      );
+
+      const libraries: LibraryRequirement[] = [
+        makeLibrary('@opentelemetry/instrumentation-express', 'ExpressInstrumentation'),
+      ];
+
+      const result = await updateSdkInitFile(sdkFile, libraries, testDir);
+
+      expect(result.updated).toBe(true);
+      expect(result.fallbackWritten).toBe(false);
+
+      const content = await readFile(sdkFile, 'utf-8');
+      expect(content).toContain('ExpressInstrumentation');
+      expect(content).toContain('@opentelemetry/instrumentation-express');
+      // Original call expression must be preserved
+      expect(content).toContain('getNodeAutoInstrumentations()');
+    });
+
     it('appends new instrumentations to an existing NodeSDK instrumentations array', async () => {
       const sdkFile = await createSdkInitFile(`
 import { NodeSDK } from '@opentelemetry/sdk-node';


### PR DESCRIPTION
## Summary

- Adds a unit test for `updateSdkInitFile` with the exact SDK init content used in the coordinator acceptance gate: an ESM file where the `instrumentations` array already contains `getNodeAutoInstrumentations()` (a call expression, not a `new` expression)
- Confirms the function correctly appends new entries — both `new X()` in the array and the `import { X } from '...'` statement — without treating the existing call expression as a pattern-rejection trigger
- Smoke-tested the P4-3 coordinator acceptance gate test with a real API call; it passed

## Test plan

- [x] `npm test` — 2312 tests pass
- [x] `npm run typecheck` — clean
- [x] P4-3 coordinator acceptance gate smoke test passed locally (real LLM call, ~275s)
- [ ] CI acceptance gate passes with `run-acceptance` label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap with standardized evaluation criteria and current progress status; revised multiple PRDs to update blocking prerequisites, milestone guidance, and coordination notes; added an unreleased changelog bullet describing a unit-test scenario.

* **Tests**
  * Added unit test covering SDK initialization behavior when existing instrumentation entries are present, ensuring new instrumentations are appended and proper ESM imports are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->