### PR TITLE
fix(867): retry push when pre-push hook creates a commit and exits non-zero

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- (2026-05-25) Fixed spiny-orb's push step silently giving up when a target repo's pre-push hook creates a new commit and exits non-zero asking for a re-push. Some repos (like commit-story-v2) have a `progress-md-pr.sh` hook that commits a PROGRESS.md update to the instrument branch and prints "Push again to include it." before exiting with a non-zero status. spiny-orb was treating any non-zero push exit as a permanent failure, skipping PR creation and stranding the hook's commit on the branch. The fix detects the "Push again" pattern in the hook's stderr output and retries the push once, transparently picking up the hook-created commit. This was firing on every commit-story-v2 eval run and required manual PR creation as a workaround.
+
 ### Added
 
 - (2026-05-18) Fixed NDS-003 false positive where `return { ... };` split at deeper indentation left `};` as an unreconciled added line. When `startActiveSpan` adds indent levels and a return-object statement crosses Prettier's printWidth, Prettier splits the object across lines with `};` on its own final line. `reconcileAgentSplitLines` try-c was matching one line short because `stripForComparison` strips `};` from the missing line, making the N-1 group compare equal. The fix: after a try-c match, absorb the immediately following consecutive line if it is exactly `};`. Two unit tests added for the `return { ... };` and `pool.query(..., [id]);` split patterns. Also recalibrated the Phase 3 fix-loop test assertion for `user-routes.js` to accept function-level fallback as a valid success path alongside full-file validation.

--- a/src/git/git-wrapper.ts
+++ b/src/git/git-wrapper.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Thin wrapper over simple-git for branch, stage, commit, and log operations.
 // ABOUTME: Used by Phase 7 deliverables to create feature branches and per-file commits.
 
-import { simpleGit } from 'simple-git';
+import { simpleGit, type SimpleGit } from 'simple-git';
 
 /** A single commit log entry. */
 export interface LogEntry {
@@ -124,6 +124,26 @@ export function resolveAuthenticatedUrl(remoteUrl: string, token: string | undef
 }
 
 /**
+ * Push with a single retry when a pre-push hook creates a commit and requests a re-push.
+ *
+ * Some repos have a pre-push hook (e.g. progress-md-pr.sh) that commits a file
+ * and exits non-zero with a "Push again" message to include the new commit. Detect
+ * this pattern and retry once so spiny-orb handles it transparently.
+ */
+async function pushWithHookRetry(git: SimpleGit, remote: string, branchName: string): Promise<void> {
+  try {
+    await git.push(remote, branchName, ['--set-upstream']);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/push again/i.test(msg)) {
+      await git.push(remote, branchName, ['--set-upstream']);
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
  * Push the current branch to the remote, setting upstream tracking.
  * When GITHUB_TOKEN is set in the environment and the remote uses HTTPS,
  * the token is embedded in the push URL to avoid authentication failures
@@ -169,7 +189,7 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
         let pushError: Error | undefined;
         try {
           await git.remote(['set-url', '--push', remote, authUrl]);
-          await git.push(remote, branchName, ['--set-upstream']);
+          await pushWithHookRetry(git, remote, branchName);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           pushError = new Error(sanitizeTokenFromError(msg));
@@ -202,7 +222,7 @@ export async function pushBranch(dir: string, branchName: string, remote = 'orig
   try {
     process.stderr.write(`pushBranch: path=bare-push, reason=${token ? 'url-unchanged' : 'no-token'}\n`);
   } catch { /* diagnostic only — never block push */ }
-  await git.push(remote, branchName, ['--set-upstream']);
+  await pushWithHookRetry(git, remote, branchName);
 }
 
 /**

--- a/test/git/git-wrapper.test.ts
+++ b/test/git/git-wrapper.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Tests branch creation, file staging, commit, log, and current branch operations in isolated temp repos.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { writeFile, mkdir, rm, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -318,6 +318,43 @@ describe('git-wrapper', () => {
       const bare = simpleGit(bareDir);
       const branches = await bare.branch();
       expect(branches.all).toContain('spiny-orb/test-push');
+    });
+
+    it('retries push when pre-push hook creates a commit and exits non-zero with "Push again"', { timeout: LOCAL_PUSH_TIMEOUT }, async () => {
+      // Simulate the progress-md-pr.sh pattern: on first invocation the hook creates
+      // a commit and exits 1 asking for a re-push; on second invocation it exits 0.
+      const hooksDir = join(repoDir, '.git', 'hooks');
+      await mkdir(hooksDir, { recursive: true });
+      const hookPath = join(hooksDir, 'pre-push');
+      const hookScript = [
+        '#!/bin/sh',
+        'STATE="$(git rev-parse --git-dir)/hook-fired"',
+        'if [ ! -f "$STATE" ]; then',
+        '  touch "$STATE"',
+        '  echo "hook-content" >> PROGRESS.md',
+        '  git add PROGRESS.md',
+        '  git commit -m "chore: update PROGRESS.md"',
+        '  echo "Committed PROGRESS.md update. Push again to include it." >&2',
+        '  exit 1',
+        'fi',
+        'exit 0',
+      ].join('\n');
+      await writeFile(hookPath, hookScript);
+      await chmod(hookPath, 0o755);
+
+      await createBranch(repoDir, 'spiny-orb/test-hook-retry');
+      await writeFile(join(repoDir, 'test.js'), 'const x = 1;\n');
+      await stageFiles(repoDir, ['test.js']);
+      await commit(repoDir, 'instrument test.js');
+
+      await expect(pushBranch(repoDir, 'spiny-orb/test-hook-retry')).resolves.not.toThrow();
+
+      // Both the original commit and the hook-created commit should be on the remote
+      const bare = simpleGit(bareDir);
+      const log = await bare.log(['spiny-orb/test-hook-retry']);
+      const messages = log.all.map((e) => e.message);
+      expect(messages).toContain('chore: update PROGRESS.md');
+      expect(messages).toContain('instrument test.js');
     });
 
     // This exercises the non-token path (local bare repo, no GITHUB_TOKEN).


### PR DESCRIPTION
## Summary

- `pushBranch` in `src/git/git-wrapper.ts` now retries once when a pre-push hook creates a commit and exits non-zero with "Push again" in its output
- Extracted `pushWithHookRetry` helper — both the token-authenticated and bare-push code paths use it
- New test in `test/git/git-wrapper.test.ts` covers the full scenario with a real pre-push hook installed in an isolated temp repo

## Context

`progress-md-pr.sh` in commit-story-v2 (and similar hooks in other target repos) commits a PROGRESS.md update to the instrument branch and exits 1 with "Committed PROGRESS.md update. Push again to include it." spiny-orb was treating any non-zero push exit as permanent failure, skipping PR creation and stranding the hook's commit. This fired on every commit-story-v2 eval run and required manual PR creation as a workaround.

## CodeRabbit CLI finding

One critical finding flagged that simple-git might not include stderr in `error.message`. Triaged as **Skip** — empirical evidence from the failing test shows the full hook output (including the "Push again" line written to stderr) appears in `err.message` for push failures. The passing test confirms the detection works correctly in practice.

## Test plan

- [ ] `npx vitest run test/git/git-wrapper.test.ts` — 32/32 passing
- [ ] Acceptance gate CI passes
- [ ] Update PROGRESS.md when resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed git push behavior when pre-push hooks create new commits and request a retry. The system now detects the retry request and automatically retries the push once, ensuring hook-created commits are properly included instead of being skipped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/spinybacked-orbweaver/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->