### PR TITLE
chore: add npx tsc --noEmit to permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(coderabbit review *)",
-      "Bash(npm run typecheck)"
+      "Bash(npm run typecheck)",
+      "Bash(npx tsc --noEmit *)"
     ]
   }
 }


### PR DESCRIPTION
Adds `Bash(npx tsc --noEmit *)` to the project allowlist to reduce permission prompts for read-only typechecks. Generated by `/fewer-permission-prompts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->