### PR TITLE
docs: remove closed-issue entries from ROADMAP.md

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -38,6 +38,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - (2026-06-15) `coordinate()` now aborts with `CoordinatorAbortError` before the cost ceiling prompt when the target project's tests are already failing at the start of a run. Previously it degraded-and-continued with rollback disabled, wasting tokens on instrumentation the checkpoints would undo and producing misleading failures. The early check runs in a new Step 2c, before cost ceiling computation, so users see a clear message naming the failing tests and are told to fix them before retrying (issue #935).
 
+### Removed
+
+- (2026-06-30) Removed the "Taze run-16 eval findings" (#1011, #1010) and "Coordinator acceptance gate findings" (#1013) sections from `docs/ROADMAP.md`. All three issues were already closed and merged, but the entries were never removed on closure, contradicting the documented convention that ROADMAP.md is forward-looking and completed work should only live in this file.
+
 ### Changed
 
 - (2026-06-19) Revised CDQ-006 (isRecording guard) prompt instruction in `src/agent/prompt.ts` to lead with the general principle rather than an exhaustive method list. The previous instruction listed named methods (`JSON.stringify`, `.map`, etc.) which caused agents to miss unlisted function calls. The revised instruction states upfront that any function call or method call requires a guard, adds an explicit positive list of value expression forms that do require a guard, and an explicit negative list of cheap reads that do not (simple variable reads, literals, direct property accesses). Updated the CDQ checklist item in the pre-submission verification section to match. Updated `docs/rules-reference.md` CDQ-006 row to reflect the new principle-based description. Updated comments in `src/languages/javascript/rules/cdq006.ts` to align with the principle-based framing (no logic changes — the validator already catches all CallExpressions via `forEachDescendant`). Fixes issue #956.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,13 +45,6 @@ Commit-story-v2 run-25 eval findings:
 
 - Agent prompt: minimum-attribute threshold and registered-vs-extension decision framework ([issue #993](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/993)) — root cause of run-to-run attribute variance across all eval targets; research spike required before implementation.
 
-Taze run-16 eval findings:
-- CDQ-006: align fixIsRecordingGuards() and checkIsRecordingGuard() around entry-point detection ([issue #1011](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/1011)) — validator/auto-fix asymmetry caused unguarded setAttribute calls to commit in taze run-16; fix is either removing isInsideEntryPoint from auto-fix or adding it to validator, plus documenting the parameter-name heuristic.
-- SCH-003: add reverse coercion fix (strip String() wrapper from int-typed attributes) ([issue #1010](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/1010)) — fixAttributeTypeCoercions() handles string-typed attributes only; int-typed attributes wrapped in String() still commit as blocking violations; deterministic reverse case needed.
-
-Coordinator acceptance gate findings (PR #1012 run 27966202382):
-- coordinator acceptance gate: no diagnostic data written for any coordinator test ([issue #1013](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/1013)) — `logRunResult()` only fires on instrumentation failures; coordinator tests never write to `/tmp/spiny-orb-debug-*.js`; CI artifact always empty; blocks diagnosis of any coordinator test failure.
-
 ## Medium-term
 - Watch: IS SPA-002 (orphan span) recurrence in taze ([issue #1008](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/1008)) — first appeared in taze run-16; possibly stochastic (async span parent race); monitor across future runs before investing in a fix.
 - Watch: P4-3 SDK init failure — possible importName contract mismatch between test and coordinator ([issue #1014](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/1014)) — unconfirmed hypothesis; needs coordinator debug dump from Issue #1013 to investigate; do not implement a fix until data is available.


### PR DESCRIPTION
## Summary
- Removed the "Taze run-16 eval findings" (#1011, #1010) and "Coordinator acceptance gate findings" (#1013) sections from `docs/ROADMAP.md` — all three issues are already closed and merged.
- Added a PROGRESS.md entry documenting the cleanup.

## Test plan
- [x] Docs-only change; no code or tests affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Cleaned up the roadmap by removing outdated “evaluation findings” sections that were already completed.
  * The roadmap now transitions directly into the next planning section for improved readability.
* **Chores**
  * Updated progress notes to record the removal of those completed roadmap entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->