### PR TITLE
fix(nds003): preserve file-level trivia when first-position OTel import is removed

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- (2026-06-02) Fixed a false-positive NDS-003 validator bug introduced by PRD #885: when the agent places the OTel import as the first statement in a file, ts-morph's `ImportDeclaration.remove()` was silently stripping the file's leading trivia — shebang lines (`#!/usr/bin/env node`) and file-level JSDoc blocks — along with the import node. The fix detects when the removed import is the first statement and calls `replaceWithText(leadingTrivia)` instead, preserving the trivia while removing the import text. This unblocked `mcp/server.js` in commit-story-v2, which failed all 3 run-20 attempts on 21 identical NDS-003 violations at fixed line numbers (a validator false positive — the agent's output was correct). Two regression tests added: one using the server.js shebang + JSDoc structure as a fixture, one confirming non-first-position imports are unaffected.
+
+### Added
+
+- (2026-06-02) Research spike on OTel span granularity at caller/callee boundaries (issue #898). Recommendation: keep leaves-first file ordering. OTel community standard (official opentelemetry.io docs, Honeycomb, Jessitron) says to instrument at layer boundaries — incoming requests, network calls, async task boundaries — not at every internal coordination step. Context propagation creates parent-child span relationships automatically; callee spans attach to the nearest active span without the caller needing wrapper spans. The suppression directive in `src/agent/prompt.ts` targets callee-duplicate spans specifically (not entry-point spans), aligning with this standard. Run-20 PR evidence and IS scoring history (runs 15–19) show no failures attributable to orchestration-layer gaps. One open question for future runs: whether MCP tool handlers (`context-capture-tool.js`, `reflection-tool.js`) are correctly classified as not needing entry-point spans — a pre-scan heuristic question orthogonal to ordering. Research saved to `docs/research/otel-span-granularity.md`.
+
 ### Added
 
 - (2026-05-27) Wired `normalizeMultiLineFlags` into NDS-003's comparison pipeline. Both the original code and the OTel-stripped instrumented code are now passed through the multiLine normalizer before Prettier runs, so Prettier sees the same `multiLine=false` baseline on both sides and produces consistent output regardless of how the agent formatted object/array literals. Previously, when the agent expanded an inline object like `{ nodes: [], edges: [] }` to a multi-line block inside a span wrapper, the stripped instrumented code retained `multiLine=true` while the original had `multiLine=false`, causing Prettier to format them differently and NDS-003 to fire a false positive. Validated by acceptance gate CI run 26547319073 — `journal-graph.js` now produces `success` (was `partial`), all other fixtures unchanged.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,3 +9,4 @@
 | typescript-cli-tsc-behavior.md | tsc CLI gotchas for 5.x→6.x: TS5112 error, --ignoreConfig flag, stdout vs stderr, new 6.x defaults, --noCheck | 2026-04-28 |
 | weaver-registry-dependency-import-syntax.md | Weaver 0.21.2 dependency/import syntax: wildcard imports are schema-invalid, extends works for specific group IDs, --include-unreferenced produces 4.9MB payload | 2026-04-29 |
 | industry-practices-spike.md | Flaky test detection (Meta PFS, Buildkite, Datadog, Slack), codemod rollback patterns, OTel SDK injection (Vitest sdkPath vs NODE_OPTIONS), live compliance validation (Weaver is the only tool) | 2026-05-01 |
+| otel-span-granularity.md | OTel span granularity at caller/callee boundaries: community standard (instrument at layer boundaries, not every function), context propagation wiring, leaves-first ordering recommendation | 2026-06-02 |

--- a/docs/research/otel-span-granularity.md
+++ b/docs/research/otel-span-granularity.md
@@ -1,0 +1,112 @@
+# Research: OTel Span Granularity at Caller/Callee Boundaries
+
+**Project:** spinybacked-orbweaver
+**Last Updated:** 2026-06-02
+
+## Update Log
+
+| Date | Summary |
+|------|---------|
+| 2026-06-02 | Initial research — informing #898 leaves-first ordering recommendation |
+
+---
+
+## Findings
+
+### Core question
+
+Should orchestration-layer functions have their own spans when the callee is already instrumented? Should context propagation suffice?
+
+### Community standard: instrument at layer boundaries, not every function
+
+🟢 **High confidence** — from official OTel docs (opentelemetry.io) and widely-cited Honeycomb/Jessitron guidance.
+
+**Source says:** "Public methods that make network calls internally or local operations that take significant time and may fail" — ([OpenTelemetry Libraries Documentation](https://opentelemetry.io/docs/concepts/instrumentation/libraries/))
+
+**Source says:** "create spans only for the logical request to the database. The physical requests over the network should be instrumented within the libraries implementing that functionality" — ([OpenTelemetry Libraries Documentation](https://opentelemetry.io/docs/concepts/instrumentation/libraries/))
+
+**Source says:** "Add data to the current span as attributes. They enable correlation across multiple dimensions and are cheap — 'nearly free' with event-based pricing." ([Jessitron span-or-attribute guide](https://jessitron.com/2026/04/29/span-or-attribute-in-opentelemetry-custom-instrumentation/))
+
+**Interpretation:** The OTel community default is attributes over new spans. Create spans for layer boundaries (incoming requests, network calls, async boundaries), not for every internal coordination step.
+
+### When to create a span (the affirmative list)
+
+🟢 **High confidence** — corroborated by official OTel traces concepts page and Jessitron.
+
+1. **Incoming requests** — establishes the root span for a trace
+2. **Network boundaries** — outgoing calls to external services or databases
+3. **Async task boundaries** — reveals what runs concurrently vs. sequentially
+4. **Significant-duration operations** — where timing matters for debugging
+
+**Source says:** "When kicking off async work, create a new span around each async task so that we can see what happens concurrently and what waits." ([Honeycomb span-or-attribute guide](https://www.honeycomb.io/blog/span-or-attribute-opentelemetry-custom-instrumentation))
+
+**Source says:** "Work crosses a process, service, or system boundary" ([OpenTelemetry Concepts — Traces](https://opentelemetry.io/docs/concepts/signals/traces/))
+
+### What NOT to span: sub-events and internal retries
+
+🟢 **High confidence**
+
+**Source says:** "Capture secondary activities (serialization, retries) as span events on the parent span, not as child spans." ([OpenTelemetry Libraries Documentation](https://opentelemetry.io/docs/concepts/instrumentation/libraries/))
+
+**Source says:** "Avoid unnecessary spans for trivial internal operations" ([OpenTelemetry Concepts — Traces](https://opentelemetry.io/docs/concepts/signals/traces/))
+
+**Interpretation:** If the callee already has a span, the orchestration function does not need to duplicate that work as a caller-level span. Context propagation creates the parent-child relationship automatically.
+
+### How context propagation handles caller/callee
+
+🟢 **High confidence** — from OTel Go instrumentation docs, generalizes to all languages.
+
+**Source says:** The idiomatic pattern shows that neither caller nor callee needs awareness of the other — context is passed down and child spans attach automatically to the active span:
+
+```go
+func parentFunction(ctx context.Context) {
+    ctx, parentSpan := tracer.Start(ctx, "parent")
+    defer parentSpan.End()
+    childFunction(ctx) // passes context — child span attaches automatically
+}
+```
+
+([OpenTelemetry Go Instrumentation](https://opentelemetry.io/docs/languages/go/instrumentation/))
+
+**Interpretation:** The caller does not need its own span to be the parent. Any active span in the context becomes the parent for all descendent spans. If the caller already has a span (e.g., an MCP server span), all callee spans attach to it without the caller needing per-function spans for every orchestration call.
+
+### spiny-orb leaves-first suppression vs. OTel standards
+
+The suppression directive in `src/agent/prompt.ts` line 493:
+> `"Already instrumented in \`${sourceModule}\`: ${nameList}. Do not add spans for these calls — the callee already owns that layer."`
+
+This targets **callee-duplicate spans only** — the specific call from the current file to a function that already has a span in an already-processed file. It does NOT suppress entry-point spans for the current file's own exported functions.
+
+**Evidence from run-20 PR #73** (commit-story-v2):
+- `src/index.js` (processed last, max manifest coverage): got 1 span — `commit_story.commands.main` (the entry point). The orchestration calls to `summary-manager.generateAndSaveDailySummary`, `git-collector.getCommitData`, etc. were correctly suppressed. The trace shows the entry point with all callee spans hanging off it.
+- `src/commands/summarize.js` (caller of summary-manager): got 3 spans for its own entry-point commands. Sub-operation calls to already-instrumented summary-manager functions were suppressed.
+- IS history (runs 15-19): no IS failures attributed to missing orchestration spans. SPA-001 failures were structural (orphan spans from partial instrumentation) not coverage gaps.
+
+### One caveat: `context-capture-tool.js` and `reflection-tool.js`
+
+Run-20 PR shows COV-004 advisory (async function without span) for both MCP tool handler files. These were in "No changes needed" — the agent decided not to instrument them. These ARE entry points (called by the MCP server on incoming tool requests), which by OTel standards should have their own spans.
+
+This is NOT a suppression issue — it's a pre-scan heuristic question. The pre-scan classified them as not needing instrumentation. This class of file warrants attention in subsequent runs, but it is orthogonal to the leaves-first ordering question.
+
+---
+
+## Recommendation
+
+**Keep leaves-first.** The current behavior is aligned with OTel community standards:
+
+- The OTel spec says to instrument at layer boundaries, not every internal function
+- Context propagation creates parent-child relationships automatically — callee spans attach to the nearest active span in the context chain
+- The suppression directive targets callee-duplicate spans, not entry-point spans
+- Run-20 and historical IS data show no failures attributable to orchestration-layer gaps from this ordering
+
+The only open question is whether MCP tool handlers (`context-capture-tool.js`, `reflection-tool.js`) are correctly classified as not needing instrumentation — that is a pre-scan heuristic question, not an ordering question.
+
+---
+
+## Sources
+
+- [OpenTelemetry Libraries Documentation](https://opentelemetry.io/docs/concepts/instrumentation/libraries/) — official guidance on when to create spans vs. use events
+- [OpenTelemetry Concepts — Traces](https://opentelemetry.io/docs/concepts/signals/traces/) — span creation rules and when not to create spans
+- [Jessitron: Span or Attribute in OTel Custom Instrumentation](https://jessitron.com/2026/04/29/span-or-attribute-in-opentelemetry-custom-instrumentation/) — default to attributes; span when crossing async boundaries
+- [Honeycomb: Span or Attribute](https://www.honeycomb.io/blog/span-or-attribute-opentelemetry-custom-instrumentation) — async task boundary guidance
+- [OpenTelemetry Go Instrumentation](https://opentelemetry.io/docs/languages/go/instrumentation/) — context propagation pattern showing automatic parent-child wiring

--- a/src/languages/javascript/rules/nds003-ast-stripper.ts
+++ b/src/languages/javascript/rules/nds003-ast-stripper.ts
@@ -511,6 +511,11 @@ function getContainingStatementForUnwrap(
 
 /**
  * Remove @opentelemetry/* import declarations (P12).
+ *
+ * When the OTel import is the first statement in the file, its leading trivia
+ * (shebang, file-level JSDoc) is attached to the import node in the AST.
+ * Calling imp.remove() would drop that trivia. Instead, replace the import
+ * with just its leading trivia so file-level headers are preserved.
  */
 function removeOtelImports(sourceFile: SourceFile): void {
   const toRemove: ImportDeclaration[] = [];
@@ -521,8 +526,24 @@ function removeOtelImports(sourceFile: SourceFile): void {
     }
   }
 
+  // Process in reverse document order to avoid position invalidation.
+  // The first-in-file import is processed last.
   for (const imp of toRemove.reverse()) {
-    if (!imp.wasForgotten()) imp.remove();
+    if (imp.wasForgotten()) continue;
+
+    const statements = sourceFile.getStatements();
+    if (statements.length > 0 && statements[0] === imp) {
+      // This import carries file-level leading trivia (shebang, JSDoc). Replace
+      // with just the trivia text so those headers survive the import removal.
+      const fileText = sourceFile.getFullText();
+      const leadingTrivia = fileText.slice(imp.getFullStart(), imp.getStart());
+      if (leadingTrivia.length > 0) {
+        imp.replaceWithText(leadingTrivia);
+        continue;
+      }
+    }
+
+    imp.remove();
   }
 }
 

--- a/test/languages/javascript/rules/nds003-ast-stripper.test.ts
+++ b/test/languages/javascript/rules/nds003-ast-stripper.test.ts
@@ -405,6 +405,61 @@ describe('P12: OTel import declaration', () => {
     expect(result).toContain("import { something } from 'other-package'");
     expect(result).toContain('function doWork()');
   });
+
+  it('preserves shebang and file-level JSDoc when OTel import is the first statement (run-20 server.js regression)', () => {
+    const code = [
+      '#!/usr/bin/env node',
+      '/**',
+      ' * Commit Story MCP Server',
+      ' */',
+      '',
+      "import { trace, SpanStatusCode } from '@opentelemetry/api';",
+      "import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';",
+      '',
+      "const tracer = trace.getTracer('commit-story');",
+      '',
+      '/**',
+      ' * Create and configure the MCP server',
+      ' */',
+      'function createServer() {',
+      "  return tracer.startActiveSpan('create', (span) => {",
+      '    span.end();',
+      '    return {};',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const result = stripOtelNodes(code, '/tmp/server.js');
+
+    expect(result).toContain('#!/usr/bin/env node');
+    const originalCount = (code.match(/\/\*\*/g) ?? []).length;
+    const resultCount = (result.match(/\/\*\*/g) ?? []).length;
+    expect(resultCount).toBe(originalCount);
+    expect(result).not.toContain('@opentelemetry');
+    expect(result).not.toContain('startActiveSpan');
+  });
+
+  it('does not affect files where OTel import is not the first statement', () => {
+    const code = [
+      "import { readFileSync } from 'node:fs';",
+      "import { trace } from '@opentelemetry/api';",
+      '',
+      "const tracer = trace.getTracer('svc');",
+      '',
+      'function doWork() {',
+      "  return tracer.startActiveSpan('work', (span) => {",
+      '    span.end();',
+      '    return readFileSync("/tmp/x");',
+      '  });',
+      '}',
+    ].join('\n');
+
+    const result = stripOtelNodes(code, filePath);
+
+    expect(result).toContain("import { readFileSync } from 'node:fs'");
+    expect(result).not.toContain('@opentelemetry');
+    expect(result).not.toContain('startActiveSpan');
+  });
 });
 
 // ─── P13: Tracer declaration ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes a false-positive NDS-003 bug (issue #904): when the agent places the OTel import as the first statement in a file, `removeOtelImports` was calling `imp.remove()` which strips the import's leading trivia (shebang, file-level JSDoc) along with the node. Fixed by calling `imp.replaceWithText(leadingTrivia)` instead when the import is the first statement, preserving file-level headers while removing the import text.
- Adds OTel span granularity research (issue #898): recommendation to keep leaves-first file ordering, which is aligned with OTel community standards. Research saved to `docs/research/otel-span-granularity.md`.

## Test plan

- [ ] `npm test` passes (2796 tests, all green)
- [ ] Two new regression tests in `nds003-ast-stripper.test.ts`: shebang + JSDoc preserved when OTel import is first statement; non-first-position imports unaffected
- [ ] Acceptance gate CI triggered via `run-acceptance` label
- [ ] `mcp/server.js` unblocked for run-21 (false-positive NDS-003 at lines 1, 3–20, 37, 39 eliminated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NDS-003 validator to preserve file headers (shebang, JSDoc) when removing OpenTelemetry imports.

* **Documentation**
  * Added OpenTelemetry span granularity guidance documenting best practices for layer boundary instrumentation and context propagation.

* **Tests**
  * Extended test coverage for import removal scenarios with regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->