### PR TITLE
fix: Weaver HOME propagation + ETIMEDOUT message; P3 dumpDiagnostics (#758, #759)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- (2026-05-04) Fixed `checkWeaverSchema` in `src/config/prerequisites.ts` silently surfacing "unknown error" when Weaver hangs during prerequisite checks. The root cause: launchers like `caffeinate -s` + `vals exec -i` strip `HOME` from subprocess environments, preventing Weaver from finding `~/.weaver/vdir_cache` for dependency caching; Weaver then hangs until `execFileSync`'s 30-second timeout fires as `ETIMEDOUT`. The fix passes `HOME` explicitly in the `execFileSync` env options via `homedir()` fallback. Additionally, the error handling now joins stdout + stderr (Weaver writes failure details to stdout, not stderr) and distinguishes `ETIMEDOUT` with an actionable message directing users to check HOME propagation (#758).
+
+- (2026-05-04) Added `dumpDiagnostics` to every `it()` block in `test/fix-loop/acceptance-gate.test.ts` so future P3 fix-loop failures produce `/tmp/spiny-orb-debug-*.js` artifacts with all five diagnostic dimensions (instrumented code, `lastError`, `errorProgression`, `notes`, `thinkingBlocksByAttempt`). Previously, intermittent failures where `user-routes.js` returned `partial` instead of `success` left no diagnosable artifact because the P3 test bypassed the coordinator's dumpDiagnostics path (#759).
+
 - (2026-05-03) Strengthened attribute namespace enforcement in `src/agent/prompt.ts` to complete the span/attribute parallel that PRD #581 intended (#724). The attribute invention step previously used soft `Derive` language where the span naming section used hard `MUST`/`Do NOT` constraints. Changed to: all invented attribute keys MUST start with the registry namespace prefix; Do NOT derive namespace from URL domains, variable names, or code-local terminology (with explicit counter-example: `store.product.id` from a URL is wrong, `dd.store.product.id` is correct). Also added debug output to Test B in `test/acceptance-gate.test.ts` so CI artifact upload captures agent notes and schema extensions on both pass and fail — Test B previously bypassed the fix-loop's `dumpDiagnostics` path entirely.
 
 ### Added

--- a/src/config/prerequisites.ts
+++ b/src/config/prerequisites.ts
@@ -3,6 +3,7 @@
 
 import { readFile, access } from 'node:fs/promises';
 import { join, resolve, relative, isAbsolute } from 'node:path';
+import { homedir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import type { AgentConfig } from './schema.ts';
 import { resolveSchema } from '../coordinator/dispatch.ts';
@@ -203,16 +204,18 @@ async function checkWeaverSchema(projectRoot: string, schemaPath: string): Promi
     };
   }
 
-  // Run weaver registry check for schema validation
+  // Run weaver registry check for schema validation.
+  // HOME must be explicit so Weaver can locate ~/.weaver/vdir_cache when spiny-orb
+  // is launched through a runner that strips HOME (e.g. caffeinate -s + vals exec -i).
   try {
     execFileSync('weaver', ['registry', 'check', '-r', fullPath], {
       cwd: projectRoot,
       timeout: 30000,
       stdio: 'pipe',
+      env: { ...process.env, HOME: process.env.HOME || homedir() },
     });
   } catch (err: unknown) {
-    // Distinguish between "weaver not installed" and "schema invalid"
-    const error = err as { status?: number; stderr?: Buffer; code?: string };
+    const error = err as { status?: number; stderr?: Buffer; stdout?: Buffer; code?: string };
     if (error.code === 'ENOENT') {
       return {
         id: PREREQUISITE_IDS.WEAVER_SCHEMA,
@@ -220,11 +223,22 @@ async function checkWeaverSchema(projectRoot: string, schemaPath: string): Promi
         message: `Weaver CLI not found. Install it: see https://github.com/open-telemetry/weaver. Schema path exists at ${fullPath} but cannot be validated.`,
       };
     }
-    const stderr = error.stderr ? error.stderr.toString().trim() : 'unknown error';
+    const out = error.stdout?.toString().trim() ?? '';
+    const errOut = error.stderr?.toString().trim() ?? '';
+    const output = [out, errOut].filter(Boolean).join('\n') || (err as Error).message;
+    if (error.code === 'ETIMEDOUT') {
+      return {
+        id: PREREQUISITE_IDS.WEAVER_SCHEMA,
+        passed: false,
+        message: `Weaver timed out validating the schema at ${fullPath} (30s limit). ` +
+          `This usually means Weaver could not find ~/.weaver/vdir_cache to cache a dependency download — ` +
+          `ensure HOME is in the environment when invoking spiny-orb. Weaver output:\n${output}`,
+      };
+    }
     return {
       id: PREREQUISITE_IDS.WEAVER_SCHEMA,
       passed: false,
-      message: `Weaver schema validation failed at ${fullPath}: ${stderr}`,
+      message: `Weaver schema validation failed at ${fullPath}:\n${output}`,
     };
   }
 

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -3,6 +3,7 @@
 
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve, join, basename } from 'node:path';
+import { homedir } from 'node:os';
 import { formatTestOutput } from './test-output.ts';
 import { execFile } from 'node:child_process';
 import type { LanguageProvider } from '../languages/types.ts';
@@ -175,6 +176,7 @@ export async function resolveSchema(projectDir: string, schemaPath: string): Pro
     execFile('weaver', ['registry', 'resolve', '-r', fullSchemaPath, '--format', 'json'], {
       cwd: projectDir,
       timeout: 30000,
+      env: { ...process.env, HOME: process.env.HOME || homedir() },
     }, (error, stdout) => {
       if (error) {
         reject(error);

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -37,7 +37,7 @@ export async function validateRegistryCheck(
       execFile(
         'weaver',
         ['registry', 'check', '-r', registryDir],
-        { timeout: 30000 },
+        { timeout: 30000, env: { ...process.env, HOME: process.env.HOME || homedir() } },
         (error, stdout, stderr) => {
           if (error) {
             const stdoutStr = stdout?.trim() ?? '';

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -40,6 +40,10 @@ export async function validateRegistryCheck(
         { timeout: 30000, env: { ...process.env, HOME: process.env.HOME || homedir() } },
         (error, stdout, stderr) => {
           if (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
+              resolve({ passed: false, error: 'weaver registry check timed out (30s limit). Ensure HOME is propagated to the subprocess so Weaver can access ~/.weaver/vdir_cache for dependency caching.' });
+              return;
+            }
             const stdoutStr = stdout?.trim() ?? '';
             const stderrStr = stderr?.trim() ?? '';
             const cliOutput = [stdoutStr, stderrStr].filter(Boolean).join('\n') || error.message;
@@ -177,9 +181,15 @@ export async function resolveSchema(projectDir: string, schemaPath: string): Pro
       cwd: projectDir,
       timeout: 30000,
       env: { ...process.env, HOME: process.env.HOME || homedir() },
-    }, (error, stdout) => {
+    }, (error, stdout, stderr) => {
       if (error) {
-        reject(error);
+        if ((error as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
+          reject(new Error('weaver registry resolve timed out (30s limit). Ensure HOME is propagated to the subprocess so Weaver can access ~/.weaver/vdir_cache for dependency caching.'));
+          return;
+        }
+        const stdoutStr = stdout?.toString().trim() ?? '';
+        const stderrStr = stderr?.toString().trim() ?? '';
+        reject(new Error([stdoutStr, stderrStr].filter(Boolean).join('\n') || error.message));
         return;
       }
       try {

--- a/src/interfaces/init-handler.ts
+++ b/src/interfaces/init-handler.ts
@@ -254,9 +254,11 @@ async function handleInit(options: InitOptions, deps: InitDeps): Promise<InitRes
       env: { ...process.env, HOME: process.env.HOME || homedir() },
     });
   } catch (err: unknown) {
-    const error = err as { stderr?: Buffer };
-    const stderr = error.stderr ? error.stderr.toString().trim() : 'unknown error';
-    errors.push(`Weaver schema validation failed at ${schemaPath}: ${stderr}`);
+    const error = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
+    const out = error.stdout?.toString().trim() ?? '';
+    const errOut = error.stderr?.toString().trim() ?? '';
+    const cliOutput = [out, errOut].filter(Boolean).join('\n') || error.message || 'unknown error';
+    errors.push(`Weaver schema validation failed at ${schemaPath}: ${cliOutput}`);
     return { success: false, errors, warnings };
   }
 

--- a/src/interfaces/init-handler.ts
+++ b/src/interfaces/init-handler.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Checks prerequisites, detects project type, and creates spiny-orb.yaml config file.
 
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { stringify as stringifyYaml } from 'yaml';
 import { DEFAULT_GRPC_PORT, DEFAULT_ADMIN_PORT } from '../coordinator/live-check.ts';
 
@@ -179,6 +180,7 @@ async function handleInit(options: InitOptions, deps: InitDeps): Promise<InitRes
     const versionOutput = deps.execFileSync('weaver', ['--version'], {
       timeout: 10000,
       stdio: 'pipe',
+      env: { ...process.env, HOME: process.env.HOME || homedir() },
     });
     const versionString = versionOutput.toString().trim();
     const versionMatch = versionString.match(/(\d+\.\d+\.\d+)/);
@@ -249,6 +251,7 @@ async function handleInit(options: InitOptions, deps: InitDeps): Promise<InitRes
       cwd: projectDir,
       timeout: 30000,
       stdio: 'pipe',
+      env: { ...process.env, HOME: process.env.HOME || homedir() },
     });
   } catch (err: unknown) {
     const error = err as { stderr?: Buffer };

--- a/src/validation/tier1/weaver.ts
+++ b/src/validation/tier1/weaver.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Runs weaver registry check and passes raw CLI output as diagnostic message.
 
 import { execFileSync } from 'node:child_process';
+import { homedir } from 'node:os';
 import type { CheckResult } from '../types.ts';
 
 /**
@@ -35,6 +36,7 @@ export function checkWeaver(filePath: string, registryPath: string | undefined):
     execFileSync('weaver', ['registry', 'check', '-r', registryPath], {
       timeout: 30_000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, HOME: process.env.HOME || homedir() },
     });
 
     return {

--- a/src/validation/tier1/weaver.ts
+++ b/src/validation/tier1/weaver.ts
@@ -52,10 +52,14 @@ export function checkWeaver(filePath: string, registryPath: string | undefined):
     // Extract CLI output for the diagnostic message
     let cliOutput = '';
     if (error !== null && typeof error === 'object') {
-      const execError = error as { stdout?: Buffer; stderr?: Buffer; message?: string };
+      const execError = error as { code?: string; stdout?: Buffer; stderr?: Buffer; message?: string };
       const stdout = execError.stdout?.toString().trim() ?? '';
       const stderr = execError.stderr?.toString().trim() ?? '';
-      cliOutput = [stdout, stderr].filter(Boolean).join('\n') || execError.message || String(error);
+      if (execError.code === 'ETIMEDOUT') {
+        cliOutput = 'weaver registry check timed out (30s limit). Ensure HOME is propagated to the subprocess so Weaver can access ~/.weaver/vdir_cache for dependency caching.';
+      } else {
+        cliOutput = [stdout, stderr].filter(Boolean).join('\n') || execError.message || String(error);
+      }
     } else {
       cliOutput = String(error);
     }

--- a/test/config/prerequisites.test.ts
+++ b/test/config/prerequisites.test.ts
@@ -1,10 +1,16 @@
 // ABOUTME: Unit tests for prerequisite checks before instrumentation.
 // ABOUTME: Covers package.json, OTel API dependency, SDK init file, Weaver schema, and API key checks.
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, mkdirSync, rmSync, cpSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, execFileSync: vi.fn(actual.execFileSync) };
+});
 import {
   checkPackageJson,
   checkOtelApiDependency,
@@ -224,6 +230,23 @@ describe('checkWeaverSchema', () => {
     } finally {
       process.env.PATH = originalPath;
     }
+  });
+
+  it('returns actionable HOME hint when weaver subprocess times out (ETIMEDOUT)', async () => {
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
+      const err = new Error('spawnSync weaver ETIMEDOUT');
+      (err as NodeJS.ErrnoException).code = 'ETIMEDOUT';
+      throw err;
+    });
+
+    mkdirSync(join(testDir, 'telemetry', 'registry'), { recursive: true });
+
+    const result = await checkWeaverSchema(testDir, './telemetry/registry');
+
+    expect(result.passed).toBe(false);
+    expect(result.id).toBe('WEAVER_SCHEMA');
+    expect(result.message).toContain('timed out');
+    expect(result.message).toContain('HOME');
   });
 
   describe('empty schema gate', () => {

--- a/test/config/prerequisites.test.ts
+++ b/test/config/prerequisites.test.ts
@@ -247,6 +247,11 @@ describe('checkWeaverSchema', () => {
     expect(result.id).toBe('WEAVER_SCHEMA');
     expect(result.message).toContain('timed out');
     expect(result.message).toContain('HOME');
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'weaver',
+      ['registry', 'check', '-r', expect.any(String)],
+      expect.objectContaining({ env: expect.objectContaining({ HOME: expect.any(String) }) }),
+    );
   });
 
   describe('empty schema gate', () => {

--- a/test/fix-loop/acceptance-gate.test.ts
+++ b/test/fix-loop/acceptance-gate.test.ts
@@ -74,6 +74,54 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
     return { filePath, originalCode };
   }
 
+  /**
+   * Write diagnostic artifacts for a FileResult to /tmp for post-failure analysis.
+   * Five diagnostic dimensions (per CLAUDE.md):
+   *   1. History — git log in CI
+   *   2. Instrumented code — written to /tmp/spiny-orb-debug-{label}
+   *   3. Validator error messages — result.lastError and result.lastErrorByAttempt
+   *   4. Agent notes — result.notes
+   *   5. Agent thinking — result.thinkingBlocksByAttempt (all attempts)
+   */
+  function dumpDiagnostics(label: string, result: FileResult): void {
+    const safeLabel = label.replace(/[^a-zA-Z0-9._-]/g, '_');
+    const debugFilePath = join(tmpdir(), `spiny-orb-debug-${safeLabel}`);
+    const codeToCapture = result.lastInstrumentedCode ??
+      (existsSync(result.path) ? readFileSync(result.path, 'utf-8') : undefined);
+    if (codeToCapture) {
+      try {
+        writeFileSync(debugFilePath, codeToCapture, 'utf-8');
+        console.log(`[${label} instrumented file] ${debugFilePath}`);
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    if (result.thinkingBlocksByAttempt) {
+      result.thinkingBlocksByAttempt.forEach((blocks, idx) => {
+        if (blocks.length > 0) {
+          const text = blocks.join('\n\n');
+          const preview = text.length > 2000
+            ? `${text.slice(0, 2000)}\n[... truncated at 2000 chars; full thinking in result.thinkingBlocksByAttempt[${idx}]]`
+            : text;
+          console.log(`[${label} thinking attempt ${idx + 1}]`, preview);
+        }
+      });
+    }
+
+    console.log(`[${label} diagnostics]`, JSON.stringify({
+      status: result.status,
+      reason: result.reason,
+      spansAdded: result.spansAdded,
+      validationAttempts: result.validationAttempts,
+      errorProgression: result.errorProgression,
+      lastError: result.lastError,
+      lastErrorByAttempt: result.lastErrorByAttempt,
+      notes: result.notes,
+      tokenUsage: result.tokenUsage,
+    }, null, 2));
+  }
+
   describe('successful instrumentation through fix loop', () => {
     it('instruments user-routes.js and produces a fully populated FileResult', { timeout: 1_200_000 }, async () => {
       const { filePath, originalCode } = setupTempFile('src/user-routes.js');
@@ -82,6 +130,7 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
       const result: FileResult = await instrumentWithRetry(
         filePath, originalCode, resolvedSchema, config, { provider: jsProvider },
       );
+      dumpDiagnostics('user-routes.js', result);
 
       // The fix loop should eventually succeed (possibly after retries)
       expect(result.status).toBe('success');
@@ -126,6 +175,7 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
       const result: FileResult = await instrumentWithRetry(
         filePath, originalCode, resolvedSchema, config, { provider: jsProvider },
       );
+      dumpDiagnostics('order-service.js', result);
 
       expect(result.status).toBe('success');
       expect(result.validationAttempts).toBeGreaterThanOrEqual(1);
@@ -146,6 +196,7 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
       const result: FileResult = await instrumentWithRetry(
         filePath, originalCode, resolvedSchema, config, { provider: jsProvider },
       );
+      dumpDiagnostics('user-routes.js-budget', result);
 
       // Should fail due to budget (pre-flight estimate or post-hoc check)
       expect(result.status).toBe('failed');
@@ -180,6 +231,7 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
       const result: FileResult = await instrumentWithRetry(
         filePath, originalCode, resolvedSchema, config, { provider: jsProvider },
       );
+      dumpDiagnostics('user-routes.js-exhaustion', result);
 
       // Whether success or failure, verify the contract:
       if (result.status === 'failed') {
@@ -221,6 +273,7 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
       const result: FileResult = await instrumentWithRetry(
         filePath, originalCode, resolvedSchema, config, { provider: jsProvider },
       );
+      dumpDiagnostics('user-routes.js-strategy', result);
 
       // The strategy must match the attempt number
       if (result.validationAttempts === 1) {
@@ -249,6 +302,7 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
       const result: FileResult = await instrumentWithRetry(
         filePath, originalCode, resolvedSchema, config, { provider: jsProvider },
       );
+      dumpDiagnostics('format-helpers.js', result);
 
       // Whether success or failure, the snapshot file should be cleaned up.
       // We can't directly check tmpdir for our specific snapshot, but we verify

--- a/test/fix-loop/acceptance-gate.test.ts
+++ b/test/fix-loop/acceptance-gate.test.ts
@@ -85,7 +85,8 @@ describe.skipIf(!API_KEY_AVAILABLE)('Acceptance Gate — Phase 3 Fix Loop', () =
    */
   function dumpDiagnostics(label: string, result: FileResult): void {
     const safeLabel = label.replace(/[^a-zA-Z0-9._-]/g, '_');
-    const debugFilePath = join(tmpdir(), `spiny-orb-debug-${safeLabel}`);
+    const fileLabel = safeLabel.endsWith('.js') ? safeLabel : `${safeLabel}.js`;
+    const debugFilePath = join(tmpdir(), `spiny-orb-debug-${fileLabel}`);
     const codeToCapture = result.lastInstrumentedCode ??
       (existsSync(result.path) ? readFileSync(result.path, 'utf-8') : undefined);
     if (codeToCapture) {


### PR DESCRIPTION
## Summary

- **#758**: `checkWeaverSchema` now passes `HOME` explicitly to the Weaver subprocess so `~/.weaver/vdir_cache` is reachable when launchers like `caffeinate -s` + `vals exec -i` strip environment variables. Error handling joins stdout + stderr (Weaver writes failure details to stdout, not stderr) and distinguishes `ETIMEDOUT` with an actionable message directing users to check HOME propagation.
- **#759**: Added `dumpDiagnostics` to every `it()` block in `test/fix-loop/acceptance-gate.test.ts`. Future P3 failures where `user-routes.js` returns `partial` instead of `success` will now produce `/tmp/spiny-orb-debug-*.js` artifacts with `lastError`, `errorProgression`, `notes`, and `thinkingBlocksByAttempt` for root-cause analysis.

## Changes

- `src/config/prerequisites.ts` — add `homedir` import; pass `HOME` in `execFileSync` env; join stdout+stderr; handle `ETIMEDOUT` with specific message
- `test/config/prerequisites.test.ts` — add `vi.mock('node:child_process')` with pass-through default; add ETIMEDOUT unit test (red → green via TDD)
- `test/fix-loop/acceptance-gate.test.ts` — add `dumpDiagnostics` function and call it after each `instrumentWithRetry` invocation
- `~/.claude/rules/weaver-gotchas.md` — note that `ETIMEDOUT` is the signal when HOME is missing

## Test plan

- [ ] All 2529 unit tests pass (`npm test`)
- [ ] Typecheck clean (`npm run typecheck`)
- [ ] ETIMEDOUT unit test was red before the fix, green after
- [ ] Acceptance gate CI triggered by `run-acceptance` label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema validation error reporting to avoid silent hangs, added specific timeout messaging, and ensured external CLI calls run with a valid HOME environment to prevent cache-related failures.

* **Tests**
  * Added tests simulating timeout scenarios and verifying HOME behavior.
  * Emit diagnostic artifacts during acceptance tests for richer debug output on failures.

* **Documentation**
  * Updated progress log with the above fixes and test enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->