### PR TITLE
docs(prd-687): add foundational insight framing and live-check false-positive context

### DIFF
--- a/prds/687-smarter-end-of-run-failure-handling.md
+++ b/prds/687-smarter-end-of-run-failure-handling.md
@@ -11,7 +11,10 @@
 
 When the end-of-run test suite fails, spiny-orb rolls back all recently committed files indiscriminately. This is often incorrect.
 
-**Why the current behavior is provably wrong**: During checkpoint tests, `testCommand` executes without loading the SDK init file. Every `tracer.startActiveSpan()` resolves to a `NonRecordingSpan` via `@opentelemetry/api`'s no-op default — zero spans are emitted. Span wrappers have negligible overhead (microseconds) because they're no-ops. This means our instrumentation **cannot cause timeout errors** in the checkpoint test suite. Timeout failures are environmental.
+**Foundational insight** (the most important context for this PRD): During checkpoint tests, `testCommand` executes without loading the SDK init file. Every `tracer.startActiveSpan()` resolves to a `NonRecordingSpan` via `@opentelemetry/api`'s no-op default — zero spans are emitted. Span wrappers have negligible overhead (microseconds) because they're no-ops. This insight has two consequences:
+
+- **Consequence 1 (drives this PRD)**: Our instrumentation **cannot cause timeout errors** in the checkpoint test suite. Timeout failures are environmental — the current rollback logic is wrong to roll back instrumented files when a timeout occurs.
+- **Consequence 2 (drives PRD 1)**: Every "Live-check: OK" in every PR summary to date is a false positive — Weaver received nothing and nothing failed. The live-check is currently inert. This is addressed separately in PRD 1.
 
 **Run-11 proof case**:
 - `resolves.test.ts:136` failed with an npm timeout on `resolveDependency`


### PR DESCRIPTION
Closes two gaps found in the M2 audit against the handoff doc:

1. **Foundational insight not marked as foundational** — added "Foundational insight (the most important context for this PRD)" framing to the Problem section
2. **Consequence 2 absent** — added the live-check false-positive consequence alongside Consequence 1, with a note that it's addressed separately in PRD 1

Gaps 3–5 from the audit were structural differences only (content present, organization differs) — treated as Skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated failure handling documentation with clearer foundational insights on system behavior
  * Clarified timeout failure characteristics and live-check result interpretation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->