### PR TITLE
feat(#722): route wrong-namespace extension feedback into fix loop

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- (2026-05-06) Wired fix-loop feedback for wrong-namespace schema extensions (issue #722). When the agent declares schema extensions whose namespace prefix doesn't match the registry manifest's `name` field, the fix loop now detects this inside `instrumentWithRetry` and routes to a fresh-regeneration retry with a targeted failure hint ("namespace must be X but got Y"). Previously, wrong-namespace extensions were silently dropped by `writeSchemaExtensions` after the fix loop had already exited — the agent had no opportunity to correct them. The fix: `dispatch.ts` extracts the registry namespace prefix once via `extractNamespacePrefix` and passes it as `expectedNamespacePrefix` to each `instrumentWithRetry` call; `executeRetryLoop` checks each declared extension against the prefix after validation passes, and jumps to fresh-regeneration if any fail. The Test B annotation in `test/acceptance-gate.test.ts` was updated to reflect the resolved issue.
+
 ### Fixed
 
 - (2026-05-06) Fixed NDS-003 false positive on optional chaining property access guards (issue #784). The truthy property-access guard pattern in `src/languages/javascript/rules/nds003.ts` matched `if (req.route.path) {` but rejected `if (req.route?.path) {` because the `?.` operator wasn't allowed in the regex. When the agent adds this guard to safely capture the `http.route` attribute from an Express request object, NDS-003 fired and the agent retreated from instrumenting the function entirely. The pattern now allows optional chaining with `(?:(?:\??\.)\w+)+`.

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -20,7 +20,7 @@ import {
   snapshotExtensionsFile as defaultSnapshotExtensionsFile,
   restoreExtensionsFile as defaultRestoreExtensionsFile,
   parseExtension,
-  extractNamespacePrefix,
+  tryExtractNamespacePrefix,
 } from './schema-extensions.ts';
 
 /**
@@ -317,12 +317,12 @@ export async function dispatchFiles(
 
   // Extract registry namespace prefix once — passed to each instrumentFn call so wrong-namespace
   // extensions are caught inside the fix loop rather than silently dropped by writeSchemaExtensions.
-  let registryNamespacePrefix: string | undefined;
-  if (registryDir) {
-    try {
-      registryNamespacePrefix = await extractNamespacePrefix(registryDir);
-    } catch { /* non-fatal — namespace enforcement falls back to post-write rejection */ }
-  }
+  // tryExtractNamespacePrefix returns undefined when the manifest is absent (ENOENT, registry not
+  // yet created), and throws on malformed manifest or permission errors so those aren't silently
+  // swallowed.
+  const registryNamespacePrefix = registryDir
+    ? await tryExtractNamespacePrefix(registryDir)
+    : undefined;
 
   // Take initial checkpoint window snapshot for rollback capability
   if (registryDir && !isDryRun && options.runTestCommand) {

--- a/src/coordinator/dispatch.ts
+++ b/src/coordinator/dispatch.ts
@@ -20,6 +20,7 @@ import {
   snapshotExtensionsFile as defaultSnapshotExtensionsFile,
   restoreExtensionsFile as defaultRestoreExtensionsFile,
   parseExtension,
+  extractNamespacePrefix,
 } from './schema-extensions.ts';
 
 /**
@@ -314,6 +315,15 @@ export async function dispatchFiles(
     projectName = rawProjectName.trim();
   }
 
+  // Extract registry namespace prefix once — passed to each instrumentFn call so wrong-namespace
+  // extensions are caught inside the fix loop rather than silently dropped by writeSchemaExtensions.
+  let registryNamespacePrefix: string | undefined;
+  if (registryDir) {
+    try {
+      registryNamespacePrefix = await extractNamespacePrefix(registryDir);
+    } catch { /* non-fatal — namespace enforcement falls back to post-write rejection */ }
+  }
+
   // Take initial checkpoint window snapshot for rollback capability
   if (registryDir && !isDryRun && options.runTestCommand) {
     try {
@@ -380,7 +390,7 @@ export async function dispatchFiles(
       const existingSpanNames = accumulatedExtensions
         .filter(ext => ext.startsWith('span.'))
         .map(ext => ext.slice(5));
-      const result = await instrumentFn(filePath, fileContent, schema, config, { projectRoot: projectDir, existingSpanNames, provider, processedFilesManifest, canonicalTracerName: options.canonicalTracerName });
+      const result = await instrumentFn(filePath, fileContent, schema, config, { projectRoot: projectDir, existingSpanNames, provider, processedFilesManifest, canonicalTracerName: options.canonicalTracerName, expectedNamespacePrefix: registryNamespacePrefix });
       result.schemaHashBefore = schemaHash;
       result.schemaHashAfter = schemaHash;
       results.push(result);

--- a/src/coordinator/schema-extensions.ts
+++ b/src/coordinator/schema-extensions.ts
@@ -77,6 +77,34 @@ export async function extractNamespacePrefix(registryDir: string): Promise<strin
 }
 
 /**
+ * Like extractNamespacePrefix but returns undefined when registry_manifest.yaml does not
+ * exist yet (ENOENT) instead of throwing. Propagates all other errors (malformed manifest,
+ * permission errors) so callers can distinguish "not created yet" from "misconfigured".
+ *
+ * @param registryDir - Absolute path to the Weaver registry directory
+ * @returns The namespace prefix, or undefined if the manifest is absent
+ * @throws When the manifest exists but has no valid `name` field, or on permission errors
+ */
+export async function tryExtractNamespacePrefix(registryDir: string): Promise<string | undefined> {
+  const manifestPath = join(registryDir, 'registry_manifest.yaml');
+  let content: string;
+  try {
+    content = await readFile(manifestPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw err;
+  }
+  const manifest = parse(content) as Record<string, unknown>;
+  if (typeof manifest?.name !== 'string' || manifest.name.length === 0) {
+    throw new Error(
+      `registry_manifest.yaml at ${manifestPath} is missing a "name" field — ` +
+      'the name field defines the project namespace prefix for schema extensions.',
+    );
+  }
+  return manifest.name;
+}
+
+/**
  * Parse a schema extension YAML string into a structured attribute object.
  * Each extension string is expected to be a YAML list item (with leading "- ").
  *

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -842,6 +842,25 @@ async function executeRetryLoop(
           });
 
           if (advisoryValidation.passed) {
+            // Re-check namespace on the advisory output before accepting it.
+            // The advisory pass may add new startActiveSpan() calls with wrong-namespace
+            // span names that weren't present in the pre-advisory output.
+            if (expectedNamespacePrefix) {
+              const advisoryAll = supplementSchemaExtensions(advisoryOutput.schemaExtensions, advisoryCode);
+              const advisoryWrong = advisoryAll.filter((ext) => {
+                const pre = ext.startsWith('span:') ? ext.slice('span:'.length) : ext;
+                const checkPart = pre.startsWith('span.') ? pre.slice('span.'.length) : pre;
+                return !checkPart.startsWith(`${expectedNamespacePrefix}.`);
+              });
+              if (advisoryWrong.length > 0) {
+                // Advisory output has wrong-namespace extensions — revert and use pre-advisory result
+                await writeFile(filePath, passingCode, 'utf-8');
+                return buildSuccessResult(
+                  validation.advisoryFindings.length > 0 ? validation.advisoryFindings : undefined,
+                  cumulativeTokens,
+                );
+              }
+            }
             return buildSuccessResult(
               advisoryValidation.advisoryFindings.length > 0 ? advisoryValidation.advisoryFindings : undefined,
               cumulativeTokens,

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -87,6 +87,15 @@ interface InstrumentWithRetryOptions {
    * Required — callers must supply a provider explicitly.
    */
   provider: LanguageProvider;
+  /**
+   * Expected namespace prefix for schema extensions (e.g. "commit_story").
+   * When set, extensions whose ID does not start with "<prefix>." are treated as
+   * a blocking failure and fed back into the retry loop — consistent with how other
+   * validation failures work. Without this option, no namespace check is performed.
+   *
+   * Populated by the coordinator from the registry manifest's `name` field.
+   */
+  expectedNamespacePrefix?: string;
 }
 
 const ZERO_TOKENS: TokenUsage = {
@@ -417,6 +426,7 @@ export async function instrumentWithRetry(
       options.existingSpanNames,
       options.processedFilesManifest,
       options.canonicalTracerName,
+      options.expectedNamespacePrefix,
     );
   } catch (error) {
     // Unexpected error — restore original content from memory.
@@ -469,6 +479,7 @@ async function executeRetryLoop(
   existingSpanNames?: string[],
   processedFilesManifest?: Map<string, string[]>,
   canonicalTracerName?: string,
+  expectedNamespacePrefix?: string,
 ): Promise<FileResult> {
   const maxAttempts = 1 + config.maxFixAttempts;
   const validationConfig = buildValidationConfig(config, projectRoot, resolvedSchema, anthropicClient, canonicalTracerName);
@@ -682,6 +693,59 @@ async function executeRetryLoop(
       validation.blockingFailures.filter(f => f.ruleId === 'NDS-003'),
     );
     llmRefactorsPerAttempt.push(output.suggestedRefactors ?? []);
+
+    // Namespace prefix check: extensions must start with the expected prefix.
+    // Runs only when validation.passed (no point checking if there are blocking errors).
+    // A wrong-namespace extension is treated as a blocking failure and fed back into
+    // the next retry attempt — consistent with how other validation failures work.
+    if (validation.passed && expectedNamespacePrefix && output.schemaExtensions.length > 0) {
+      const wrongNamespace = output.schemaExtensions.filter((ext) => {
+        // Strip "span." prefix before namespace check (span extensions use "span.<prefix>.<name>")
+        const checkPart = ext.startsWith('span.') ? ext.slice('span.'.length) : ext;
+        return !checkPart.startsWith(`${expectedNamespacePrefix}.`);
+      });
+      if (wrongNamespace.length > 0) {
+        const feedback =
+          `Schema extensions rejected: namespace must be "${expectedNamespacePrefix}" but got ${wrongNamespace.join(', ')}. ` +
+          `All extensions must start with "${expectedNamespacePrefix}." ` +
+          `(or "span.${expectedNamespacePrefix}." for span names). ` +
+          `Do not invent attributes with other namespace prefixes.`;
+        errorProgression.push(`${wrongNamespace.length} blocking errors (namespace-rejected: ${wrongNamespace.join(', ')})`);
+        lastErrorByAttempt.push(feedback);
+        nds003ViolationsPerAttempt.push([]);
+        llmRefactorsPerAttempt.push([]);
+        if (attempt < maxAttempts) {
+          // Route through fresh-regeneration so the agent sees the failure hint
+          // in a clean context. Multi-turn fix requires conversation history which
+          // isn't always available; fresh-regen reliably delivers the hint.
+          lastValidation = {
+            passed: false,
+            tier1Results: [],
+            tier2Results: [],
+            blockingFailures: [{
+              ruleId: 'SCH-NS',
+              passed: false,
+              filePath,
+              lineNumber: null,
+              message: feedback,
+              tier: 2,
+              blocking: true,
+            }],
+            advisoryFindings: [],
+          };
+          // Jump to the last attempt (fresh-regeneration) so the next loop
+          // iteration runs as fresh-regen with the namespace failure hint.
+          attempt = maxAttempts - 1;
+          continue;
+        }
+        // Already on last attempt — return failure
+        return buildFailedResult(
+          filePath, feedback, feedback,
+          cumulativeTokens, attempt, actualStrategy, errorProgression, lastOutput,
+          undefined, undefined, thinkingBlocksByAttempt, lastErrorByAttempt,
+        );
+      }
+    }
 
     if (validation.passed) {
       const spansAdded = countSpansInCode(provider, output.instrumentedCode);

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -698,13 +698,18 @@ async function executeRetryLoop(
     // Runs only when validation.passed (no point checking if there are blocking errors).
     // A wrong-namespace extension is treated as a blocking failure and fed back into
     // the next retry attempt — consistent with how other validation failures work.
-    if (validation.passed && expectedNamespacePrefix && output.schemaExtensions.length > 0) {
-      const wrongNamespace = output.schemaExtensions.filter((ext) => {
+    if (validation.passed && expectedNamespacePrefix) {
+      // Check ALL extensions the file will emit — both declared (output.schemaExtensions)
+      // and span names auto-extracted from the instrumented code by supplementSchemaExtensions.
+      // Checking only output.schemaExtensions would miss span names the agent embedded in
+      // startActiveSpan() calls without explicitly declaring them.
+      const allExtensions = supplementSchemaExtensions(output.schemaExtensions, output.instrumentedCode);
+      const wrongNamespace = allExtensions.filter((ext) => {
         // Strip "span." or "span:" prefix before namespace check.
         // normalizeSchemaExtension() converts span: → span. but runs after this check,
         // so handle both forms here.
-        const normalized = ext.startsWith('span:') ? ext.slice('span:'.length) : ext;
-        const checkPart = normalized.startsWith('span.') ? normalized.slice('span.'.length) : normalized;
+        const preNormalized = ext.startsWith('span:') ? ext.slice('span:'.length) : ext;
+        const checkPart = preNormalized.startsWith('span.') ? preNormalized.slice('span.'.length) : preNormalized;
         return !checkPart.startsWith(`${expectedNamespacePrefix}.`);
       });
       if (wrongNamespace.length > 0) {
@@ -736,6 +741,9 @@ async function executeRetryLoop(
             }],
             advisoryFindings: [],
           };
+          // Restore before jumping — if fresh-regen fails before writing its own output,
+          // the file should not be left with the wrong-namespace code.
+          try { await writeFile(filePath, originalCode, 'utf-8'); } catch { /* best-effort */ }
           // Jump to the last attempt (fresh-regeneration) so the next loop
           // iteration runs as fresh-regen with the namespace failure hint.
           attempt = maxAttempts - 1;

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -700,8 +700,11 @@ async function executeRetryLoop(
     // the next retry attempt — consistent with how other validation failures work.
     if (validation.passed && expectedNamespacePrefix && output.schemaExtensions.length > 0) {
       const wrongNamespace = output.schemaExtensions.filter((ext) => {
-        // Strip "span." prefix before namespace check (span extensions use "span.<prefix>.<name>")
-        const checkPart = ext.startsWith('span.') ? ext.slice('span.'.length) : ext;
+        // Strip "span." or "span:" prefix before namespace check.
+        // normalizeSchemaExtension() converts span: → span. but runs after this check,
+        // so handle both forms here.
+        const normalized = ext.startsWith('span:') ? ext.slice('span:'.length) : ext;
+        const checkPart = normalized.startsWith('span.') ? normalized.slice('span.'.length) : normalized;
         return !checkPart.startsWith(`${expectedNamespacePrefix}.`);
       });
       if (wrongNamespace.length > 0) {
@@ -738,7 +741,8 @@ async function executeRetryLoop(
           attempt = maxAttempts - 1;
           continue;
         }
-        // Already on last attempt — return failure
+        // Already on last attempt — restore original file and return failure
+        try { await writeFile(filePath, originalCode, 'utf-8'); } catch { /* best-effort */ }
         return buildFailedResult(
           filePath, feedback, feedback,
           cumulativeTokens, attempt, actualStrategy, errorProgression, lastOutput,

--- a/test/acceptance-gate.test.ts
+++ b/test/acceptance-gate.test.ts
@@ -229,14 +229,14 @@ module.exports = { fetchProduct };
 
     it('Test B: agent invents attributes with dd. namespace when only dd.* attributes exist in registry', { timeout: 240_000 }, async () => {
       // NOTE: This test asserts on raw instrumentFile() output — before the coordinator
-      // layer runs. In a real run, writeSchemaExtensions() (src/coordinator/schema-extensions.ts)
-      // independently rejects extensions whose namespace doesn't match registry_manifest.yaml's
-      // `name` field. However, that coordinator gate enforces a different rule (the project's
-      // declared name) than what this test checks (visible schema pattern inference). The two
-      // layers are not redundant — this test is the only coverage for the prompt's theory of
-      // correctness. A Test B failure is an agent output quality signal, not a registry integrity
-      // risk. See Issue #722 (coordinator silent rejection → fix-loop feedback) and Issue #724
-      // (complete PRD #581 attribute namespace parallel) for full architectural context.
+      // layer runs. In a real run, dispatch.ts passes the registry namespace prefix to
+      // instrumentWithRetry (Issue #722, now fixed), which enforces it inside the fix loop
+      // so wrong-namespace extensions trigger a fresh-regeneration retry rather than being
+      // silently dropped. The two layers enforce different theories of correctness and are
+      // not redundant — this test is the only coverage for the prompt's theory (visible
+      // schema pattern inference). A Test B failure is an agent output quality signal, not
+      // a registry integrity risk. See Issue #724 (complete PRD #581 attribute namespace
+      // parallel) for the remaining prompt-layer gap.
 
       // Schema has only dd.* attributes, no HTTP-specific one.
       // Agent must invent an HTTP attribute — it must start with dd.

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -3926,3 +3926,106 @@ describe('instrumentWithRetry — NDS-003 repeat-line escalation', () => {
     expect(capturedFailureHint).not.toContain('must be reproduced exactly');
   });
 });
+
+describe('instrumentWithRetry — namespace prefix enforcement (#722)', () => {
+  let testFilePath: string;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'spiny-test-'));
+    testFilePath = join(tempDir, 'test-file.js');
+    writeFileSync(testFilePath, 'export async function fetchData() { return fetch("/api"); }');
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('retries with feedback when agent declares extensions with wrong namespace prefix', async () => {
+    let attempt = 0;
+    let capturedFeedback: string | undefined;
+
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async (_fp, _code, _schema, _config, _provider, callOptions) => {
+        attempt++;
+        if (attempt === 1) {
+          // Wrong namespace — generic.* instead of myapp.*
+          return {
+            success: true,
+            output: makeInstrumentationOutput({
+              schemaExtensions: ['generic.request.id', 'span.generic.fetch_data'],
+              instrumentedCode: 'const x = 1;\n',
+            }),
+          } as InstrumentFileResult;
+        }
+        // Capture feedback so we can assert on it
+        capturedFeedback = callOptions?.feedbackMessage ?? callOptions?.failureHint;
+        // Correct namespace on retry
+        return {
+          success: true,
+          output: makeInstrumentationOutput({
+            schemaExtensions: ['myapp.request.id', 'span.myapp.fetch_data'],
+            instrumentedCode: 'const x = 1;\n',
+          }),
+        } as InstrumentFileResult;
+      },
+      validateFile: async () => makePassingValidation(testFilePath),
+    };
+
+    const result = await instrumentWithRetry(
+      testFilePath, 'export async function fetchData() {}', {}, makeConfig({ maxFixAttempts: 2 }),
+      { deps, provider: jsProvider, expectedNamespacePrefix: 'myapp' },
+    );
+
+    expect(result.status).toBe('success');
+    // Namespace failure on attempt 1 → jump to fresh-regen (attempt 3) → succeeds
+    expect(result.validationAttempts).toBe(3);
+    // failureHint on fresh-regen attempt contains the rejection details
+    expect(capturedFeedback).toBeDefined();
+    expect(capturedFeedback).toContain('generic.request.id');
+    expect(capturedFeedback).toContain('myapp');
+  });
+
+  it('passes on first attempt when all extensions match the expected namespace', async () => {
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async () => ({
+        success: true,
+        output: makeInstrumentationOutput({
+          schemaExtensions: ['myapp.request.id', 'span.myapp.fetch_data'],
+          instrumentedCode: 'const x = 1;\n',
+        }),
+      } as InstrumentFileResult),
+      validateFile: async () => makePassingValidation(testFilePath),
+    };
+
+    const result = await instrumentWithRetry(
+      testFilePath, 'export async function fetchData() {}', {}, makeConfig({ maxFixAttempts: 2 }),
+      { deps, provider: jsProvider, expectedNamespacePrefix: 'myapp' },
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.validationAttempts).toBe(1);
+  });
+
+  it('does not fire when expectedNamespacePrefix is not provided', async () => {
+    // Without a prefix, wrong-namespace extensions should not cause a retry
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async () => ({
+        success: true,
+        output: makeInstrumentationOutput({
+          schemaExtensions: ['generic.request.id'],
+          instrumentedCode: 'const x = 1;\n',
+        }),
+      } as InstrumentFileResult),
+      validateFile: async () => makePassingValidation(testFilePath),
+    };
+
+    const result = await instrumentWithRetry(
+      testFilePath, 'export async function fetchData() {}', {}, makeConfig({ maxFixAttempts: 2 }),
+      { deps, provider: jsProvider },
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.validationAttempts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

**What does this PR do?**

Fixes issue #722 — when the agent declares schema extensions with a namespace prefix that doesn't match the registry manifest's `name` field, the fix loop now detects this inside `instrumentWithRetry` and routes to a fresh-regeneration retry with a targeted failure hint.

**Why is this change needed?**

Previously, wrong-namespace extensions were silently dropped by `writeSchemaExtensions` after the fix loop had already exited. The agent had no opportunity to correct them — spans fired with undocumented attributes that couldn't be queried consistently.

**How it works:**

1. `dispatch.ts` calls `extractNamespacePrefix(registryDir)` once before the file loop and passes the result as `expectedNamespacePrefix` to each `instrumentFn` call
2. `executeRetryLoop` checks each declared extension against the expected prefix after validation passes
3. If any fail: jumps to fresh-regeneration (last attempt) with a targeted hint — "namespace must be X but got Y" — so the agent starts fresh with the correction in context
4. On last attempt with still-wrong namespace: restores original file and returns failure

Uses fresh-regen (not multi-turn) because fresh-regen uses `buildFailureHint` which doesn't require conversation history. Mirrors the existing oscillation detection pattern.

The `buildFailureHint` call truncates at the first period, so the namespace prefix appears in the first sentence of the feedback message. The `span:` colon variant is normalized before the namespace check (the agent occasionally produces `span:` before `normalizeSchemaExtension` runs).

## Related Issues

- Closes #722

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test updates (adding or updating tests)

## Testing Checklist

- [x] Tests added or updated
- [x] All existing tests pass locally (2595 tests)

**Test commands run:**
```bash
vals exec -f .vals.yaml -- bash -c 'export PATH="/opt/homebrew/bin:$PATH" && npx vitest run'
```

## Documentation Checklist

- [x] PROGRESS.md updated
- [x] Test B annotation updated in test/acceptance-gate.test.ts

## Security Checklist

- [x] No secrets or credentials committed
- [x] No security implications

## Breaking Changes

- [x] No — `expectedNamespacePrefix` is optional; existing callers without it get the same behavior as before

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally
- [x] PR title follows Conventional Commits format

## Additional Context

**Reviewer Notes:**
1. `src/fix-loop/instrument-with-retry.ts` ~lines 697–750 — namespace check block; `span:` colon normalization, fresh-regen jump, file-restore before last-attempt failure
2. `src/coordinator/dispatch.ts` — `extractNamespacePrefix` import + one-time call before file loop; try/catch means missing manifest falls back to old silent-drop
3. `test/fix-loop/instrument-with-retry.test.ts` — three new unit tests at the bottom

**Acceptance gate coverage:** Unit tests cover the retry behavior deterministically. LLM-response quality (will the agent fix namespace when prompted?) is an eval question, not CI. The dispatch wiring is two lines verifiable by reading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced per-registry namespace validation during instrumentation with safer fallback behavior and clearer error messaging.
  * Fixed various language-server and validator oscillations and improved environment/error visibility.

* **New Features**
  * Optional per-registry namespace expectation to guide instrumentation and automated retries.

* **Tests**
  * Added tests for namespace-prefix validation and retry handling for invalid prefixes; expanded acceptance scenarios.

* **Documentation**
  * Large progress/Unreleased notes, expanded architecture, live-check parsing, SDK guidance, and acceptance gate/test docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->