### PR TITLE
docs: remove completed issue #993 from roadmap

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+- (2026-07-15) Removed the minimum-attribute-threshold and registered-vs-extension decision framework item from `docs/ROADMAP.md`'s "Path to Python" sequence, since it shipped and closed as issue #993. ROADMAP is forward-looking only; completed work lives in this changelog instead.
+
 - (2026-07-14) Removed the completed engineering talk story-asset item from `docs/ROADMAP.md`'s "Path to Python" sequence, since it shipped and closed. ROADMAP is forward-looking only; completed work lives in this changelog instead.
 
 - (2026-07-13) Wrote a navigation guide (`docs/demo/observability-triangle-navigation.md`) explaining how to get from an APM trace to the metrics that trace produced, since Datadog's UI puts that path one non-obvious click away and has a trap along the way: an individual trace's own "Metrics" tab shows unrelated host CPU/memory data, not the trace-derived metrics this project cares about. The guide covers both the live conference demo (with the narrative behind each of its two example metrics, and a troubleshooting order to follow if a widget looks empty on stage) and future users checking their own service's metrics after receiving spiny-orb instrumentation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,10 +31,9 @@ Before opening any PRD that adds, removes, or modifies validation rules or recon
 
 A strict sequential path — complete each step before starting the next. This is the near-term critical path; everything else in Short-term/Medium-term/Long-term below happens after Go, unless it's a Watch item (see Watch issues, below).
 
-1. Small-issue batch — step 1 is complete once #993 (the only unblocked item) is done; #954 and #958 stay blocked and do not gate progress to step 2:
+1. Small-issue batch — #954 and #958 stay blocked and do not gate progress to step 2:
    - resolves.ts oscillation root cause investigation ([issue #954](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/954)) — **BLOCKED: no diagnostic data available.** resolves.ts recovered in run-16 (6 spans committed), so no debug dump was written. The run-15 tsc error is still unknown. Cannot proceed until a future eval run where resolves.ts fails again with `--debug-dump-dir` active. Do not start.
    - resolves.ts oscillation fix ([issue #958](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/958)) — **BLOCKED: depends on #954.**
-   - Agent prompt: minimum-attribute threshold and registered-vs-extension decision framework ([issue #993](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/993)) — root cause of run-to-run attribute variance across all eval targets; research spike required before implementation.
 2. Eval run: commit-story-v2, positioned immediately before Python work begins (per [Eval cadence](#eval-cadence) above — run after any agent-behavior change made in step 1).
 3. Python language provider ([PRD #373](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/373)) — TypeScript canary prerequisite ✓ cleared (0/27 interface changes); multi-language rule architecture ✓ cleared (PRD #507 merged).
 4. Go language provider ([PRD #374](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/374)), including its OD-10 packaging research spike gate — multi-language rule architecture ✓ cleared (PRD #507 merged).


### PR DESCRIPTION
## Description
Removes the now-completed minimum-attribute-threshold / registered-vs-extension decision framework item (issue #993) from `docs/ROADMAP.md`'s "Path to Python" sequence. Issue #993 shipped and closed via PR #1030.

## Changes Made
- `docs/ROADMAP.md`: removed the #993 bullet and its now-stale "step 1 is complete once #993 is done" framing
- `PROGRESS.md`: logged the roadmap cleanup

## Testing
Docs-only change; no code affected.

## Documentation
- `docs/ROADMAP.md` and `PROGRESS.md` updated in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project roadmap to reflect current sequencing and clarify that remaining blocked issues do not prevent progress.
  * Recorded completion of the minimum-attribute-threshold and registered-versus-extension decision framework.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->