### PR TITLE
chore: add eval cadence section and reorder short-term items in ROADMAP.md

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,10 +15,17 @@ Pass rate = files committed / files discovered. Syntax errors = files where `tsc
 
 ---
 
+## Eval cadence
+
+Run a commit-story-v2 eval after any change to `src/agent/prompt.ts`, NDS-003 reconcilers, or acceptance gate tests — before starting the next PRD that changes agent behavior. PRD #857's prompt clarifications have not yet been validated by a full eval run; run one after the Short-term items below before opening PRD #845 M1.
+
 ## Short-term (current focus)
 
-- Agent misses primary exported function in git-collector (COV-001, 8+ consecutive runs) ([issue #855](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/855)) — PRD #857 M1 audit verdict: targeting-logic issue in `instrument-with-retry.ts`, not a prompt interpretation problem. Issue expanded with audit findings pointers.
+Work these in order:
 
+1. Agent misses primary exported function in git-collector (COV-001, 8+ consecutive runs) ([issue #855](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/855)) — PRD #857 M1 audit verdict: targeting-logic issue in `instrument-with-retry.ts`, not a prompt interpretation problem. Issue expanded with audit findings pointers.
+2. Add missing unit tests for three NDS-003 reconciler patterns ([issue #861](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/861)) — `normalizeLine` arrow-paren-strip, `reconcileReturnCaptures` multi-line object literal sub-case, and `isSpanCallbackComma` inline filter all lack dedicated tests; identified in PRD #857 M1 audit.
+3. **Run a commit-story-v2 eval** to validate PRD #857 prompt changes before opening PRD #845 M1.
 
 ## Medium-term
 
@@ -30,7 +37,6 @@ Pass rate = files committed / files discovered. Syntax errors = files where `tsc
 
 - SPA-001: design discussion — span granularity for CLI tools processing large collections ([issue #731](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/731)) — taze run-13 produced 164 INTERNAL spans against 38 packages (structurally correct, but fails IS SPA-001 limit). Design question: per-item vs. batched spans for CLI tools iterating user-controlled collections. One run of data; wait for 2+ CLI evals before deciding.
 - P4 coordinator: ExpressInstrumentation missing from SDK init file after successful instrumentation ([issue #846](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/846)) — `librariesNeeded` for express not reaching SDK init update; investigate `src/coordinator/aggregate.ts` → `src/coordinator/sdk-init.ts` path.
-- Add missing unit tests for three NDS-003 reconciler patterns ([issue #861](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/861)) — `normalizeLine` arrow-paren-strip, `reconcileReturnCaptures` multi-line object literal sub-case, and `isSpanCallbackComma` inline filter all lack dedicated tests; identified in PRD #857 M1 audit.
 
 ## Long-term
 


### PR DESCRIPTION
- Adds an 'Eval cadence' section explaining when to run a commit-story-v2 eval (after any prompt.ts, NDS-003, or acceptance gate change) and flags that PRD #857 prompt changes need a validation run before PRD #845 M1 starts
- Moves issue #861 (NDS-003 unit tests) from Medium-term to Short-term, making the sequence explicit: #855 → #861 → eval run → #845
- Numbers the Short-term items so a fresh AI knows the order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ROADMAP with a new evaluation cadence section defining when to conduct evaluations
  * Reorganized short-term roadmap items into a structured, ordered checklist with clear dependencies for improved planning and tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/spinybacked-orbweaver/pull/864)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->