### PR TITLE
fix: union file-level framework detection into all retry attempts (#846)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- (2026-06-02) Fixed non-deterministic SDK init library detection (issue #846): when a file's instrumentation required more than one attempt, the deterministic framework library detection (express, pg, etc.) was only applied on attempt 1's output. If attempt 1 failed validation and was discarded, subsequent successful attempts returned empty `librariesNeeded` because the pre-scan doesn't re-run on multi-turn-fix calls (which pass a `feedbackMessage`). Fix: `executeRetryLoop` now runs `preInstrumentationAnalysis` once on the original file before the retry loop starts, captures the detected libraries, and unions them into every successful attempt's `librariesNeeded`. This guarantees `ExpressInstrumentation` and other auto-instrumentation libraries detected from file imports always appear in the final `FileResult`, regardless of which attempt succeeded. The P4 coordinator acceptance gate test — `SDK init file is updated with discovered library instrumentations` — was non-deterministic because of this gap.
+
 ### Added
 
 - (2026-06-02) Added a carve-out to the retry prompt (`buildFixPrompt` in `src/fix-loop/instrument-with-retry.ts`) that explicitly forbids the agent from dropping or reducing `schemaExtension` declarations when fixing blocking errors. The previous "make minimal, targeted changes" framing was pushing agents toward the cheapest path to compliance — substituting a semantically wrong registered attribute key rather than declaring a new extension. The carve-out makes clear that declaring a new schema extension is always valid when no registered attribute precisely matches the data being captured. Includes a test asserting the carve-out language is present alongside the existing "minimal, targeted changes" instruction.

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -477,7 +477,17 @@ export async function instrumentWithRetry(
     wholeFileResult, validateFileFn, options,
   );
 
-  return fallbackResult ?? wholeFileResult;
+  if (!fallbackResult) return wholeFileResult;
+
+  // Apply the same file-level library union used in executeRetryLoop — per-function calls
+  // instrument isolated function snippets that lack file-level imports, so the LLM will
+  // not see framework imports and cannot include them in librariesNeeded.
+  const fallbackDetectedLibraries =
+    provider.preInstrumentationAnalysis?.(originalCode, options.processedFilesManifest, filePath)?.detectedLibraries ?? [];
+  return {
+    ...fallbackResult,
+    librariesNeeded: mergeLibraries(fallbackResult.librariesNeeded, fallbackDetectedLibraries),
+  };
 }
 
 /**

--- a/src/fix-loop/instrument-with-retry.ts
+++ b/src/fix-loop/instrument-with-retry.ts
@@ -385,6 +385,22 @@ function strategyForAttempt(attemptNumber: number, maxAttempts: number): Validat
   return 'multi-turn-fix';
 }
 
+/** Union two librariesNeeded arrays, deduplicating by package name. */
+function mergeLibraries(
+  primary: { package: string; importName: string }[],
+  additional: { package: string; importName: string }[],
+): { package: string; importName: string }[] {
+  const seen = new Set(primary.map(l => l.package));
+  const result = [...primary];
+  for (const lib of additional) {
+    if (!seen.has(lib.package)) {
+      seen.add(lib.package);
+      result.push(lib);
+    }
+  }
+  return result;
+}
+
 /**
  * Instrument a file with validation and retry loop.
  *
@@ -505,6 +521,14 @@ async function executeRetryLoop(
       `File has ${originalCode.length} characters. Increase maxTokensPerFile or reduce file size.`;
     return buildFailedResult(filePath, reason, reason, ZERO_TOKENS, 0, 'initial-generation');
   }
+
+  // Detect auto-instrumentation libraries from file imports once, before any LLM attempts.
+  // The instrumentFile call on attempt 1 also does this internally, but that result is
+  // discarded if attempt 1 fails validation. Subsequent attempts (multi-turn-fix,
+  // fresh-regen) may not rerun the detection, so we capture it here and union it into
+  // every successful attempt's librariesNeeded to guarantee coverage.
+  const fileDetectedLibraries: { package: string; importName: string }[] =
+    provider.preInstrumentationAnalysis?.(originalCode, processedFilesManifest, filePath)?.detectedLibraries ?? [];
 
   let cumulativeTokens: TokenUsage = { ...ZERO_TOKENS };
   const errorProgression: string[] = [];
@@ -784,7 +808,7 @@ async function executeRetryLoop(
         path: filePath,
         status: 'success',
         spansAdded,
-        librariesNeeded: output.librariesNeeded,
+        librariesNeeded: mergeLibraries(output.librariesNeeded, fileDetectedLibraries),
         schemaExtensions: supplementSchemaExtensions(output.schemaExtensions, output.instrumentedCode),
         attributesCreated: output.attributesCreated,
         validationAttempts: attempt,

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -3278,6 +3278,40 @@ describe('instrumentWithRetry — function-level fallback (Milestone 7)', () => 
     // Reassembly-level validation must not be called — short-circuit happened before reassembly
     expect(reassemblyValidateCount).toBe(0);
   });
+
+  it('includes framework libraries detected from imports when whole-file fails and function-level fallback succeeds', async () => {
+    // File imports express — deterministic detection must surface ExpressInstrumentation
+    // even when the whole-file path fails and per-function calls return empty librariesNeeded.
+    const expressContent = "import express from 'express';\nexport async function handleRequest(req, res) { res.json({ ok: true }); }\n";
+    writeFileSync(filePath, expressContent, 'utf-8');
+
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async (path) => {
+        if (isPerFunctionCall(path)) {
+          return {
+            success: true,
+            output: makeInstrumentationOutput({
+              instrumentedCode: "import { trace } from '@opentelemetry/api';\nexport async function handleRequest(req, res) { trace.getTracer('svc').startActiveSpan('s', () => {}); res.json({ ok: true }); }\n",
+              librariesNeeded: [], // LLM omits express — the deterministic path must fill this in
+              attributesCreated: 0,
+              spanCategories: { externalCalls: 0, schemaDefined: 0, serviceEntryPoints: 1, totalFunctionsInFile: 1 },
+            }),
+          };
+        }
+        // Whole-file path always fails
+        return { success: false, error: 'LLM produced null parsed_output', tokenUsage: sampleTokens };
+      },
+      validateFile: async (input) => makePassingValidation(input.filePath),
+    };
+
+    const result = await instrumentWithRetry(filePath, expressContent, {}, makeConfig(), { deps, provider: jsProvider });
+
+    expect(result.status).toBe('success');
+    expect(result.librariesNeeded).toContainEqual({
+      package: '@opentelemetry/instrumentation-express',
+      importName: 'ExpressInstrumentation',
+    });
+  });
 });
 
 describe('instrumentWithRetry — suggestedRefactors collection', () => {

--- a/test/fix-loop/instrument-with-retry.test.ts
+++ b/test/fix-loop/instrument-with-retry.test.ts
@@ -1205,6 +1205,55 @@ describe('instrumentWithRetry — multi-turn fix (Milestone 4)', () => {
     expect(result.schemaExtensions).toEqual(goodOutput.schemaExtensions);
     expect(result.notes).toEqual(goodOutput.notes);
   });
+
+  it('includes framework libraries detected from imports even when LLM returns empty librariesNeeded on attempt 2', async () => {
+    // File imports express — deterministic detection should always surface ExpressInstrumentation
+    // regardless of which attempt succeeds and regardless of what the LLM returns.
+    const expressContent = "import express from 'express';\nexport async function handleRequest(req, res) { res.json({ ok: true }); }\n";
+
+    let callCount = 0;
+    // Attempt 1: fails validation — its librariesNeeded is discarded
+    const badOutput = makeInstrumentationOutput({
+      instrumentedCode: 'const bad = syntax error;\n',
+      librariesNeeded: [],
+      tokenUsage: attempt1Tokens,
+    });
+    // Attempt 2: succeeds, but LLM omits express from librariesNeeded (the real-world failure mode)
+    const goodOutput = makeInstrumentationOutput({
+      instrumentedCode: 'const good = true;\n',
+      librariesNeeded: [],
+      tokenUsage: attempt2Tokens,
+    });
+
+    const deps: InstrumentWithRetryDeps = {
+      instrumentFile: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { success: true, output: badOutput, conversationContext: mockConversationContext } as InstrumentFileResult;
+        }
+        return { success: true, output: goodOutput } as InstrumentFileResult;
+      },
+      validateFile: async (input) => {
+        if (input.instrumentedCode === 'const bad = syntax error;\n') {
+          return makeFailingValidation(testFilePath);
+        }
+        return makePassingValidation(testFilePath);
+      },
+    };
+
+    const result = await instrumentWithRetry(
+      testFilePath, expressContent, {}, makeConfig({ maxFixAttempts: 1 }), { deps, provider: jsProvider },
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.validationAttempts).toBe(2);
+    // ExpressInstrumentation must be in librariesNeeded because express is in the file's imports,
+    // regardless of which attempt the LLM succeeded on or what it returned for librariesNeeded.
+    expect(result.librariesNeeded).toContainEqual({
+      package: '@opentelemetry/instrumentation-express',
+      importName: 'ExpressInstrumentation',
+    });
+  });
 });
 
 describe('instrumentWithRetry — fresh regeneration (Milestone 5)', () => {


### PR DESCRIPTION
## Summary

- Fixes non-deterministic P4 coordinator acceptance gate: `SDK init file is updated with discovered library instrumentations`
- Root cause: when attempt 1 failed validation and was discarded, subsequent multi-turn-fix attempts (which use a `feedbackMessage`) did not re-run `preInstrumentationAnalysis`, so `librariesNeeded` was empty if the LLM also omitted the library
- Fix: `executeRetryLoop` runs `preInstrumentationAnalysis` once before the retry loop and unions the detected framework libraries into every successful attempt's `librariesNeeded`

## What changed

- `src/fix-loop/instrument-with-retry.ts` — added `mergeLibraries()` helper; call `preInstrumentationAnalysis` once before the loop; apply union in `buildSuccessResult`
- `test/fix-loop/instrument-with-retry.test.ts` — new test: attempt 1 fails validation, attempt 2 succeeds with empty LLM `librariesNeeded`, assert `ExpressInstrumentation` appears in final result from file import detection
- `PROGRESS.md` — entry documenting the fix and root cause

## Test plan

- [ ] New test `includes framework libraries detected from imports even when LLM returns empty librariesNeeded on attempt 2` passes
- [ ] Full fix-loop test suite: 244/244 pass
- [ ] Build, typecheck, lint pass (verified via pre-push hook)
- [ ] Acceptance gate CI triggered — watch for P4 coordinator test stability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic SDK initialization library detection during instrumentation retries. Framework and library detection now runs once before retries, ensuring all discovered libraries are properly captured and included in final results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->