### PR TITLE
PRD: Smarter end-of-run test failure handling

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- (2026-05-01) Created four GitHub issues from the taze eval run-11 handoff document, capturing the four actionable problems found: the PR summary incorrectly showing "OK" when Weaver received no spans (#683), the rollback count math becoming unreadable after a 3-file rollback (#684), the missing documentation explaining why checkpoint test failures can't be caused by instrumentation (#685), and a research spike to survey how CI tooling, code-transformation tools, and live telemetry validators handle the same problems in other ecosystems (#686). All issue bodies reviewed with `/write-prompt` before creation. Updated Issue D to include a step that triggers `/prd-update-decisions` if the research reveals design changes for PRDs 1–4, and updated PRD #679's M2–M5 milestones to read the research output before drafting each PRD.
+
 ### Changed
 
 - (2026-05-01) Fixed NDS-003 (Code Preserved) to handle three instrumentation-motivated transformations that appeared in taze eval run-11 (`src/io/resolves.ts`): (1) braceless single-statement `if` gaining braces for span body wrapping — `normalizeLine()` now strips the trailing `{` from `if (condition) {` lines so both forms compare equal; (2) `await` added to a non-async expression during return-value capture — `reconcileReturnCaptures()` now strips leading `await` from both the capture expression and the return expression before comparison; (3) catch variable renamed to avoid shadowing (e.g., `spanError` instead of `error`) — the `throw` instrumentation pattern now matches any single-identifier throw rather than a fixed list of known names.

--- a/docs/handoff/issue-tracking.md
+++ b/docs/handoff/issue-tracking.md
@@ -2,3 +2,4 @@ Issue A: #683
 Issue B: #684
 Issue C: #685
 Issue D: #686
+PRD 2: #687

--- a/docs/handoff/issue-tracking.md
+++ b/docs/handoff/issue-tracking.md
@@ -1,0 +1,4 @@
+Issue A: #683
+Issue B: #684
+Issue C: #685
+Issue D: #686

--- a/docs/research/typescript-cli-tsc-behavior.md
+++ b/docs/research/typescript-cli-tsc-behavior.md
@@ -4,6 +4,7 @@
 **Last Updated:** 2026-04-28
 
 ## Update Log
+
 | Date | Summary |
 |------|---------|
 | 2026-04-28 | Initial research — TS5112, --ignoreConfig, stdout vs stderr, new 6.x defaults, --noCheck |
@@ -20,7 +21,7 @@ TypeScript 6.0 (released March 2026) introduced TS5112, a hard error that fires 
 
 **The biggest surprise: tsc errors go to stdout, not stderr** — and this is "Working as Intended." Multiple GitHub issues (615, 9526, 12844) report this and are all closed as "By Design." TS5112 specifically also goes to stdout. Any tool capturing tsc output must capture both streams.
 
-The spiny-orb codebase empirically discovered this; line 210 of `validation.ts` reads:
+The spiny-orb codebase empirically discovered this; line 262 of `validation.ts` reads:
 ```typescript
 // tsc sometimes writes diagnostics to stdout rather than stderr (e.g. TS5112).
 ```

--- a/docs/research/typescript-cli-tsc-behavior.md
+++ b/docs/research/typescript-cli-tsc-behavior.md
@@ -1,0 +1,183 @@
+# Research: TypeScript tsc CLI Behavior (5.x → 6.x)
+
+**Project:** spinybacked-orbweaver
+**Last Updated:** 2026-04-28
+
+## Update Log
+| Date | Summary |
+|------|---------|
+| 2026-04-28 | Initial research — TS5112, --ignoreConfig, stdout vs stderr, new 6.x defaults, --noCheck |
+
+## Findings
+
+### Summary
+
+TypeScript 6.0 (released March 2026) introduced TS5112, a hard error that fires when files are passed on the command line while a tsconfig.json is discoverable. The fix is `--ignoreConfig`, a new tsc 6.x-only flag. tsc writes most diagnostics to **stdout** (not stderr) — this has been the behavior since TypeScript 2.x and remains unchanged in 6.x. `--noCheck` (added in 5.6) skips type-checking without loading a tsconfig. The spiny-orb project has already implemented handling for all of these in `src/languages/typescript/validation.ts`.
+
+---
+
+### Surprises & Gotchas
+
+**The biggest surprise: tsc errors go to stdout, not stderr** — and this is "Working as Intended." Multiple GitHub issues (615, 9526, 12844) report this and are all closed as "By Design." TS5112 specifically also goes to stdout. Any tool capturing tsc output must capture both streams.
+
+The spiny-orb codebase empirically discovered this; line 210 of `validation.ts` reads:
+```typescript
+// tsc sometimes writes diagnostics to stdout rather than stderr (e.g. TS5112).
+```
+and the code joins both streams.
+
+---
+
+### 1. TS5112 — "tsconfig.json is present but will not be loaded" (tsc 6.0+)
+
+🟢 **High confidence** — confirmed in official release notes, RC blog post, GitHub issue #62197.
+
+**What triggers it:** Running `tsc <file>` (with file arguments on the CLI) when a `tsconfig.json` is discoverable. tsc walks up ancestor directories to discover tsconfig, so the tsconfig does not need to be in the CWD — TS5112 fires for any tsconfig found by walking up the directory tree.
+
+**Exact error text:**
+```text
+error TS5112: tsconfig.json is present but will not be loaded if files are specified
+on commandline. Use '--ignoreConfig' to skip this error.
+```
+
+**Exit code:** Hard error (non-zero exit), not a warning. The `error TS5112:` prefix confirms this.
+
+**Introduced in:** TypeScript 6.0 (March 2026). Not present in any 5.x release.
+
+**Motivation:** AI coding agents ran `tsc foo.ts` expecting defaults, silently ignoring tsconfig, then tried to "fix" errors that were artifacts of wrong compiler settings. TS5112 forces the mismatch to be explicit.
+
+**Source:** "error TS5112: tsconfig.json is present but will not be loaded if files are specified on commandline." — [TypeScript 6.0 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html)
+
+---
+
+### 2. `--ignoreConfig` Flag
+
+🟢 **High confidence** — in official CLI options docs and release notes.
+
+**Exact flag names:** `--ignoreConfig` (camelCase) or `--ignore-config` (kebab-case) — both accepted.
+
+**What it does:** "Ignore the tsconfig found and build with commandline options and files." Bypasses tsconfig discovery entirely. Suppresses TS5112. No tsconfig is loaded, even from ancestor directories.
+
+**When available:** tsc 6.0+ ONLY. On tsc 5.x, passing `--ignoreConfig` causes "unknown compiler option" error. Must version-gate.
+
+**Recommended pattern for tsc 6+:**
+```bash
+tsc --noEmit --ignoreConfig --strict [other flags] file.ts
+```
+
+**The spiny-orb code does exactly this:**
+```typescript
+...getTscMajorVersion(tsc) >= 6 ? ['--ignoreConfig'] : [],
+```
+
+---
+
+### 3. stdout vs stderr — the long-standing trap
+
+🟢 **High confidence** (empirical + multiple GitHub issues closed "By Design").
+
+tsc has written all diagnostics (errors, warnings, TS5112) to **stdout** since at least TypeScript 2.x. This behavior is marked "Working as Intended" / "By Design" in multiple closed issues:
+- [Issue #615](https://github.com/Microsoft/TypeScript/issues/615): "By Design"
+- [Issue #9526](https://github.com/Microsoft/TypeScript/issues/9526): "Working as Intended"
+- [Issue #12844](https://github.com/microsoft/TypeScript/issues/12844): "Duplicate"/"Working as Intended"
+
+**stderr is used by tsc** only for certain infrastructure/configuration errors (e.g., missing tsconfig when one is required). A [vitest fix](https://github.com/vitest-dev/vitest/commit/7b10ab4cd) added stderr capture specifically for that case: "Also capture stderr for configuration errors like missing tsconfig."
+
+**Practical consequence:** Code that only reads `stderr` from a tsc child process will miss most errors. Must capture both streams and join them.
+
+**No change in 5.x → 6.x.** The stdout-first behavior is unchanged.
+
+---
+
+### 4. New defaults when running tsc 6.x without a tsconfig
+
+🟢 **High confidence** — from official release notes.
+
+When running `tsc --ignoreConfig file.ts` (no tsconfig loaded), tsc 6.0 defaults have changed significantly from 5.x:
+
+| Option | tsc 5.x default | tsc 6.0 default |
+|---|---|---|
+| `strict` | `false` | `true` |
+| `module` | `commonjs` | `esnext` |
+| `target` | `es5` | `es2025` |
+| `types` | all @types/* | `[]` (none) |
+| `rootDir` | inferred from files | `.` |
+
+Tools that relied on 5.x's permissive defaults will see more errors under 6.x. Always pass explicit flags.
+
+---
+
+### 5. `--noCheck` flag (tsc 5.6+)
+
+🟡 **Medium confidence** — from search results; official docs page gave minimal detail.
+
+- **Introduced:** Internal in TypeScript 5.5; public CLI flag in TypeScript 5.6 (September 2024).
+- **What it does:** Disables full type checking; only critical parse and emit errors are reported. Faster.
+- **Use case:** Tools that want to emit JavaScript without type-checking (separate type-check process). Not the same as `--noEmit`. Does not suppress TS5112 on its own.
+- **spiny-orb uses `--noEmit`** (check types, don't emit) which is correct for a validator. `--noCheck` is not used.
+
+---
+
+### 6. Deprecated options that are now hard errors in tsc 6.0
+
+🟢 **High confidence** — from release notes.
+
+These flags, valid in 5.x, now cause hard errors in 6.0 when passed on the CLI:
+- `--target es5` (minimum is now ES2015)
+- `--moduleResolution node` / `node10`
+- `--baseUrl` (as a module resolution root)
+- `--outFile` (removed entirely)
+- `--module amd` / `umd` / `systemjs` / `none`
+
+Tools that hardcode any of these flags will break under tsc 6.0.
+
+---
+
+### Recommended Pattern for File-by-File Type Checking (tsc 5.x + 6.x compatible)
+
+```typescript
+// Detect tsc version first
+const version = getTscMajorVersion(tsc); // parse 'Version X.Y.Z' from tsc --version
+
+// Build args array
+const args = [
+  '--noEmit',
+  '--strict',
+  '--skipLibCheck',
+  '--allowImportingTsExtensions',
+  // Only add --ignoreConfig on tsc 6+; it is an unknown flag on 5.x
+  ...(version >= 6 ? ['--ignoreConfig'] : []),
+  '--module', moduleFlag,
+  '--moduleResolution', moduleResolutionFlag,
+  '--target', 'ES2022',
+  filePath,
+];
+
+// Always capture both stdout and stderr — tsc writes errors to stdout (by design)
+const result = execFileSync(tsc, args, {
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+// On error, join error.stdout and error.stderr
+```
+
+---
+
+### Caveats
+
+- The exact scope of TS5112's tsconfig discovery (CWD only vs. ancestor walk) is not explicitly documented. The evidence (tsc has always walked ancestor directories; TS5112 fires whenever tsconfig "would be loaded") strongly implies it fires for parent-dir tsconfigs, but no authoritative quote confirms this specific scenario.
+- The stdout-first behavior has never been officially documented as a permanent guarantee — it's empirically observed and "Working as Intended." A future major version could change it without announcement.
+- tsc 7.0 (Go-based rewrite) is in development. CLI behavioral compatibility is not yet documented.
+
+## Sources
+
+- [TypeScript 6.0 Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html) — official docs for TS5112, --ignoreConfig, new defaults
+- [Announcing TypeScript 6.0 (MS Blog)](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/) — confirmed TS5112, --ignoreConfig motivation
+- [Announcing TypeScript 6.0 RC (MS Blog)](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-rc/) — RC details for CLI changes
+- [GitHub Issue #62197: Error if command-line options specified when tsconfig present](https://github.com/microsoft/TypeScript/issues/62197) — design discussion for TS5112
+- [TypeScript CLI Options docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html) — --ignoreConfig and --noCheck flag reference
+- [GitHub Issue #615: Compilation error not reported on stderr](https://github.com/Microsoft/TypeScript/issues/615) — stdout-first behavior, "By Design"
+- [GitHub Issue #9526: Errors are output to stdout](https://github.com/Microsoft/TypeScript/issues/9526) — "Working as Intended"
+- [GitHub Issue #12844: tsc error message printed to stdout not stderr](https://github.com/microsoft/TypeScript/issues/12844) — "Duplicate"/"Working as Intended"
+- [TypeScript 5.x to 6.0 Migration Guide (Gist)](https://gist.github.com/privatenumber/3d2e80da28f84ee30b77d53e1693378f) — migration guide with breaking changes
+- [vitest commit 7b10ab4: improve error when tsc outputs help text](https://github.com/vitest-dev/vitest/commit/7b10ab4cd) — empirical evidence for stderr used for config errors
+- [TypeScript 5.9 Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html) — 5.9 CLI changes (--init, --module node20)

--- a/prds/679-create-issues-and-prds-from-taze-handoff.md
+++ b/prds/679-create-issues-and-prds-from-taze-handoff.md
@@ -25,7 +25,7 @@ Create each deliverable in dependency order. Every milestone starts by reading t
 
 ## Milestones
 
-- [ ] M1: Create 4 standalone GitHub issues from the handoff doc
+- [x] M1: Create 4 standalone GitHub issues from the handoff doc
 - [ ] M2: Create PRD 2 (smarter end-of-run test failure handling) + CodeRabbit review + audit
 - [ ] M3: Create PRD 1 (live-check actually validates something) + CodeRabbit review + audit
 - [ ] M4: Create PRD 3 (diagnostic agent for persistent failures) + CodeRabbit review + audit
@@ -85,7 +85,7 @@ If VERDICT is FAIL, update the issues to close the gaps before proceeding to M2.
 
 ### M2: Create PRD 2 — Smarter end-of-run test failure handling
 
-**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — the foundational insight section and the "PRD 2" section are both required reading. The foundational insight explains why timeout failures cannot be caused by instrumentation (spans are no-ops); this context must be reflected in the PRD's design principle.
+**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — the foundational insight section and the "PRD 2" section are both required reading. The foundational insight explains why timeout failures cannot be caused by instrumentation (spans are no-ops); this context must be reflected in the PRD's design principle. If `docs/research/industry-practices-spike.md` exists, read it too — the spike covers flaky test handling and rollback patterns that directly inform PRD 2's design decisions. If the research surfaces design decisions that affect this or other open PRDs, run `/prd-update-decisions` before proceeding to Step 1.
 
 **Step 1 — Create branch**: `git checkout -b prd/smarter-end-of-run-failure-handling`
 
@@ -134,7 +134,7 @@ If VERDICT is FAIL, update the PRD to close the gaps before proceeding to M3.
 
 ### M3: Create PRD 1 — Make live-check actually validate something
 
-**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — the foundational insight section and the "PRD 1" section are both required reading. The foundational insight is the background that makes the problem legible; the PRD must reflect it.
+**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — the foundational insight section and the "PRD 1" section are both required reading. The foundational insight is the background that makes the problem legible; the PRD must reflect it. If `docs/research/industry-practices-spike.md` exists, read it too — the spike covers live telemetry validation tooling patterns that directly inform PRD 1's SDK injection approach. If the research surfaces design decisions that affect this or other open PRDs, run `/prd-update-decisions` before proceeding to Step 1.
 
 **Step 1 — Create branch**: `git checkout -b prd/live-check-validation`
 
@@ -184,7 +184,7 @@ If VERDICT is FAIL, update the PRD to close the gaps before proceeding to M4.
 
 ### M4: Create PRD 3 — Diagnostic agent for persistent failures
 
-**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — specifically the "PRD 3" section. Note the prerequisite dependencies (PRDs 1 and 2) which must be explicit in the PRD.
+**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — specifically the "PRD 3" section. Note the prerequisite dependencies (PRDs 1 and 2) which must be explicit in the PRD. If `docs/research/industry-practices-spike.md` exists, read it too — the spike covers diagnostic tooling patterns that inform PRD 3's call graph serialization and rollback decision design. If the research surfaces design decisions that affect this or other open PRDs, run `/prd-update-decisions` before proceeding to Step 1.
 
 **Step 1 — Create branch**: `git checkout -b prd/diagnostic-agent-persistent-failures`
 
@@ -230,7 +230,7 @@ If VERDICT is FAIL, update the PRD to close the gaps before proceeding to M5.
 
 ### M5: Create PRD 4 — Dependency-aware file instrumentation ordering
 
-**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — specifically the "PRD 4" section. Note that this PRD is independent of PRDs 1–3 and can be worked in parallel.
+**Start**: Read `docs/handoff/spiny-orb-design-handoff.md` in full — specifically the "PRD 4" section. Note that this PRD is independent of PRDs 1–3 and can be worked in parallel. If `docs/research/industry-practices-spike.md` exists, read it too — it may contain findings relevant to dependency graph tooling patterns. If the research surfaces design decisions that affect this or other open PRDs, run `/prd-update-decisions` before proceeding to Step 1.
 
 **Step 1 — Create branch**: `git checkout -b prd/dependency-aware-ordering`
 

--- a/prds/687-smarter-end-of-run-failure-handling.md
+++ b/prds/687-smarter-end-of-run-failure-handling.md
@@ -1,0 +1,188 @@
+# PRD #687: Smarter end-of-run test failure handling
+
+**Status**: Active
+**Priority**: High
+**GitHub Issue**: [#687](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/687)
+**Created**: 2026-05-01
+
+---
+
+## Problem
+
+When the end-of-run test suite fails, spiny-orb rolls back all recently committed files indiscriminately. This is often incorrect.
+
+**Why the current behavior is provably wrong**: During checkpoint tests, `testCommand` executes without loading the SDK init file. Every `tracer.startActiveSpan()` resolves to a `NonRecordingSpan` via `@opentelemetry/api`'s no-op default — zero spans are emitted. Span wrappers have negligible overhead (microseconds) because they're no-ops. This means our instrumentation **cannot cause timeout errors** in the checkpoint test suite. Timeout failures are environmental.
+
+**Run-11 proof case**:
+- `resolves.test.ts:136` failed with an npm timeout on `resolveDependency`
+- `resolves.ts` failed NDS-003 and was **never committed**
+- Three correctly-instrumented files (`yarnWorkspaces.ts`, `pnpmWorkspaces.ts`, `packument.ts`) were rolled back for a failure in code spiny-orb never touched
+- npm registry was healthy at the time (`registry.npmjs.org/-/ping` returns `{}`)
+
+The current end-of-run rollback logic in `coordinate.ts` Step 7c applies no filtering — it rolls back all committed files whenever the test suite fails, regardless of whether any committed file appears in the failing test's call path.
+
+---
+
+## Design Principle
+
+**The default assumption when a test fails is that we caused it. The only permitted exception is if the external API is verifiably down.**
+
+Health checks are not a courtesy — they are the narrow gate through which environmental failures escape the "we caused it" default.
+
+**Explicitly rejected approaches**:
+- `--exclude` flags for specific failing tests: hides real signal. If a test is flaky, we need to know. Excluding it masks the symptom without diagnosing the cause.
+- Treating all timeouts as environmental: this would let real instrumentation regressions slip through if a test happens to also make external calls.
+
+---
+
+## Open Design Question
+
+**Should smart-rollback run first as a cheap deterministic gate?**
+
+The three fixes below are ordered: health-check → retry → smart-rollback. But consider the run-11 case: smart-rollback alone would have prevented the bad rollback without any external calls or delays, because the failing test's stack trace points to `resolves.ts`, which was never committed.
+
+The alternative ordering — smart-rollback first, then health-check and retry only when committed files are in the call path — is cheaper and requires no network calls in the common case. The PRD implementor should evaluate both orderings and document the decision before implementation.
+
+---
+
+## Solution
+
+Three connected fixes that form a decision tree. A partial implementation leaves the rollback logic inconsistent — all three must ship together.
+
+### Fix 1: API health check before rollback
+
+When a test fails with a timeout error, check the health endpoint of the external API involved:
+- npm: `GET registry.npmjs.org/-/ping` — healthy if response is `{}`
+- jsr: `GET jsr.io` — healthy if HTTP 200
+
+If the API is unhealthy: report that and suspend rollback. The failure is environmental, not caused by instrumentation.
+
+If the API is healthy: proceed to Fix 2.
+
+**Open research question**: How do we identify "the external API this test depends on" generically when it's not npm or jsr? The current approach hard-codes npm/jsr health endpoints. The implementor should research whether a more general approach (e.g., parsing timeout error messages for hostnames) is feasible.
+
+### Fix 2: One retry with delay
+
+After a healthy API check, wait ~30 seconds and retry the test suite once.
+
+- If the retry passes: do not roll back. The failure was transient.
+- If the retry fails again: proceed to Fix 3.
+
+**Open research question**: Which test failure types are amenable to retry vs. deterministic instrumentation breakage? The implementor should survey the failure taxonomy before finalizing the retry heuristic. Timeout errors with a healthy API are the clear case for retry; other failure types (assertion errors, type errors) should likely not trigger retry.
+
+### Fix 3: Extend smart-rollback to the end-of-run path
+
+The `parseFailingSourceFiles` function in `dispatch.ts` parses a failing test's stack trace and identifies which source files it exercises. This logic is already used during checkpoint rollback decisions but is **not applied** at the end-of-run in `coordinate.ts` Step 7c.
+
+Apply it there: when a test fails, parse the stack trace, identify source files in the call path, compare against the set of committed instrumented files. If no committed file appears in the call path, do not roll back.
+
+**Open research question**: Is `parseFailingSourceFiles` lift-and-shift from `dispatch.ts` to `coordinate.ts`, or are there differences between the checkpoint context and the end-of-run context that require separate handling? The implementor should read both call sites before deciding.
+
+---
+
+## Out of Scope
+
+- **NDS-003 calibration for `resolves.ts`**: Filed as issue #675. `resolves.ts` failed NDS-003 due to non-instrumentation line additions (braceless `if` style, `await` in return capture, renamed catch variable) — a separate agent-quality issue.
+- **`--exclude` flags for specific failing tests**: Explicitly rejected (see Design Principle).
+- **Generic timeout detection across all external APIs**: The health check approach requires known endpoints. Generalizing beyond npm/jsr is out of scope for this PRD.
+
+---
+
+## Milestones
+
+- [ ] M1: Research — answer the three open research questions before any implementation
+- [ ] M2: Implement Fix 3 (smart-rollback at end-of-run) with tests
+- [ ] M3: Implement Fix 1 (API health check) with tests
+- [ ] M4: Implement Fix 2 (retry with delay) with tests
+- [ ] M5: Integration test — end-to-end scenario reproducing run-11 failure pattern
+
+---
+
+## Milestone Detail
+
+### M1: Research
+
+**Do not write any implementation code in this milestone.** This milestone answers the three open questions before any code is written.
+
+**Question 1 — Failure type taxonomy**: Survey the existing test failure cases in the eval runs at `~/Documents/Repositories/spinybacked-orbweaver-eval` (taze runs 8–11). If that path does not exist, run `gh repo list wiggitywhitney | grep eval` to find the cloned location. Categorize each failure by type: timeout, assertion error, type error, import error, etc. For each category, determine whether retry is appropriate. Document the taxonomy and the retry heuristic in a markdown file at `docs/research/end-of-run-failure-taxonomy.md`.
+
+**Question 2 — Generic API identification**: Read the timeout error messages from run-11 (in the eval repo diagnostic output). Determine whether the hostname causing the timeout can be reliably extracted from the error message. If yes, document the extraction approach. If no, document why hard-coding npm/jsr is acceptable for now. Write findings to `docs/research/end-of-run-failure-taxonomy.md` (same file, separate section).
+
+**Question 3 — parseFailingSourceFiles portability**: Read `parseFailingSourceFiles` in `dispatch.ts` and the call site in `coordinate.ts` Step 7c. Determine whether the function can be called from `coordinate.ts` without modification, or whether end-of-run stack traces differ in structure from checkpoint stack traces. Write findings to `docs/research/end-of-run-failure-taxonomy.md` (same file, separate section).
+
+**Question 4 — Fix ordering**: Based on the answers to Questions 1–3, decide the ordering of the three fixes (see Open Design Question section). Document the chosen ordering and the rationale. Update this PRD's Decision Log with the ordering decision before proceeding to M2.
+
+Success criterion: `docs/research/end-of-run-failure-taxonomy.md` exists and answers all four questions with enough specificity to drive M2–M4 implementation without further research.
+
+### M2: Implement Fix 3 — Smart-rollback at end-of-run
+
+**Start by reading `docs/research/end-of-run-failure-taxonomy.md`** to confirm the research answers before writing any code.
+
+Apply `parseFailingSourceFiles` from `dispatch.ts` at the end-of-run failure path in `coordinate.ts` Step 7c. Do NOT rewrite or replace the function. If the end-of-run stack trace format differs from the checkpoint format, write a normalization adapter that converts end-of-run stack traces to the format `parseFailingSourceFiles` expects, then call the original function. When a test fails, parse the stack trace, compare against committed instrumented files. If no committed file appears in the call path, skip rollback and report why.
+
+TDD: write a failing unit test that reproduces the run-11 scenario (failing test with no committed files in call path) before implementing. Confirm the test fails, implement, confirm it passes.
+
+Success criteria:
+- Unit test exists and passes
+- The run-11 scenario (failing test in uncommitted file) does not trigger rollback
+- Existing test suite passes with no regressions
+
+### M3: Implement Fix 1 — API health check before rollback
+
+**Start by reading `docs/research/end-of-run-failure-taxonomy.md`** to use the documented failure taxonomy and API identification approach.
+
+Add health check logic: when a timeout error is detected in the failing test output, check the relevant API endpoint. Health check targets: `registry.npmjs.org/-/ping` (npm), `jsr.io` (jsr). If unhealthy, suspend rollback and report the specific endpoint that failed.
+
+TDD: write a failing unit test that mocks an unhealthy npm endpoint and asserts rollback is suspended. Confirm failure, implement, confirm pass.
+
+Success criteria:
+- Unit test exists and passes (mocked unhealthy API → no rollback)
+- Unit test exists and passes (mocked healthy API → rollback proceeds to retry)
+- Existing test suite passes with no regressions
+
+### M4: Implement Fix 2 — Retry with delay
+
+**Start by reading `docs/research/end-of-run-failure-taxonomy.md`** to confirm the retry heuristic.
+
+After a healthy API check, wait ~30 seconds and retry the test suite once. If the retry passes, skip rollback and report "transient failure resolved on retry." If it fails again, proceed to the rollback decision.
+
+TDD: write a failing unit test that simulates a transient failure (first run fails, second run passes) and asserts no rollback occurs. Use a time-control mechanism (fake timers or configurable delay) so the test doesn't actually wait 30 seconds.
+
+Success criteria:
+- Unit test exists and passes (transient failure → retry succeeds → no rollback)
+- Unit test exists and passes (persistent failure → retry also fails → rollback proceeds)
+- The delay is configurable for testing (default 30s, override via env var or config)
+- Existing test suite passes with no regressions
+
+### M5: Integration test — end-of-run failure scenario
+
+Write an integration test that reproduces the run-11 failure pattern end-to-end:
+- A fixture with committed instrumented files
+- A test suite that fails with a timeout in an uncommitted file
+- Assert that the committed files are not rolled back
+
+This is an end-to-end integration test, not a unit test. It should run against real coordinator logic. Place this test in `test/coordinator/acceptance-gate.test.ts` — this project uses acceptance gate tests for end-to-end coordinator scenarios. Verify the test runs with:
+
+```bash
+vals exec -f .vals.yaml -- bash -c 'export PATH="/opt/homebrew/bin:$PATH" && npx vitest run test/coordinator/acceptance-gate.test.ts'
+```
+
+Success criterion: integration test exists in `test/coordinator/acceptance-gate.test.ts`, passes under the command above, and CI acceptance gate workflow passes.
+
+---
+
+## Design Notes
+
+- The feature PR created by `/prd-done` needs the `run-acceptance` label to trigger acceptance gate CI. This is handled automatically by `/prd-done` when acceptance gate tests are detected.
+- The three fixes form a decision tree. The ordering (which fix runs first) is an open design question resolved in M1. Do not implement M2–M4 until the ordering decision is documented in the Decision Log.
+- Fix 3 (smart-rollback) is the cheapest and most deterministic fix. Fix 1 (health check) makes external network calls. Fix 2 (retry) adds a 30-second delay. The M1 research should inform whether Fix 3 should gate Fixes 1 and 2.
+
+---
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-01 | Three fixes must ship together | They form a decision tree; partial implementation leaves rollback logic inconsistent |
+| 2026-05-01 | `--exclude` flag workaround explicitly rejected | Hides real signal; masks symptoms without diagnosing cause |
+| 2026-05-01 | Fix ordering deferred to M1 research | Run-11 suggests smart-rollback-first may be more efficient; decision requires reading `parseFailingSourceFiles` portability before committing |


### PR DESCRIPTION
Adds PRD #687 for smarter end-of-run test failure handling from taze eval handoff.

## Summary
- Creates `prds/687-smarter-end-of-run-failure-handling.md` with 5 milestones covering research, three connected fixes (smart-rollback, API health check, retry with delay), and an integration test
- Updates `docs/handoff/issue-tracking.md` with `PRD 2: #687`

## Test plan
- [ ] CodeRabbit review passes
- [ ] PRD milestones are accurate and complete per handoff doc fidelity check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PRD describing smarter end-of-run failure handling with defined milestones and combined fixes.
  * Updated milestone checklist and roadmap to require conditional research review steps before proceeding.
  * Added a handoff issue-tracking mapping linking four newly created issues to the handoff.
  * Published a research note detailing TypeScript tsc CLI behavioral differences (5.x vs 6.x).

* **Chores**
  * Updated changelog with the new issues and milestone updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->