### PR TITLE
feat: TypeScript pre-scan + --thinking flag docs (#714, #738)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ Configuration not found — run 'spiny-orb init' to create spiny-orb.yaml
             schema extensions, and agent notes. Use this when a file fails and you want
             to understand why.
 --thinking  Show agent thinking blocks for failed files. Thinking blocks contain the
-            agent's step-by-step reasoning per attempt. Requires --verbose to see both
-            the structured output and the thinking blocks together.
+            agent's step-by-step reasoning per attempt. Combine with --verbose to see
+            structured output alongside thinking blocks.
 --debug     Show debug-level diagnostic output
 --no-pr     Skip PR creation (create branch and commits only)
 ```

--- a/README.md
+++ b/README.md
@@ -359,19 +359,46 @@ Configuration not found — run 'spiny-orb init' to create spiny-orb.yaml
 --dry-run   Preview changes without writing
 --output    Output format: text (default) or json
 --yes       Skip cost ceiling confirmation
---verbose   Show additional diagnostic output
+--verbose   Show structured per-file output: status, token count, validation failures,
+            schema extensions, and agent notes. Use this when a file fails and you want
+            to understand why.
+--thinking  Show agent thinking blocks for failed files. Thinking blocks contain the
+            agent's step-by-step reasoning per attempt. Requires --verbose to see both
+            the structured output and the thinking blocks together.
 --debug     Show debug-level diagnostic output
 --no-pr     Skip PR creation (create branch and commits only)
 ```
 
-The `--verbose` flag shows the config file path being loaded:
+**Flag combinations:**
+
+| Flags | Per-file output | Thinking blocks (failed files only) |
+|-------|----------------|--------------------------------------|
+| _(none)_ | Compact one-liner | No |
+| `--verbose` | Structured multi-line | No |
+| `--thinking` | Compact one-liner | Yes |
+| `--verbose --thinking` | Structured multi-line | Yes |
+
+The `--verbose` flag expands each file's output into a structured block:
 
 ```text
 $ spiny-orb instrument src/ --verbose --yes
-Loading config from /path/to/your-project/spiny-orb.yaml
-Config loaded from /path/to/your-project/spiny-orb.yaml
-Processing file 1 of 1: src/order-service.js
-...
+Processing file 1 of 4: src/api-client.js
+  ✅ SUCCESS — 3 spans, 2 attributes
+  Tokens: 8.4K output
+
+  Schema extensions
+  ────────────────────────────────────────────────────────────
+  • span.myapp.api.fetch_user
+  • span.myapp.api.fetch_orders
+
+  Agent notes
+  ────────────────────────────────────────────────────────────
+
+  • fetchUser and fetchOrders are exported async functions — each receives its own span
+    per COV-004 (Async Operation Spans). formatResponse is a pure sync helper and is
+    skipped per RST-001 (No Utility Spans).
+
+  Report: src/api-client.instrumentation.md
 ```
 
 The `--debug` flag shows the full resolved configuration as JSON:

--- a/docs/interpreting-output.md
+++ b/docs/interpreting-output.md
@@ -41,20 +41,91 @@ The status line for each file shows:
 
 ### Verbose output (`--verbose`)
 
-Verbose mode adds per-function details, schema extensions, and agent reasoning notes below each file's status line:
+`--verbose` expands each file's output into a structured block. Default (non-verbose) mode shows a compact one-liner per file; verbose mode replaces that with:
+
+- A prominent status line with span count and attributes
+- Token usage for that file
+- Full validation failure messages (for failed files)
+- Schema extensions as a bulleted list
+- Agent notes explaining non-obvious instrumentation decisions
+- Path to the companion instrumentation report
 
 ```text
-  src/api-client.js: success (3 spans, 5.2K output tokens)
-    fetchUser: instrumented (1 spans)
-    fetchOrders: instrumented (2 spans)
-    formatResponse: skipped — sync utility
-    Extensions: span.myapp.api.fetch_user, span.myapp.api.fetch_orders
-    Note: Added context propagation for outgoing HTTP calls
-    Note: formatResponse skipped per RST-001 (No Utility Spans) — pure sync function
-    Note: Using @opentelemetry/instrumentation-http for fetch calls
+Processing file 1 of 4: src/api-client.js
+  ✅ SUCCESS — 1 span, 0 attributes
+  Tokens: 30.1K output
+
+  Schema extensions
+  ────────────────────────────────────────────────────────────
+  • span.myapp.context.collect_messages
+
+  Agent notes
+  ────────────────────────────────────────────────────────────
+
+  • Six synchronous helper functions (parseResponse, formatHeaders, buildUrl,
+    validateId, encodeParam, decodeResult) are pure sync operations with no async
+    I/O. They were skipped per RST-001 (No Utility Spans). Their execution is
+    covered by the parent span via context propagation.
+
+  • commit_story.context.source is used directly — no new attribute keys were
+    invented.
+
+  Report: src/api-client.instrumentation.md
 ```
 
-All agent notes are shown in verbose mode — no truncation.
+For a failed file, verbose mode also shows the full validation failure messages:
+
+```text
+Processing file 3 of 4: src/payment.js
+  ❌ FAILED — NDS-005 (Code Pattern Preserved) after 3 attempts
+  Tokens: 12.3K output
+
+  Validation failures (last attempt)
+  ────────────────────────────────────────────────────────────
+  • NDS-005b: Block at lines 47-52 was modified. Original block:
+      } catch (err) {
+        logger.error(err);
+      }
+    Received block:
+      } catch (err) {
+        span.recordException(err);
+        logger.error(err);
+      }
+```
+
+### Thinking blocks (`--thinking`)
+
+`--thinking` shows the agent's step-by-step reasoning for every attempt on **failed files**. Use it when a file fails repeatedly and you need to understand whether the agent is misreading the code, misapplying a rule, or oscillating between contradictory fixes.
+
+Thinking blocks are shown for failed files only — successful files produce no thinking output regardless of this flag.
+
+```text
+Processing file 3 of 4: src/payment.js
+  src/payment.js: failed (NDS-005 (Code Pattern Preserved) after 3 attempts)
+
+  Agent thinking
+  ────────────────────────────────────────────────────────────
+  Attempt 1
+    I need to add error recording to the catch block. The rule says to call
+    span.recordException(err) and span.setStatus({ code: SpanStatusCode.ERROR })
+    before rethrowing...
+
+  Attempt 2
+    The validator rejected my previous attempt because I modified the catch block.
+    NDS-005 requires preserving the original catch block exactly. But COV-003
+    requires an error-recording catch...
+```
+
+**Flag combinations and what they produce:**
+
+| Flags | Per-file output | Thinking blocks |
+|-------|----------------|-----------------|
+| _(none)_ | Compact one-liner | No |
+| `--verbose` | Structured multi-line | No |
+| `--thinking` | Compact one-liner | Yes, for failed files |
+| `--verbose --thinking` | Structured multi-line | Yes, for failed files |
+
+Use `--thinking` alone when you want to diagnose a failing file without the full verbose block for every other file. Use `--verbose --thinking` when you want the complete picture for every file alongside reasoning for failures.
 
 ### Recommended refactors
 

--- a/src/languages/typescript/index.ts
+++ b/src/languages/typescript/index.ts
@@ -232,16 +232,42 @@ export class TypeScriptProvider implements LanguageProvider {
 
   preInstrumentationAnalysis(originalCode: string): PreScanResult {
     const functions = findTsFunctions(originalCode);
-    // A file is instrumentable when it has at least one async function.
-    // Pure re-export files, type-only files, and all-sync files have none.
-    const hasInstrumentableFunctions = functions.some(fn => fn.isAsync);
+
+    const entryPointsNeedingSpans: PreScanResult['entryPointsNeedingSpans'] = [];
+    const asyncFunctionsNeedingSpans: PreScanResult['asyncFunctionsNeedingSpans'] = [];
+    const pureSyncFunctions: PreScanResult['pureSyncFunctions'] = [];
+    const unexportedFunctions: PreScanResult['unexportedFunctions'] = [];
+    const entryPointNames = new Set<string>();
+
+    for (const fn of functions) {
+      const isEntryPoint = fn.isAsync && (fn.isExported || fn.name === 'main');
+      if (isEntryPoint) {
+        entryPointNames.add(fn.name);
+        entryPointsNeedingSpans.push({ name: fn.name, startLine: fn.startLine });
+      }
+    }
+
+    for (const fn of functions) {
+      if (entryPointNames.has(fn.name)) continue;
+      if (fn.isAsync) {
+        asyncFunctionsNeedingSpans.push({ name: fn.name, startLine: fn.startLine });
+      } else {
+        pureSyncFunctions.push({ name: fn.name, startLine: fn.startLine });
+        if (!fn.isExported) {
+          unexportedFunctions.push({ name: fn.name, startLine: fn.startLine });
+        }
+      }
+    }
+
+    const hasInstrumentableFunctions = entryPointsNeedingSpans.length > 0 || asyncFunctionsNeedingSpans.length > 0;
+
     return {
       hasInstrumentableFunctions,
-      entryPointsNeedingSpans: [],
+      entryPointsNeedingSpans,
       processExitEntryPoints: [],
-      asyncFunctionsNeedingSpans: [],
-      pureSyncFunctions: [],
-      unexportedFunctions: [],
+      asyncFunctionsNeedingSpans,
+      pureSyncFunctions,
+      unexportedFunctions,
       outboundCallsNeedingSpans: [],
       entryPointSubOperations: [],
       alreadyInstrumentedImports: [],

--- a/src/languages/typescript/index.ts
+++ b/src/languages/typescript/index.ts
@@ -237,18 +237,18 @@ export class TypeScriptProvider implements LanguageProvider {
     const asyncFunctionsNeedingSpans: PreScanResult['asyncFunctionsNeedingSpans'] = [];
     const pureSyncFunctions: PreScanResult['pureSyncFunctions'] = [];
     const unexportedFunctions: PreScanResult['unexportedFunctions'] = [];
-    const entryPointNames = new Set<string>();
+    const entryPointStartLines = new Set<number>();
 
     for (const fn of functions) {
       const isEntryPoint = fn.isAsync && (fn.isExported || fn.name === 'main');
       if (isEntryPoint) {
-        entryPointNames.add(fn.name);
+        entryPointStartLines.add(fn.startLine);
         entryPointsNeedingSpans.push({ name: fn.name, startLine: fn.startLine });
       }
     }
 
     for (const fn of functions) {
-      if (entryPointNames.has(fn.name)) continue;
+      if (entryPointStartLines.has(fn.startLine)) continue;
       if (fn.isAsync) {
         asyncFunctionsNeedingSpans.push({ name: fn.name, startLine: fn.startLine });
       } else {

--- a/src/languages/typescript/index.ts
+++ b/src/languages/typescript/index.ts
@@ -13,6 +13,7 @@ import type {
   LanguagePromptSections,
   Example,
   InstrumentationDetectionResult,
+  PreScanResult,
 } from '../types.ts';
 import type { CheckResult } from '../../validation/types.ts';
 import type { FunctionResult } from '../../fix-loop/types.ts';
@@ -225,6 +226,26 @@ export class TypeScriptProvider implements LanguageProvider {
       }
       throw error;
     }
+  }
+
+  // ── Pre-instrumentation analysis ──────────────────────────────────────────
+
+  preInstrumentationAnalysis(originalCode: string): PreScanResult {
+    const functions = findTsFunctions(originalCode);
+    // A file is instrumentable when it has at least one async function.
+    // Pure re-export files, type-only files, and all-sync files have none.
+    const hasInstrumentableFunctions = functions.some(fn => fn.isAsync);
+    return {
+      hasInstrumentableFunctions,
+      entryPointsNeedingSpans: [],
+      processExitEntryPoints: [],
+      asyncFunctionsNeedingSpans: [],
+      pureSyncFunctions: [],
+      unexportedFunctions: [],
+      outboundCallsNeedingSpans: [],
+      entryPointSubOperations: [],
+      alreadyInstrumentedImports: [],
+    };
   }
 
   // ── Feature parity check ──────────────────────────────────────────────────

--- a/test/agent/instrument-file.test.ts
+++ b/test/agent/instrument-file.test.ts
@@ -487,7 +487,7 @@ export async function handleRequest(req: Request, res: Response): Promise<void> 
   });
 }
 
-async function processData(data: string[]): Promise<string[]> {
+function processData(data: string[]): string[] {
   return data.map(item => item.trim());
 }`;
 

--- a/test/languages/typescript/pre-instrumentation.test.ts
+++ b/test/languages/typescript/pre-instrumentation.test.ts
@@ -115,4 +115,59 @@ export function add(a: number, b: number): number {
       expect(result.hasInstrumentableFunctions).toBe(false);
     });
   });
+
+  describe('semantic array population', () => {
+    it('populates entryPointsNeedingSpans for exported async functions', () => {
+      const source = `
+export async function handleRequest(req: Request): Promise<Response> {
+  return await process(req);
+}
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.entryPointsNeedingSpans).toHaveLength(1);
+      expect(result.entryPointsNeedingSpans[0].name).toBe('handleRequest');
+    });
+
+    it('populates asyncFunctionsNeedingSpans for unexported async functions', () => {
+      const source = `
+async function internalFetch(url: string): Promise<string> {
+  return await fetch(url).then(r => r.text());
+}
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.asyncFunctionsNeedingSpans).toHaveLength(1);
+      expect(result.asyncFunctionsNeedingSpans[0].name).toBe('internalFetch');
+      expect(result.entryPointsNeedingSpans).toHaveLength(0);
+    });
+
+    it('populates pureSyncFunctions for synchronous functions', () => {
+      const source = `
+export function formatDate(d: Date): string {
+  return d.toISOString();
+}
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.pureSyncFunctions).toHaveLength(1);
+      expect(result.pureSyncFunctions[0].name).toBe('formatDate');
+    });
+
+    it('populates unexportedFunctions for unexported sync functions', () => {
+      const source = `
+function helper(x: number): number {
+  return x * 2;
+}
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.unexportedFunctions).toHaveLength(1);
+      expect(result.unexportedFunctions[0].name).toBe('helper');
+    });
+  });
 });

--- a/test/languages/typescript/pre-instrumentation.test.ts
+++ b/test/languages/typescript/pre-instrumentation.test.ts
@@ -1,0 +1,118 @@
+// ABOUTME: Tests for TypeScriptProvider.preInstrumentationAnalysis() — deterministic pre-scan.
+// ABOUTME: Covers pure re-export detection and hasInstrumentableFunctions early-exit.
+
+import { describe, it, expect } from 'vitest';
+import { TypeScriptProvider } from '../../../src/languages/typescript/index.ts';
+
+describe('TypeScriptProvider.preInstrumentationAnalysis()', () => {
+  const provider = new TypeScriptProvider();
+
+  it('exposes preInstrumentationAnalysis as a callable method', () => {
+    // The method is optional on the LanguageProvider interface — callers must check existence.
+    // This test confirms TypeScriptProvider implements it.
+    expect(typeof provider.preInstrumentationAnalysis).toBe('function');
+  });
+
+  describe('pure re-export detection', () => {
+    it('returns hasInstrumentableFunctions=false for a named re-export file', () => {
+      const source = `export { foo, bar } from './foo.js';`;
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(false);
+    });
+
+    it('returns hasInstrumentableFunctions=false for a namespace re-export file', () => {
+      const source = `export * from './utils.js';`;
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(false);
+    });
+
+    it('returns hasInstrumentableFunctions=false for a file with only imports and re-exports', () => {
+      const source = `
+import { foo } from './foo.js';
+export { foo };
+export { bar } from './bar.js';
+export * from './baz.js';
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(false);
+    });
+
+    it('returns hasInstrumentableFunctions=false for a type-only re-export file', () => {
+      const source = `
+export type { Foo } from './foo.js';
+export type { Bar } from './bar.js';
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(false);
+    });
+
+    it('returns hasInstrumentableFunctions=true when the file mixes re-exports with a local async function', () => {
+      const source = `
+export { helper } from './helper.js';
+
+export async function process(item: string): Promise<void> {
+  await doWork(item);
+}
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(true);
+    });
+
+    it('returns hasInstrumentableFunctions=false for an empty file', () => {
+      const result = provider.preInstrumentationAnalysis!('');
+
+      expect(result.hasInstrumentableFunctions).toBe(false);
+    });
+
+    it('returns hasInstrumentableFunctions=false for a file with only type declarations', () => {
+      const source = `
+export interface Foo { bar: string; }
+export type Baz = string | number;
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(false);
+    });
+  });
+
+  describe('hasInstrumentableFunctions: async functions', () => {
+    it('returns hasInstrumentableFunctions=true for an exported async function', () => {
+      const source = `
+export async function fetchData(id: string): Promise<Data> {
+  return await db.query(id);
+}
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(true);
+    });
+
+    it('returns hasInstrumentableFunctions=false for a file with only sync functions', () => {
+      const source = `
+export function formatName(first: string, last: string): string {
+  return \`\${first} \${last}\`;
+}
+
+export function add(a: number, b: number): number {
+  return a + b;
+}
+`.trim();
+
+      const result = provider.preInstrumentationAnalysis!(source);
+
+      expect(result.hasInstrumentableFunctions).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **#714**: Adds `preInstrumentationAnalysis` to `TypeScriptProvider`. Pure re-export files, type-only files, and all-sync files now return `hasInstrumentableFunctions=false`, skipping the LLM call entirely — the same gate that already existed in `JavaScriptProvider`. Covers the two taze run-12 files (`src/addons/index.ts`, `src/addons/vscode.ts`) that were correctly skipped but still consumed tokens.
- **#738**: Updates `README.md` and `docs/interpreting-output.md` to document `--thinking`, correct the stale `--verbose` description, and add a flag combination table.

## Changes

**`src/languages/typescript/index.ts`** — adds `preInstrumentationAnalysis` using existing `findTsFunctions` to check for any async function; returns `hasInstrumentableFunctions=false` for files with none.

**`test/languages/typescript/pre-instrumentation.test.ts`** — new test file; 10 tests covering named re-exports, namespace re-exports, type-only files, mixed re-export+async files, empty files, sync-only files, and async files.

**`README.md`** — flags table updated: `--thinking` row added, `--verbose` description expanded to cover structured per-file output, flag combination table added.

**`docs/interpreting-output.md`** — verbose example replaced with accurate format (was stale); `--thinking` subsection added covering what thinking blocks contain, when to use the flag, all four flag combinations.

## Test plan

- [ ] `npm test` passes (2503 tests, 0 failures)
- [ ] `npm run typecheck` passes
- [ ] New pre-scan tests: 10/10 pass
- [ ] Acceptance gate: run with `run-acceptance` label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--thinking` flag for step-by-step agent reasoning on failed files.
  * `--debug` documents printing the resolved configuration during runs.

* **Documentation**
  * Expanded CLI flags docs with detailed `--verbose` structured per-file output, examples, and a flag-combination matrix.
  * Clarified how `--thinking` combines with `--verbose`.

* **Refactor**
  * Improved TypeScript pre-instrumentation analysis to better detect instrumentable functions.

* **Tests**
  * Added comprehensive tests for pre-instrumentation analysis and updated a fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->