### PR TITLE
docs: remove completed issue #924 from roadmap

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - (2026-07-14) Created `docs/eng-talk-story-assets.md` and documented the SCH-002 (schema registration near-synonym detection) catch from commit-story-v2 run 22: the agent declared `commit_story.journal.base_path` as a new schema extension when instrumenting `findUnsummarizedWeeks`, and the validator caught it as a semantic duplicate of the already-registered `commit_story.journal.file_path`, blocking the submission. Preserved as a concrete example for the Datadog engineering team talk on why the schema registry's duplicate-detection rule exists.
 
+### Removed
+
+- (2026-07-14) Removed the completed engineering talk story-asset item from `docs/ROADMAP.md`'s "Path to Python" sequence, since it shipped and closed. ROADMAP is forward-looking only; completed work lives in this changelog instead.
+
 - (2026-07-13) Wrote a navigation guide (`docs/demo/observability-triangle-navigation.md`) explaining how to get from an APM trace to the metrics that trace produced, since Datadog's UI puts that path one non-obvious click away and has a trap along the way: an individual trace's own "Metrics" tab shows unrelated host CPU/memory data, not the trace-derived metrics this project cares about. The guide covers both the live conference demo (with the narrative behind each of its two example metrics, and a troubleshooting order to follow if a widget looks empty on stage) and future users checking their own service's metrics after receiving spiny-orb instrumentation.
 
 - (2026-07-13) Created the observability triangle demo dashboard in Datadog (https://app.datadoghq.com/dashboard/gmf-rra-var, "commit-story Observability Triangle"): four widgets showing span rate and duration by AI section type, LLM token cost by section type and model, and span rate by model — all built from the metric queries validated the day before, with no new query syntax introduced. This is the visual artifact the demo project has been building toward.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,14 +31,13 @@ Before opening any PRD that adds, removes, or modifies validation rules or recon
 
 A strict sequential path — complete each step before starting the next. This is the near-term critical path; everything else in Short-term/Medium-term/Long-term below happens after Go, unless it's a Watch item (see Watch issues, below).
 
-1. Talk prep: engineering talk story asset — SCH-002 near-synonym catch from run 22 ([issue #924](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/924)) — agent invented `commit_story.journal.base_path` instead of reusing registered `commit_story.journal.file_path`; validator caught it; capture for engineering team talk.
-2. Small-issue batch — step 2 is complete once #993 (the only unblocked item) is done; #954 and #958 stay blocked and do not gate progress to step 3:
+1. Small-issue batch — step 1 is complete once #993 (the only unblocked item) is done; #954 and #958 stay blocked and do not gate progress to step 2:
    - resolves.ts oscillation root cause investigation ([issue #954](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/954)) — **BLOCKED: no diagnostic data available.** resolves.ts recovered in run-16 (6 spans committed), so no debug dump was written. The run-15 tsc error is still unknown. Cannot proceed until a future eval run where resolves.ts fails again with `--debug-dump-dir` active. Do not start.
    - resolves.ts oscillation fix ([issue #958](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/958)) — **BLOCKED: depends on #954.**
    - Agent prompt: minimum-attribute threshold and registered-vs-extension decision framework ([issue #993](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/993)) — root cause of run-to-run attribute variance across all eval targets; research spike required before implementation.
-3. Eval run: commit-story-v2, positioned immediately before Python work begins (per [Eval cadence](#eval-cadence) above — run after any agent-behavior change made in step 2).
-4. Python language provider ([PRD #373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373)) — TypeScript canary prerequisite ✓ cleared (0/27 interface changes); multi-language rule architecture ✓ cleared (PRD #507 merged).
-5. Go language provider ([PRD #374](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/374)), including its OD-10 packaging research spike gate — multi-language rule architecture ✓ cleared (PRD #507 merged).
+2. Eval run: commit-story-v2, positioned immediately before Python work begins (per [Eval cadence](#eval-cadence) above — run after any agent-behavior change made in step 1).
+3. Python language provider ([PRD #373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373)) — TypeScript canary prerequisite ✓ cleared (0/27 interface changes); multi-language rule architecture ✓ cleared (PRD #507 merged).
+4. Go language provider ([PRD #374](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/374)), including its OD-10 packaging research spike gate — multi-language rule architecture ✓ cleared (PRD #507 merged).
 
 ## Watch issues
 


### PR DESCRIPTION
## Summary
- Removes the completed engineering talk story-asset item (issue #924, closed via PR #1028) from `docs/ROADMAP.md`'s "Path to Python" sequence
- ROADMAP is forward-looking only; completed work belongs in `PROGRESS.md`, which already has the entry
- Renumbers the remaining sequence steps

## Test plan
- [x] Docs-only change, no code affected
- [x] `PROGRESS.md` updated under `## [Unreleased] / ### Removed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the product roadmap to reflect the completion and removal of the engineering talk story asset.
  * Renumbered the remaining “Path to Python” milestones and clarified their sequencing and dependencies.
  * Added a changelog entry documenting the completed roadmap item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->