### PR TITLE
fix: suppress live-check JSON from terminal output and skip reassembly for 0-span files

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- (2026-05-11) Fixed live-check compliance report JSON flooding the terminal on every run (issue #849, RUN16-2): the full JSON blob was being emitted to stderr even though it is already written to disk as `spiny-orb-live-check-report.json`. The one-line summary (`Live-check: OK (N spans, N advisory findings — see compliance report)`) is preserved. Fixed function-level fallback corrupting committed code when no spans are added (issue #849, RUN16-3): reassembly was running even when all per-function calls added 0 spans, stripping try/catch blocks from the committed output. When 0 spans are added, the fallback now returns the original file unchanged without reassembly.
+
 ### Added
 
 - (2026-05-11) Recorded run-16 eval findings: added a pre-confirmed NDS-003 gap entry for `technicalNode` in `journal-graph.js` (3 consecutive failures, error count 1→5 on attempt 3) to PRD #845's Decision Log, with cascaded updates to M0 (start gap count at 1) and M2 (mandatory regression fixture). Created issues #848 (adaptive thinking token exhaustion — switch to `enabled+budget_tokens`, raise MIN_OUTPUT_BUDGET, tighten COV-003 guidance) and #849 (live-check JSON stdout flood + 0-span file reassembly corruption). Both issues added to ROADMAP short-term section.

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -1134,6 +1134,44 @@ async function functionLevelFallback(
     return null; // All functions failed — fall through to whole-file failure
   }
 
+  // Short-circuit: if no spans were added, return the original file unchanged.
+  // Reassembly has no valid purpose when nothing was instrumented and can corrupt
+  // code structure (e.g. stripping try/catch blocks). The check at the end of the
+  // success path restores the original too, but only after reassembly and validation
+  // have already run — the partial-results fallback path does not restore cleanly.
+  const preReassemblySpans = successful.reduce((sum, r) => sum + r.spansAdded, 0);
+  if (preReassemblySpans === 0) {
+    await writeFile(filePath, originalCode, 'utf-8');
+    let shortCircuitTokens = { ...wholeFileResult.tokenUsage };
+    for (const r of fnResults) {
+      shortCircuitTokens = addTokenUsage(shortCircuitTokens, r.tokenUsage);
+    }
+    return {
+      path: filePath,
+      status: 'success',
+      spansAdded: 0,
+      librariesNeeded: [],
+      schemaExtensions: [],
+      attributesCreated: 0,
+      validationAttempts: wholeFileResult.validationAttempts,
+      validationStrategyUsed: wholeFileResult.validationStrategyUsed,
+      errorProgression: [
+        ...(wholeFileResult.errorProgression ?? []),
+        `function-level: 0/${extractedFunctions.length} functions instrumented (no spans needed)`,
+      ],
+      notes: [
+        ...(wholeFileResult.notes ?? []),
+        `Function-level fallback: 0/${extractedFunctions.length} functions instrumented`,
+        ...fnResults.filter(r => !r.success).map(r => `  skipped: ${r.name} — ${r.error}`),
+      ],
+      agentVersion: AGENT_VERSION,
+      tokenUsage: shortCircuitTokens,
+      functionsInstrumented: 0,
+      functionsSkipped: extractedFunctions.length,
+      functionResults: fnResults,
+    };
+  }
+
   // Reassemble: replace instrumented functions in the original file via provider
   let reassembledCode = fnProvider.reassembleFunctions(originalCode, extractedFunctions, fnResults);
 

--- a/src/interfaces/instrument-handler.ts
+++ b/src/interfaces/instrument-handler.ts
@@ -487,12 +487,6 @@ export async function handleInstrument(
         statusLine = 'Live-check: OK (no spans received — live-check did not validate any telemetry)';
       }
       deps.stderr(statusLine);
-      if (options.verbose && runResult.endOfRunValidation) {
-        deps.stderr('Full compliance report:');
-        deps.stderr(runResult.endOfRunValidation);
-      }
-    } else if (runResult.endOfRunValidation) {
-      deps.stderr(`Live-check: ${runResult.endOfRunValidation}`);
     }
     for (const warning of runResult.warnings) {
       deps.stderr(`Warning: ${warning}`);

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -3029,7 +3029,10 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
           return {
             success: true,
             output: makeInstrumentationOutput({
-              instrumentedCode: 'const x = 1;\n',
+              // Must include startActiveSpan so spansAdded > 0 — otherwise the 0-span
+              // short-circuit skips reassembly before this test's partial path is exercised.
+              instrumentedCode: `import { trace } from '@opentelemetry/api';\nexport async function fn() { return trace.getTracer('svc').startActiveSpan('op', async (span) => { try { return null; } finally { span.end(); } }); }\n`,
+              spanCategories: { externalCalls: 1, schemaDefined: 0, serviceEntryPoints: 0, totalFunctionsInFile: 1 },
             }),
           };
         }
@@ -3075,7 +3078,9 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
           return {
             success: true,
             output: makeInstrumentationOutput({
-              instrumentedCode: 'const x = 1;\n',
+              // Must include startActiveSpan so spansAdded > 0 — otherwise the 0-span
+              // short-circuit skips reassembly before this test's partial path is exercised.
+              instrumentedCode: `import { trace } from '@opentelemetry/api';\nexport async function fn() { return trace.getTracer('svc').startActiveSpan('op', async (span) => { try { return null; } finally { span.end(); } }); }\n`,
               spanCategories: { externalCalls: 1, schemaDefined: 0, serviceEntryPoints: 0, totalFunctionsInFile: 1 },
             }),
           };
@@ -3156,6 +3161,41 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
     expect(result.status).toBe('success');
     // countSpansInCode: no startActiveSpan in fixture code
     expect(result.spansAdded).toBe(0);
+  });
+
+  it('returns original file unchanged and skips reassembly when all per-function calls add 0 spans', async () => {
+    // Count only reassembly-level validation (original file path), not per-function validation (temp paths)
+    let reassemblyValidateCount = 0;
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async (path) => {
+        if (isPerFunctionCall(path)) {
+          // Succeed but return code with no startActiveSpan → 0 spansAdded
+          return {
+            success: true,
+            output: makeInstrumentationOutput({
+              instrumentedCode: FALLBACK_FIXTURE,
+              spanCategories: { externalCalls: 0, schemaDefined: 0, serviceEntryPoints: 0, totalFunctionsInFile: 2 },
+            }),
+          };
+        }
+        return { success: false, error: 'LLM failure', tokenUsage: sampleTokens };
+      },
+      validateFile: async (input) => {
+        if (input.filePath === filePath) {
+          reassemblyValidateCount++;
+        }
+        return makePassingValidation(input.filePath);
+      },
+    };
+
+    const result = await instrumentWithRetry(filePath, FALLBACK_FIXTURE, {}, makeConfig(), { deps, provider: jsProvider });
+
+    expect(result.spansAdded).toBe(0);
+    expect(result.status).toBe('success');
+    // File must be identical to original — no reassembly should have run
+    expect(readFileSync(filePath, 'utf-8')).toBe(FALLBACK_FIXTURE);
+    // Reassembly-level validation must not be called — short-circuit happened before reassembly
+    expect(reassemblyValidateCount).toBe(0);
   });
 });
 

--- a/test/interfaces/instrument-handler.test.ts
+++ b/test/interfaces/instrument-handler.test.ts
@@ -1083,11 +1083,13 @@ describe('handleInstrument', () => {
       });
       await handleInstrument(makeOptions({ verbose: true }), deps);
       const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0] as string);
+      const stderrOutput = stderrCalls.join('\n');
       // One-line summary should be printed
       expect(stderrCalls.some(s => s.includes('Live-check:'))).toBe(true);
-      // Full JSON blob must NOT be printed
-      expect(stderrCalls.some(s => s.includes(complianceJson))).toBe(false);
-      expect(stderrCalls.some(s => s.includes('Full compliance report'))).toBe(false);
+      // Full JSON blob must NOT be printed — check for stable key names present in any compliance JSON
+      expect(stderrOutput).not.toContain('"statistics"');
+      expect(stderrOutput).not.toContain('"total_entities"');
+      expect(stderrOutput).not.toContain('Full compliance report');
     });
 
     it('does not print compliance report JSON to stderr when liveCheckStatus is absent', async () => {
@@ -1099,7 +1101,9 @@ describe('handleInstrument', () => {
       });
       await handleInstrument(makeOptions(), deps);
       const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0] as string);
-      expect(stderrCalls.some(s => s.includes(complianceJson))).toBe(false);
+      const stderrOutput = stderrCalls.join('\n');
+      expect(stderrOutput).not.toContain('"spans"');
+      expect(stderrOutput).not.toContain('"name":"test"');
     });
   });
 });

--- a/test/interfaces/instrument-handler.test.ts
+++ b/test/interfaces/instrument-handler.test.ts
@@ -1067,4 +1067,39 @@ describe('handleInstrument', () => {
       expect(result.exitCode).toBe(3);
     });
   });
+
+  describe('live-check compliance report output', () => {
+    it('does not print compliance report JSON to stderr when verbose is true', async () => {
+      const complianceJson = '{"spans":[{"name":"test"}],"statistics":{"total_entities":1}}';
+      const deps = makeDeps({
+        coordinate: vi.fn().mockResolvedValue(makeRunResult({
+          liveCheckStatus: {
+            spansReceived: true,
+            spanCount: 1,
+            totalAdvisories: 0,
+          },
+          endOfRunValidation: complianceJson,
+        })),
+      });
+      await handleInstrument(makeOptions({ verbose: true }), deps);
+      const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0] as string);
+      // One-line summary should be printed
+      expect(stderrCalls.some(s => s.includes('Live-check:'))).toBe(true);
+      // Full JSON blob must NOT be printed
+      expect(stderrCalls.some(s => s.includes(complianceJson))).toBe(false);
+      expect(stderrCalls.some(s => s.includes('Full compliance report'))).toBe(false);
+    });
+
+    it('does not print compliance report JSON to stderr when liveCheckStatus is absent', async () => {
+      const complianceJson = '{"spans":[{"name":"test"}]}';
+      const deps = makeDeps({
+        coordinate: vi.fn().mockResolvedValue(makeRunResult({
+          endOfRunValidation: complianceJson,
+        })),
+      });
+      await handleInstrument(makeOptions(), deps);
+      const stderrCalls = (deps.stderr as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0] as string);
+      expect(stderrCalls.some(s => s.includes(complianceJson))).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Suppress live-check compliance report JSON from terminal stderr (RUN16-2): the full JSON blob was being emitted even though it is already written to disk. Removes the verbose-mode JSON dump and the fallback raw-JSON emit; the one-line summary is preserved.
- Short-circuit function-level fallback reassembly when all per-function calls add 0 spans (RUN16-3): reassembly corrupts code structure (e.g. stripping try/catch blocks) when nothing was instrumented. The short-circuit writes the original file back and returns success with spansAdded=0, bypassing reassembly and validation entirely. Updates two existing partial-path tests to use instrumented code with actual spans so the reassembly path remains covered.

Closes #849.

## Test plan

- [ ] `npm test` passes (2689 tests)
- [ ] `npm run typecheck` passes
- [ ] New test: does not print compliance report JSON to stderr when verbose is true
- [ ] New test: does not print compliance report JSON to stderr when liveCheckStatus is absent
- [ ] New test: returns original file unchanged and skips reassembly when all per-function calls add 0 spans
- [ ] Existing partial-path tests (reassembly validation failure) still pass with updated instrumentedCode fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental modification of committed files when instrumentation adds no telemetry spans; validation is skipped and the original file is preserved.
  * Reduced terminal noise from live-check by emitting a concise one-line status when no spans are received.

* **Documentation**
  * Updated unreleased changelog with fixes for live-check reporting and safe fallback behavior.

* **Tests**
  * Added/updated tests covering fallback behavior and live-check reporting output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/spinybacked-orbweaver/pull/851)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->